### PR TITLE
chore: set up knope for release management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## 0.4.0
+
+### Breaking Changes
+
+- Removed standalone CLI app (`wail-app` crate) — use the Tauri desktop app instead
+- Split single plugin into separate WAIL Send and WAIL Recv plugins
+
+### Features
+
+- Split plugin into separate send and receive plugins for clearer DAW routing
+- Add web listener client for mobile listening
+- Increase MAX_REMOTE_PEERS from 7 to 15
+
+### Fixes
+
+- Ensure display names are always exchanged between peers
+- Add multiple STUN servers for ICE reliability
+- Hide IPC port field (hardcoded to match plugins)
+- Remove BPM input — let DAW handle tempo via Link
+- Simplify TURN server configuration with sensible defaults
+- Enable bundle generation in Tauri config
+- Correct Windows artifact path in release workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,38 @@ cargo test -p wail-audio      # audio tests (codec, ring buffer, wire format)
 - wail-audio has no networking dependencies (reusable from plugin)
 - TDD: write tests first, especially for ring buffer and codec
 
+## Versioning and Releases
+
+Managed by [knope](https://github.com/knope-dev/knope) via `knope.toml`. All crates share one version (workspace-level).
+
+**Versioned files** (kept in sync automatically): `Cargo.toml` (workspace), `crates/wail-tauri/tauri.conf.json`
+
+### Recording changes
+
+When making a user-facing change (feature, fix, breaking change), create a changeset file:
+
+```sh
+knope document-change
+```
+
+This creates a markdown file in `.changeset/` describing what changed and the bump type (major/minor/patch). Commit the changeset file with your PR. Conventional commit messages (`feat:`, `fix:`, `feat!:`) also work and are picked up automatically.
+
+### Cutting a release
+
+```sh
+knope release              # bump version, update CHANGELOG.md, commit, push, create GitHub release
+knope release --dry-run    # preview without making changes
+```
+
+`PrepareRelease` consumes all `.changeset/` files + conventional commits since the last tag, determines the version bump, updates versioned files and `CHANGELOG.md`, then `Release` creates the GitHub release and git tag.
+
+### Rules for agents
+
+- **Always create a changeset** for user-facing work. Run `knope document-change` or manually create a `.changeset/<short-name>.md` file.
+- **Never manually edit version numbers** in `Cargo.toml` or `tauri.conf.json` — knope handles this.
+- **Never manually create git tags** for releases — `knope release` handles tagging.
+- Use conventional commit prefixes: `feat:`, `fix:`, `chore:`, `feat!:` (breaking).
+
 ## Common Tasks
 
 - **Add a new sync message**: Add variant to `SyncMessage` in `crates/wail-core/src/protocol.rs`, handle in `crates/wail-tauri/src/session.rs` select loop

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 

--- a/crates/wail-tauri/tauri.conf.json
+++ b/crates/wail-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "WAIL",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "identifier": "com.wail.desktop",
   "build": {
     "frontendDist": "ui"

--- a/knope.toml
+++ b/knope.toml
@@ -1,0 +1,34 @@
+[package]
+versioned_files = ["Cargo.toml", "crates/wail-tauri/tauri.conf.json"]
+changelog = "CHANGELOG.md"
+
+[github]
+owner = "quasor"
+repo = "WAIL"
+
+[[workflows]]
+name = "release"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+
+[[workflows.steps]]
+type = "Command"
+command = "git add ."
+
+[[workflows.steps]]
+type = "Command"
+command = "git commit -m 'chore: prepare release'"
+
+[[workflows.steps]]
+type = "Command"
+command = "git push"
+
+[[workflows.steps]]
+type = "Release"
+
+[[workflows]]
+name = "document-change"
+
+[[workflows.steps]]
+type = "CreateChangeFile"


### PR DESCRIPTION
## Summary

Sets up [knope](https://github.com/knope-dev/knope) for managing WAIL releases and versioning. Adds initial CHANGELOG.md documenting v0.4.0 release and updates project documentation with release procedures.

## Changes

- **knope.toml**: Defines release workflow, versioning, and changelog generation
- **CHANGELOG.md**: Initial changelog entry for v0.4.0 with breaking changes, features, and fixes
- **CLAUDE.md**: Added comprehensive versioning and release documentation
- **Version bumps**: Align Cargo.toml (0.1.0 → 0.4.0) and tauri.conf.json (0.2.0 → 0.4.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)