### PR TITLE
chore: prepare release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.2 (2026-03-02)
+
+### Features
+
+- add Linux support (#27)
+
 ## 0.4.1 (2026-03-02)
 
 ### Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 license = "MIT"
 

--- a/crates/wail-tauri/tauri.conf.json
+++ b/crates/wail-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "WAIL",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "identifier": "com.wail.desktop",
   "build": {
     "frontendDist": "ui"


### PR DESCRIPTION
## Summary
- Bump version to 0.4.2
- Update CHANGELOG.md with Linux support feature entry
- Consume changeset file

Generated by `knope release`.