### PR TITLE
Add Linux support

### DIFF
--- a/.changeset/linux-support.md
+++ b/.changeset/linux-support.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+Add Linux support: AppImage and .deb builds in CI, cross-platform xtask commands, and Linux installation instructions.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,3 +151,75 @@ jobs:
         with:
           name: wail-windows-x64
           path: dist\
+
+  build-linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin/cargo-binstall
+            ~/.cargo/bin/cargo-nih-plug
+            ~/.cargo/bin/cargo-tauri
+            target
+          key: linux-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: linux-cargo-
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libxdo-dev \
+            libssl-dev \
+            patchelf \
+            libopus-dev \
+            cmake \
+            g++
+
+      - name: Install cargo-binstall
+        run: which cargo-binstall || curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+
+      - name: Install cargo-nih-plug
+        run: which cargo-nih-plug || cargo install --git https://github.com/robbert-vdh/nih-plug.git cargo-nih-plug
+
+      - name: Install tauri-cli
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          which cargo-tauri && exit 0
+          TAURI_TAG=$(gh api repos/tauri-apps/tauri/releases --jq '[.[] | select(.tag_name | startswith("tauri-cli-v"))][0].tag_name')
+          gh release download "$TAURI_TAG" --repo tauri-apps/tauri --pattern "cargo-tauri-x86_64-unknown-linux-gnu.tgz" --dir /tmp
+          tar -xzf /tmp/cargo-tauri-x86_64-unknown-linux-gnu.tgz -C ~/.cargo/bin/
+
+      - name: Build plugin
+        run: cargo xtask build-plugin
+
+      - name: Build Tauri app
+        run: cargo tauri build
+
+      - name: Collect artifacts
+        run: |
+          mkdir -p dist
+          cp target/bundled/wail-plugin-send.clap dist/
+          cp -r target/bundled/wail-plugin-send.vst3 dist/
+          cp target/bundled/wail-plugin-recv.clap dist/
+          cp -r target/bundled/wail-plugin-recv.vst3 dist/
+          cp target/release/bundle/appimage/*.AppImage dist/ || true
+          cp target/release/bundle/deb/*.deb dist/ || true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wail-linux-x64
+          path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,8 +150,80 @@ jobs:
           name: wail-release-windows
           path: dist\
 
+  build-linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin/cargo-binstall
+            ~/.cargo/bin/cargo-nih-plug
+            ~/.cargo/bin/cargo-tauri
+            target
+          key: linux-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: linux-cargo-
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libxdo-dev \
+            libssl-dev \
+            patchelf \
+            libopus-dev \
+            cmake \
+            g++
+
+      - name: Install cargo-binstall
+        run: which cargo-binstall || curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+
+      - name: Install cargo-nih-plug
+        run: which cargo-nih-plug || cargo install --git https://github.com/robbert-vdh/nih-plug.git cargo-nih-plug
+
+      - name: Install tauri-cli
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          which cargo-tauri && exit 0
+          TAURI_TAG=$(gh api repos/tauri-apps/tauri/releases --jq '[.[] | select(.tag_name | startswith("tauri-cli-v"))][0].tag_name')
+          gh release download "$TAURI_TAG" --repo tauri-apps/tauri --pattern "cargo-tauri-x86_64-unknown-linux-gnu.tgz" --dir /tmp
+          tar -xzf /tmp/cargo-tauri-x86_64-unknown-linux-gnu.tgz -C ~/.cargo/bin/
+
+      - name: Build plugin
+        run: cargo xtask build-plugin
+
+      - name: Build Tauri app
+        run: cargo tauri build --bundles appimage,deb
+
+      - name: Collect artifacts
+        run: |
+          mkdir -p dist
+          cp target/bundled/wail-plugin-send.clap dist/
+          cp -r target/bundled/wail-plugin-send.vst3 dist/
+          cp target/bundled/wail-plugin-recv.clap dist/
+          cp -r target/bundled/wail-plugin-recv.vst3 dist/
+          cp target/release/bundle/appimage/*.AppImage dist/ || true
+          cp target/release/bundle/deb/*.deb dist/ || true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wail-release-linux
+          path: dist/
+
   create-release:
-    needs: [build-macos, build-windows]
+    needs: [build-macos, build-windows, build-linux]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -162,6 +234,7 @@ jobs:
         run: |
           cd wail-release-macos/dist && zip -r ../../wail-macos-x64.zip . && cd ../..
           cd wail-release-windows && zip -r ../wail-windows-x64.zip . && cd ..
+          cd wail-release-linux && zip -r ../wail-linux-x64.zip . && cd ..
 
       - name: Find individual installers
         id: files
@@ -170,13 +243,18 @@ jobs:
           echo "dmg=$(ls wail-release-macos/dist/*.dmg 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
           echo "nsis=$(ls wail-release-windows/WAIL*.exe 2>/dev/null | head -1 || true)" >> "$GITHUB_OUTPUT"
           echo "msi=$(ls wail-release-windows/*.msi 2>/dev/null | head -1 || true)" >> "$GITHUB_OUTPUT"
+          echo "appimage=$(ls wail-release-linux/*.AppImage 2>/dev/null | head -1 || true)" >> "$GITHUB_OUTPUT"
+          echo "deb=$(ls wail-release-linux/*.deb 2>/dev/null | head -1 || true)" >> "$GITHUB_OUTPUT"
 
       - uses: softprops/action-gh-release@v2
         with:
           files: |
             wail-macos-x64.zip
             wail-windows-x64.zip
+            wail-linux-x64.zip
             ${{ steps.files.outputs.pkg }}
             ${{ steps.files.outputs.dmg }}
             ${{ steps.files.outputs.nsis }}
             ${{ steps.files.outputs.msi }}
+            ${{ steps.files.outputs.appimage }}
+            ${{ steps.files.outputs.deb }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5607,7 +5607,7 @@ dependencies = [
 
 [[package]]
 name = "wail-audio"
-version = "0.1.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "audiopus",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "wail-core"
-version = "0.1.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "rusty_link",
@@ -5629,7 +5629,7 @@ dependencies = [
 
 [[package]]
 name = "wail-net"
-version = "0.1.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -5650,7 +5650,7 @@ dependencies = [
 
 [[package]]
 name = "wail-plugin-recv"
-version = "0.1.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assert_no_alloc",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "wail-plugin-send"
-version = "0.1.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assert_no_alloc",
@@ -5674,7 +5674,7 @@ dependencies = [
 
 [[package]]
 name = "wail-tauri"
-version = "0.1.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "rand 0.8.5",

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Download the latest release from the [Releases page](https://github.com/quasor/W
 
 **Windows** — Run the NSIS installer. Plugins are bundled as CLAP and VST3 files — copy them to your DAW's plugin directory.
 
+**Linux** — Download the AppImage and make it executable (`chmod +x WAIL_*.AppImage`), or install the `.deb` package with `sudo dpkg -i wail_*.deb`. Copy the plugin files to `~/.clap/` and `~/.vst3/`.
+
 > **Important:** Enable Ableton Link in your DAW before using WAIL. In Ableton Live, go to Preferences > Link, Tempo, MIDI and turn on "Show Link Toggle" then enable Link. Other DAWs have similar settings — check your DAW's documentation for Link support.
 
 ## Components
@@ -61,6 +63,12 @@ val-town/
 ## Build from source
 
 Requires: **Rust 1.75+**, CMake 3.14+, a C++ compiler, and libopus-dev.
+
+**Linux build dependencies (Debian/Ubuntu):**
+```sh
+sudo apt-get install libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
+  librsvg2-dev libxdo-dev libssl-dev patchelf libopus-dev cmake g++
+```
 
 ```sh
 git submodule update --init --recursive   # fetch Ableton Link SDK

--- a/crates/wail-tauri/tauri.conf.json
+++ b/crates/wail-tauri/tauri.conf.json
@@ -21,7 +21,9 @@
     "active": true,
     "targets": [
       "dmg",
-      "nsis"
+      "nsis",
+      "appimage",
+      "deb"
     ],
     "icon": [
       "icons/32x32.png",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -167,7 +167,12 @@ fn install_plugin(args: &[String]) -> Result<()> {
 
 fn package_plugin(args: &[String]) -> Result<()> {
     #[cfg(not(target_os = "macos"))]
-    bail!("package-plugin is only supported on macOS");
+    {
+        let _ = args;
+        println!("package-plugin is only supported on macOS (creates .pkg installer).");
+        println!("On Linux, use `cargo xtask install-plugin` to install plugins to ~/.clap and ~/.vst3.");
+        return Ok(());
+    }
 
     #[cfg(target_os = "macos")]
     {
@@ -350,24 +355,52 @@ fn which_turnserver() -> Result<String> {
     if output.status.success() {
         return Ok(String::from_utf8_lossy(&output.stdout).trim().to_string());
     }
-    bail!("coturn not found. Install with: brew install coturn")
+    #[cfg(target_os = "macos")]
+    bail!("coturn not found. Install with: brew install coturn");
+    #[cfg(target_os = "linux")]
+    bail!("coturn not found. Install with: sudo apt install coturn");
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    bail!("coturn not found. See https://github.com/coturn/coturn for installation instructions.")
 }
 
 fn detect_local_ip() -> Option<String> {
-    // Try en0 first (Wi-Fi on macOS), then en1
-    for iface in &["en0", "en1"] {
-        let output = Command::new("ipconfig")
-            .args(["getifaddr", iface])
-            .output()
-            .ok()?;
-        if output.status.success() {
-            let ip = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !ip.is_empty() {
-                return Some(ip);
+    #[cfg(target_os = "macos")]
+    {
+        // Try en0 first (Wi-Fi on macOS), then en1
+        for iface in &["en0", "en1"] {
+            let output = Command::new("ipconfig")
+                .args(["getifaddr", iface])
+                .output()
+                .ok()?;
+            if output.status.success() {
+                let ip = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !ip.is_empty() {
+                    return Some(ip);
+                }
             }
         }
+        None
     }
-    None
+
+    #[cfg(target_os = "linux")]
+    {
+        // hostname -I returns space-separated non-loopback IPs
+        let output = Command::new("hostname").arg("-I").output().ok()?;
+        if output.status.success() {
+            let ips = String::from_utf8_lossy(&output.stdout);
+            if let Some(ip) = ips.split_whitespace().next() {
+                if !ip.is_empty() {
+                    return Some(ip.to_string());
+                }
+            }
+        }
+        None
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        None
+    }
 }
 
 fn detect_public_ip() -> Option<String> {


### PR DESCRIPTION
## Summary
- Add Ubuntu 22.04 CI jobs to build and release Linux packages (AppImage, .deb)
- Configure Tauri bundling for Linux in tauri.conf.json
- Fix xtask utilities for cross-platform: detect_local_ip() now works on Linux, which_turnserver() provides platform-aware error messages, and package_plugin() gracefully skips on non-macOS
- Add Linux installation instructions and build dependencies to README

## Test plan
- [x] `cargo check -p xtask` confirms xtask compiles
- [ ] Push branch and verify build-linux job triggers in GitHub Actions
- [ ] Test release workflow includes Linux artifacts (AppImage, deb)
- [ ] Verify Linux plugin installation paths are correct (~/.clap, ~/.vst3)

🤖 Generated with Claude Code