### PR TITLE
feat: increase MAX_REMOTE_PEERS from 7 to 15

### DIFF
--- a/crates/wail-audio/src/ring.rs
+++ b/crates/wail-audio/src/ring.rs
@@ -1,5 +1,5 @@
 /// Maximum number of remote peers with independent audio channels.
-pub const MAX_REMOTE_PEERS: usize = 7;
+pub const MAX_REMOTE_PEERS: usize = 15;
 
 /// Per-peer isolated playback slot.
 pub struct PeerSlot {

--- a/crates/wail-plugin-recv/src/lib.rs
+++ b/crates/wail-plugin-recv/src/lib.rs
@@ -74,15 +74,17 @@ impl Plugin for WailRecvPlugin {
     const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
     const AUDIO_IO_LAYOUTS: &'static [AudioIOLayout] = &[
-        // Stereo in/out with 7 per-peer aux stereo outputs
+        // Stereo in/out with 15 per-peer aux stereo outputs
         AudioIOLayout {
             main_input_channels: NonZeroU32::new(2),
             main_output_channels: NonZeroU32::new(2),
-            aux_output_ports: &[new_nonzero_u32(2); 7],
+            aux_output_ports: &[new_nonzero_u32(2); 15],
             names: PortNames {
                 aux_outputs: &[
                     "Peer 1", "Peer 2", "Peer 3", "Peer 4",
-                    "Peer 5", "Peer 6", "Peer 7",
+                    "Peer 5", "Peer 6", "Peer 7", "Peer 8",
+                    "Peer 9", "Peer 10", "Peer 11", "Peer 12",
+                    "Peer 13", "Peer 14", "Peer 15",
                 ],
                 ..PortNames::const_default()
             },

--- a/tradeoffs.md
+++ b/tradeoffs.md
@@ -93,3 +93,12 @@ Deferred decisions and remaining code quality items. Each entry has enough conte
 | I5 | `now_us()` cast u128→i64 overflows after 292 years | `crates/wail-core/src/clock.rs:36` | Open |
 | I6 | Median uses upper-median for even-length arrays | `crates/wail-core/src/clock.rs:87` | Open |
 | I7 | Echo guard 150ms window suppresses legit fast tempo changes | `crates/wail-core/src/link.rs:89-94` | Open |
+| I9 | DAW aux output ports show "Peer 1–15" instead of actual peer display names | `crates/wail-plugin-recv/src/lib.rs:83-87` | Open |
+
+### I9. Static peer names in DAW aux outputs
+**Status:** Open — plugin API limitation
+**File:** `crates/wail-plugin-recv/src/lib.rs:83-87`
+**Problem:** DAW shows "Peer 1", "Peer 2", etc. instead of the peer's chosen display name (e.g. "Ringo"). Peer display names already flow through the protocol (`SyncMessage::Hello.display_name`) and are tracked in the Tauri session, but cannot be surfaced in DAW port labels.
+**Root cause:** nih_plug `PortNames` are `&'static str` (compile-time only). VST3 has no bus rename API. CLAP has `host.audio_ports->rescan(RESCAN_NAMES)` but nih_plug doesn't expose it.
+**Workaround:** Show "Peer 1 = Ringo" mapping in wail-app UI so users know which aux output corresponds to which musician.
+**Fix when ready:** Upstream nih_plug enhancement to expose CLAP's `rescan(RESCAN_NAMES)`, or use CLAP's `extensible_audio_ports` draft extension for dynamic port creation with correct names.


### PR DESCRIPTION
## Summary
Increases the recv plugin's auxiliary output count to support larger sessions (16 total outputs: 1 main mix + 15 per-peer aux). Updates the interval ring buffer's peer slot capacity and plugin I/O layout accordingly.

All 67 wail-audio tests pass with the new limit. No breaking changes to the protocol or networking layer.

## Details
- `MAX_REMOTE_PEERS` constant: 7 → 15 in `crates/wail-audio/src/ring.rs`
- Plugin aux output layout: 7 → 15 stereo ports in `crates/wail-plugin-recv/src/lib.rs`
- Added I9 to `tradeoffs.md` noting static DAW port naming limitation (display names already flow through protocol but cannot be surfaced in VST3/CLAP due to plugin API constraints)

🤖 Generated with Claude Code