### PR TITLE
Fix peer display names not showing in peer list

### DIFF
--- a/crates/wail-net/src/peer.rs
+++ b/crates/wail-net/src/peer.rs
@@ -97,6 +97,14 @@ use webrtc::peer_connection::RTCPeerConnection;
 
 use wail_core::protocol::SyncMessage;
 
+/// Drain all pending sync messages from the queue.
+fn take_pending(pending: &Mutex<Vec<String>>) -> Vec<String> {
+    match pending.lock() {
+        Ok(mut guard) => std::mem::take(&mut *guard),
+        Err(e) => std::mem::take(&mut *e.into_inner()),
+    }
+}
+
 /// A single WebRTC peer connection with DataChannels for sync and audio.
 ///
 /// Two DataChannels:
@@ -120,6 +128,8 @@ pub struct PeerConnection {
     /// Incoming audio data (binary, bounded) — taken via `take_audio_rx()` for forwarding
     pub audio_rx: Option<mpsc::Receiver<Vec<u8>>>,
     audio_tx: mpsc::Sender<Vec<u8>>,
+    /// Sync messages queued before the DataChannel is open.
+    pending_sync: Arc<Mutex<Vec<String>>>,
     /// ICE candidates that arrived before remote description was set
     pending_candidates: Vec<RTCIceCandidateInit>,
     remote_desc_set: bool,
@@ -201,6 +211,7 @@ impl PeerConnection {
             incoming_tx,
             audio_rx: Some(audio_rx),
             audio_tx,
+            pending_sync: Arc::new(Mutex::new(Vec::new())),
             pending_candidates: Vec::new(),
             remote_desc_set: false,
         })
@@ -245,6 +256,7 @@ impl PeerConnection {
         let rpid = self.remote_peer_id.clone();
         let dc_sync_slot = self.dc_sync.clone();
         let dc_audio_slot = self.dc_audio.clone();
+        let pending_sync = self.pending_sync.clone();
 
         self.pc.on_data_channel(Box::new(move |dc: Arc<RTCDataChannel>| {
             let incoming_tx = incoming_tx.clone();
@@ -252,6 +264,7 @@ impl PeerConnection {
             let rpid = rpid.clone();
             let dc_sync_slot = dc_sync_slot.clone();
             let dc_audio_slot = dc_audio_slot.clone();
+            let pending_sync = pending_sync.clone();
             Box::pin(async move {
                 let label = dc.label().to_string();
                 info!(peer = %rpid, label = %label, "Data channel opened by remote");
@@ -259,6 +272,26 @@ impl PeerConnection {
                 match label.as_str() {
                     "sync" => {
                         let _ = dc_sync_slot.set(dc.clone());
+
+                        // Flush pending messages when channel opens
+                        let pending2 = pending_sync.clone();
+                        let rpid2 = rpid.clone();
+                        let dc_for_flush = dc.clone();
+                        dc.on_open(Box::new(move || {
+                            info!(peer = %rpid2, "Sync channel open (responder)");
+                            Box::pin(async move {
+                                let messages = take_pending(&pending2);
+                                if !messages.is_empty() {
+                                    info!(count = messages.len(), "Flushing queued sync messages (responder)");
+                                }
+                                for text in messages {
+                                    if let Err(e) = dc_for_flush.send_text(text).await {
+                                        warn!("Failed to send queued sync message: {e}");
+                                    }
+                                }
+                            })
+                        }));
+
                         let tx = incoming_tx.clone();
                         dc.on_message(Box::new(move |msg: DataChannelMessage| {
                             let tx = tx.clone();
@@ -345,17 +378,18 @@ impl PeerConnection {
     }
 
     /// Send a sync message over the "sync" DataChannel (JSON text).
+    /// If the channel isn't open yet, the message is queued and will be
+    /// flushed automatically when the channel opens.
     pub async fn send(&self, msg: &SyncMessage) -> Result<()> {
+        let text = serde_json::to_string(msg)?;
         match self.dc_sync.get() {
             Some(dc) if dc.ready_state() == RTCDataChannelState::Open => {
-                let text = serde_json::to_string(msg)?;
                 dc.send_text(text).await?;
             }
-            Some(_) => {
-                debug!(peer = %self.remote_peer_id, "Sync DataChannel not open yet — message dropped");
-            }
-            None => {
-                debug!(peer = %self.remote_peer_id, "Sync DataChannel not ready — message dropped");
+            _ => {
+                let mut guard = self.pending_sync.lock().unwrap_or_else(|e| e.into_inner());
+                debug!(peer = %self.remote_peer_id, pending = guard.len() + 1, "Sync DC not open — message queued");
+                guard.push(text);
             }
         }
         Ok(())
@@ -405,11 +439,23 @@ impl PeerConnection {
     async fn setup_sync_channel(&mut self, dc: Arc<RTCDataChannel>) {
         let incoming_tx = self.incoming_tx.clone();
         let rpid = self.remote_peer_id.clone();
+        let pending = self.pending_sync.clone();
 
         let dc_clone = dc.clone();
         dc.on_open(Box::new(move || {
             info!(peer = %rpid, label = %dc_clone.label(), "Sync channel open");
-            Box::pin(async {})
+            let dc2 = dc_clone.clone();
+            Box::pin(async move {
+                let messages = take_pending(&pending);
+                if !messages.is_empty() {
+                    info!(count = messages.len(), "Flushing queued sync messages");
+                }
+                for text in messages {
+                    if let Err(e) = dc2.send_text(text).await {
+                        warn!("Failed to send queued sync message: {e}");
+                    }
+                }
+            })
         }));
 
         let tx = incoming_tx.clone();

--- a/crates/wail-tauri/src/session.rs
+++ b/crates/wail-tauri/src/session.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use anyhow::Result;
@@ -152,6 +152,8 @@ async fn session_loop(
 
     // Track peers' display names
     let mut peer_names: HashMap<String, Option<String>> = HashMap::new();
+    // Track which peers we've sent Hello to (prevents infinite Hello loops)
+    let mut hello_sent: HashSet<String> = HashSet::new();
 
     // Track last broadcast tempo to avoid echo loops
     let mut last_broadcast_bpm: f64 = bpm;
@@ -308,6 +310,11 @@ async fn session_loop(
 
                         let hello = SyncMessage::Hello { peer_id: peer_id.clone(), display_name: display_name.clone() };
                         mesh.broadcast(&hello).await;
+                        // Mark all connected peers as having been sent Hello
+                        // (messages are queued if DataChannel isn't open yet)
+                        for p in mesh.connected_peers() {
+                            hello_sent.insert(p);
+                        }
 
                         let config_msg = SyncMessage::IntervalConfig { bars, quantum };
                         mesh.broadcast(&config_msg).await;
@@ -324,6 +331,7 @@ async fn session_loop(
                         let name = peer_names.get(&pid).and_then(|n| n.as_deref()).unwrap_or(&pid);
                         ui_info!(&app, "Peer {name} left");
                         peer_names.remove(&pid);
+                        hello_sent.remove(&pid);
                         let _ = app.emit("peer:left", PeerLeftEvent { peer_id: pid });
                     }
                     Ok(Some(_)) => {}
@@ -344,6 +352,21 @@ async fn session_loop(
                         let name_display = name.as_deref().unwrap_or("(anonymous)");
                         ui_info!(&app, "Hello from {name_display} ({pid})");
                         peer_names.insert(pid.clone(), name.clone());
+
+                        // Reply with our Hello if we haven't sent one to this peer.
+                        // This handles the case where the peer wasn't in mesh.peers
+                        // when we originally broadcast Hello (responder timing).
+                        if hello_sent.insert(from.clone()) {
+                            let reply = SyncMessage::Hello {
+                                peer_id: peer_id.clone(),
+                                display_name: display_name.clone(),
+                            };
+                            if let Err(e) = mesh.send_to(&from, &reply).await {
+                                debug!(peer = %from, error = %e, "Failed to send Hello reply");
+                                hello_sent.remove(&from);
+                            }
+                        }
+
                         let _ = app.emit("peer:joined", PeerJoinedEvent {
                             peer_id: pid,
                             display_name: name,


### PR DESCRIPTION
## Summary

Fixes a race condition where display names would sometimes fail to appear in the peer list, forcing users to use truncated peer IDs instead.

Two complementary mechanisms now guarantee name exchange:
- **Pending message queue**: Messages sent before a DataChannel opens are queued and flushed when the channel becomes ready (fixes initiator timing)
- **Hello reply**: When receiving a Hello from a peer we haven't already introduced ourselves to, we reply with our own Hello (fixes responder timing)

## Test Results

All 108 tests pass. Verified with `cargo build` and `cargo test`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)