### PR TITLE
fix: add multiple STUN servers for ICE reliability

### DIFF
--- a/crates/wail-net/src/lib.rs
+++ b/crates/wail-net/src/lib.rs
@@ -15,10 +15,14 @@ use wail_core::protocol::{SignalMessage, SignalPayload, SyncMessage};
 use peer::PeerConnection;
 use signaling::SignalingClient;
 
-/// Default ICE servers (Google STUN only).
+/// Default ICE servers (multiple STUN servers for reliability).
 pub fn default_ice_servers() -> Vec<RTCIceServer> {
     vec![RTCIceServer {
-        urls: vec!["stun:stun.l.google.com:19302".to_string()],
+        urls: vec![
+            "stun:stun.l.google.com:19302".to_string(),
+            "stun:stun1.l.google.com:19302".to_string(),
+            "stun:stun2.l.google.com:19302".to_string(),
+        ],
         ..Default::default()
     }]
 }


### PR DESCRIPTION
## Summary

Single STUN server is a single point of failure for ICE (Interactive Connectivity Establishment) negotiation when peers are behind NATs. This fix adds two additional Google STUN servers (stun1 and stun2) alongside the primary, improving reliability.

When ICE candidate gathering fails to find a viable peer pair with a single STUN server, the WebRTC connection fails. With multiple STUN servers, if one is down or unreachable, peers can still discover each other and establish connections.

## Test plan

- Verify build passes
- Existing tests for peer connection should exercise this code path