### PR TITLE
fix: correct package name in cargo_version() lookup

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -237,10 +237,10 @@ fn cargo_version(root: &Path) -> Result<String> {
         .as_array()
         .context("packages not an array")?
         .iter()
-        .find(|p| p["name"] == "wail-plugin")
+        .find(|p| p["name"] == "wail-plugin-send")
         .and_then(|p| p["version"].as_str())
         .map(|s| s.to_owned())
-        .context("Could not find wail-plugin version in cargo metadata")
+        .context("Could not find wail-plugin-send version in cargo metadata")
 }
 
 fn run_tauri() -> Result<()> {


### PR DESCRIPTION
## Summary
- Fix pre-existing bug where `cargo_version()` in xtask looked for a package named `wail-plugin` which doesn't exist
- Changed to look for `wail-plugin-send` instead, which is the actual crate name
- This was causing the "Create .pkg installer" step to fail during release builds

## Test plan
- [x] `cargo check -p xtask` passes
- [ ] Re-run release workflow to verify .pkg creation succeeds