### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.1 (2026-03-02)
+
+### Fixes
+
+- Set up knope for release management and populate initial CHANGELOG
+
 ## 0.4.0
 
 ### Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT"
 

--- a/crates/wail-tauri/tauri.conf.json
+++ b/crates/wail-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "WAIL",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "identifier": "com.wail.desktop",
   "build": {
     "frontendDist": "ui"
@@ -19,7 +19,10 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg", "nsis"],
+    "targets": [
+      "dmg",
+      "nsis"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary
- Bump version to 0.4.1 across Cargo.toml and tauri.conf.json
- Update CHANGELOG.md with 0.4.1 entry

Generated by `knope release` (PrepareRelease step).

After merging, tag `v0.4.1` will be created on main.