### PR TITLE
refactor: remove all plugin controls

### DIFF
--- a/crates/wail-plugin/src/lib.rs
+++ b/crates/wail-plugin/src/lib.rs
@@ -18,6 +18,10 @@ use wail_audio::{
 /// Default IPC address (overridable via WAIL_IPC_ADDR env var).
 const DEFAULT_IPC_ADDR: &str = "127.0.0.1:9191";
 
+const BARS: u32 = 4;
+const QUANTUM: f64 = 4.0;
+const BITRATE_KBPS: u32 = 128;
+
 /// Raw completed interval with config snapshot, sent from audio thread to IPC
 /// thread for Opus encoding (keeps Opus off the real-time audio callback).
 struct RawInterval {
@@ -145,9 +149,9 @@ impl Plugin for WailPlugin {
         let bridge = AudioBridge::new(
             buffer_config.sample_rate as u32,
             channels,
-            self.params.bars.value() as u32,
-            self.params.quantum(),
-            self.params.bitrate_kbps.value() as u32,
+            BARS,
+            QUANTUM,
+            BITRATE_KBPS,
         );
 
         // Pre-allocate reusable audio buffers (max_buffer_size * channels)
@@ -178,7 +182,7 @@ impl Plugin for WailPlugin {
 
         let ipc_sample_rate = buffer_config.sample_rate as u32;
         let ipc_channels = channels;
-        let ipc_bitrate = self.params.bitrate_kbps.value() as u32;
+        let ipc_bitrate = BITRATE_KBPS;
 
         std::thread::Builder::new()
             .name("wail-ipc".into())
@@ -191,7 +195,7 @@ impl Plugin for WailPlugin {
             "WAIL plugin initialized: {}Hz, {} channels, {} bars",
             buffer_config.sample_rate,
             channels,
-            self.params.bars.value()
+            BARS
         );
 
         true
@@ -235,24 +239,16 @@ impl Plugin for WailPlugin {
         };
         self.cumulative_samples += num_samples as u64;
 
-        let send_enabled = self.params.send_enabled.value();
-        let receive_enabled = self.params.receive_enabled.value();
-        let volume = self.params.volume.value();
-
         if let Ok(mut bridge_guard) = self.bridge.try_lock() {
             if let Some(ref mut bridge) = *bridge_guard {
-                // Update interval config if params changed
-                bridge.update_config(
-                    self.params.bars.value() as u32,
-                    self.params.quantum(),
-                    bpm,
-                );
+                // Update interval config if bpm changed
+                bridge.update_config(BARS, QUANTUM, bpm);
 
                 // Interleave input into pre-allocated buffer (zeros if not recording)
                 let buf_size = num_samples * num_channels as usize;
                 ensure_buf(&mut self.interleave_buf, buf_size);
                 let interleave = &mut self.interleave_buf[..buf_size];
-                if send_enabled && playing {
+                if playing {
                     for sample_idx in 0..num_samples {
                         for ch in 0..num_channels as usize {
                             interleave[sample_idx * num_channels as usize + ch] =
@@ -281,12 +277,10 @@ impl Plugin for WailPlugin {
                 });
 
                 // Mix playback into DAW main output
-                if receive_enabled {
-                    for sample_idx in 0..num_samples {
-                        for ch in 0..num_channels as usize {
-                            let pb_idx = sample_idx * num_channels as usize + ch;
-                            buffer.as_slice()[ch][sample_idx] += playback[pb_idx] * volume;
-                        }
+                for sample_idx in 0..num_samples {
+                    for ch in 0..num_channels as usize {
+                        let pb_idx = sample_idx * num_channels as usize + ch;
+                        buffer.as_slice()[ch][sample_idx] += playback[pb_idx];
                     }
                 }
 
@@ -306,7 +300,7 @@ impl Plugin for WailPlugin {
                     for sample_idx in 0..n {
                         for ch in 0..aux_ch.min(num_channels as usize) {
                             let pb_idx = sample_idx * num_channels as usize + ch;
-                            aux_buf.as_slice()[ch][sample_idx] = peer_buf[pb_idx] * volume;
+                            aux_buf.as_slice()[ch][sample_idx] = peer_buf[pb_idx];
                         }
                     }
                 }

--- a/crates/wail-plugin/src/params.rs
+++ b/crates/wail-plugin/src/params.rs
@@ -1,68 +1,11 @@
 use nih_plug::prelude::*;
 
-/// Plugin parameters exposed to the DAW.
+/// Empty params struct — WAIL plugin has no user-controllable parameters.
 #[derive(Params)]
-pub struct WailParams {
-    /// Bars per interval (NINJAM-style)
-    #[id = "bars"]
-    pub bars: IntParam,
-
-    /// Time signature numerator (quantum / beats per bar)
-    #[id = "timesig_num"]
-    pub time_sig_numerator: IntParam,
-
-    /// Send audio to remote peers
-    #[id = "send"]
-    pub send_enabled: BoolParam,
-
-    /// Receive audio from remote peers
-    #[id = "receive"]
-    pub receive_enabled: BoolParam,
-
-    /// Output volume for received audio (0.0 to 1.0)
-    #[id = "volume"]
-    pub volume: FloatParam,
-
-    /// Opus bitrate in kbps
-    #[id = "bitrate"]
-    pub bitrate_kbps: IntParam,
-}
+pub struct WailParams {}
 
 impl Default for WailParams {
     fn default() -> Self {
-        Self {
-            bars: IntParam::new("Bars", 4, IntRange::Linear { min: 1, max: 16 }),
-
-            time_sig_numerator: IntParam::new(
-                "Time Sig",
-                4,
-                IntRange::Linear { min: 1, max: 12 },
-            ),
-
-            send_enabled: BoolParam::new("Send", true),
-
-            receive_enabled: BoolParam::new("Receive", true),
-
-            volume: FloatParam::new(
-                "Volume",
-                0.8,
-                FloatRange::Linear { min: 0.0, max: 1.0 },
-            )
-            .with_value_to_string(formatters::v2s_f32_rounded(2)),
-
-            bitrate_kbps: IntParam::new(
-                "Bitrate",
-                128,
-                IntRange::Linear { min: 32, max: 320 },
-            )
-            .with_unit(" kbps"),
-        }
-    }
-}
-
-impl WailParams {
-    /// Get quantum (beats per bar) from the time signature numerator.
-    pub fn quantum(&self) -> f64 {
-        self.time_sig_numerator.value() as f64
+        Self {}
     }
 }


### PR DESCRIPTION
## Summary

The WAIL plugin no longer exposes user-facing parameters. All configuration is now hardcoded to fixed values:
- 4 bars per interval
- 4-beat quantum
- 128 kbps Opus bitrate
- Always send and receive audio at unity gain

This simplifies the plugin UX and eliminates the overhead of parameter automation tracking.

## Changes

- Removed all parameter definitions (bars, time signature, send/receive, volume, bitrate)
- Replaced dynamic values with compile-time constants
- Hardcoded send/receive to always enabled and volume to 1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)