### PR TITLE
fix: strip nested directory from knope tarball in CI

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -32,7 +32,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           curl -sSfL "https://github.com/knope-dev/knope/releases/latest/download/knope-x86_64-unknown-linux-musl.tgz" \
-            | tar -xz -C /usr/local/bin/
+            | tar -xz --strip-components=1 -C /usr/local/bin/
 
       - name: Ensure changeset exists for patch release
         run: |


### PR DESCRIPTION
## Summary
- The knope release tarball changed its structure — the binary is now nested in a subdirectory (`knope-x86_64-unknown-linux-musl/knope`) instead of at the archive root
- This caused the auto-release workflow to fail with `knope: command not found` ([failing run](https://github.com/quasor/WAIL/actions/runs/22598480667/job/65474459137))
- Adds `--strip-components=1` to the `tar` command to extract the binary directly into `/usr/local/bin/`

## Test plan
- [ ] Merge this PR and verify the auto-release workflow succeeds on the resulting push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)