### PR TITLE
feat: auto-release on PR merge to main

### DIFF
--- a/.changeset/auto-release-setup.md
+++ b/.changeset/auto-release-setup.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Add automatic releases on PR merge to main via GitHub Actions.

--- a/.changeset/linux-support.md
+++ b/.changeset/linux-support.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-Add Linux support: AppImage and .deb builds in CI, cross-platform xtask commands, and Linux installation instructions.

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,77 @@
+name: Auto Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    # Skip the version-bump commit that knope pushes.
+    # Belt-and-suspenders: GITHUB_TOKEN pushes don't trigger workflows anyway.
+    if: "!startsWith(github.event.head_commit.message, 'chore: prepare release')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Install knope
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          curl -sSfL "https://github.com/knope-dev/knope/releases/latest/download/knope-x86_64-unknown-linux-musl.tgz" \
+            | tar -xz -C /usr/local/bin/
+
+      - name: Ensure changeset exists for patch release
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          HAS_CHANGESETS=false
+          HAS_CONVENTIONAL=false
+
+          # Check for changeset files
+          if ls .changeset/*.md 1>/dev/null 2>&1; then
+            HAS_CHANGESETS=true
+          fi
+
+          # Check for conventional commits since last tag
+          if [ -n "$LAST_TAG" ]; then
+            RANGE="${LAST_TAG}..HEAD"
+          else
+            RANGE="HEAD"
+          fi
+          if git log --oneline "$RANGE" | grep -qE '^[0-9a-f]+ (feat|fix|feat!|fix!|refactor|perf)[(:!]'; then
+            HAS_CONVENTIONAL=true
+          fi
+
+          if [ "$HAS_CHANGESETS" = false ] && [ "$HAS_CONVENTIONAL" = false ]; then
+            echo "No changesets or conventional commits found. Creating fallback patch changeset."
+            mkdir -p .changeset
+            COMMIT_MSG=$(git log -1 --format='%s')
+            printf -- '---\ntype: patch\n---\n\n%s\n' "$COMMIT_MSG" > .changeset/auto-patch.md
+          fi
+
+      - name: Run knope release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: knope release
+
+      - name: Trigger release build
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "//;s/"//')
+          TAG="v${VERSION}"
+          echo "Triggering release build for ${TAG}"
+          gh workflow run release.yml --ref "${TAG}" -f tag="${TAG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v0.5.0)'
+        required: true
+        type: string
 
 jobs:
   build-macos:
@@ -10,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.tag || github.ref }}
           submodules: recursive
 
       - uses: dtolnay/rust-toolchain@stable
@@ -75,6 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.tag || github.ref }}
           submodules: recursive
 
       - uses: dtolnay/rust-toolchain@stable
@@ -155,6 +163,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.tag || github.ref }}
           submodules: recursive
 
       - uses: dtolnay/rust-toolchain@stable
@@ -230,6 +239,15 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
 
+      - name: Determine tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Zip platform artifacts
         run: |
           cd wail-release-macos/dist && zip -r ../../wail-macos-x64.zip . && cd ../..
@@ -248,6 +266,7 @@ jobs:
 
       - uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.tag.outputs.tag }}
           files: |
             wail-macos-x64.zip
             wail-windows-x64.zip


### PR DESCRIPTION
## Summary

Implement automatic releases triggered by PR merges to main. Every PR merge now automatically produces at least a patch (0.0.x) version bump, with higher bumps when changesets or conventional commits indicate minor/major changes.

## Changes

- **New `.github/workflows/auto-release.yml`**: Triggers on push to main, runs `knope release` to bump version and create GitHub release, then dispatches `release.yml` via workflow_dispatch for multi-platform builds
- **Modified `.github/workflows/release.yml`**: Added `workflow_dispatch` trigger with `tag` input, explicit `tag_name` for artifact uploads, and conditional `ref` on checkouts
- **Fallback patch changeset logic**: If no changesets or conventional commits exist, auto-release.yml creates a patch changeset to ensure every PR gets at least a patch release
- **Cleanup**: Removed stale `linux-support.md` changeset that was not consumed by v0.4.2

## How it works

1. PR merges to main → auto-release.yml triggers
2. Ensures at least a patch changeset exists
3. Runs `knope release` → bumps version, updates changelog, commits, pushes, creates GitHub release+tag
4. Triggers `release.yml` via `gh workflow run` → builds on all 3 platforms, uploads artifacts to the release

The two-workflow design avoids GitHub's `GITHUB_TOKEN` limitation where tag-based triggers don't fire. `workflow_dispatch` is exempt from this restriction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)