### PR TITLE
fix: split release CI for branch protection

### DIFF
--- a/.changeset/fix-release-branch-protection.md
+++ b/.changeset/fix-release-branch-protection.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Split CI release into two phases (prepare-release PR + release-on-merge) to work with branch protection rules

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,22 +1,21 @@
-name: Auto Release
+name: Prepare Release
 
 on:
   push:
     branches: [main]
 
 concurrency:
-  group: auto-release
-  cancel-in-progress: false
+  group: prepare-release
+  cancel-in-progress: true
 
 jobs:
-  release:
-    # Skip the version-bump commit that knope pushes.
-    # Belt-and-suspenders: GITHUB_TOKEN pushes don't trigger workflows anyway.
-    if: "!startsWith(github.event.head_commit.message, 'chore: prepare release')"
+  prepare-release:
+    # Skip if this push is the release PR being merged
+    if: "!contains(github.event.head_commit.message, 'chore: prepare release')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      actions: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -40,12 +39,10 @@ jobs:
           HAS_CHANGESETS=false
           HAS_CONVENTIONAL=false
 
-          # Check for changeset files
           if ls .changeset/*.md 1>/dev/null 2>&1; then
             HAS_CHANGESETS=true
           fi
 
-          # Check for conventional commits since last tag
           if [ -n "$LAST_TAG" ]; then
             RANGE="${LAST_TAG}..HEAD"
           else
@@ -62,16 +59,31 @@ jobs:
             printf -- '---\ntype: patch\n---\n\n%s\n' "$COMMIT_MSG" > .changeset/auto-patch.md
           fi
 
-      - name: Run knope release
+      - name: Run knope prepare-release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: knope release
+        run: knope prepare-release
 
-      - name: Trigger release build
+      - name: Create or update release PR
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "//;s/"//')
-          TAG="v${VERSION}"
-          echo "Triggering release build for ${TAG}"
-          gh workflow run release.yml --ref "${TAG}" -f tag="${TAG}"
+          EXISTING_PR=$(gh pr list --head release --base main --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+          BODY="Automated release preparation for v${VERSION}.
+
+          Merging this PR will create GitHub release v${VERSION} and trigger artifact builds."
+
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr edit "$EXISTING_PR" \
+              --title "chore: prepare release v${VERSION}" \
+              --body "$BODY"
+            echo "Updated existing PR #${EXISTING_PR}"
+          else
+            gh pr create \
+              --head release \
+              --base main \
+              --title "chore: prepare release v${VERSION}" \
+              --body "$BODY"
+          fi

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -1,0 +1,48 @@
+name: Release on Merge
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install knope
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          curl -sSfL "https://github.com/knope-dev/knope/releases/latest/download/knope-x86_64-unknown-linux-musl.tgz" \
+            | tar -xz --strip-components=1 -C /usr/local/bin/
+
+      - name: Create GitHub release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: knope release
+
+      - name: Trigger release build
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "//;s/"//')
+          TAG="v${VERSION}"
+          echo "Triggering release build for ${TAG}"
+          gh workflow run release.yml --ref "${TAG}" -f tag="${TAG}"
+
+      - name: Delete release branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api repos/${{ github.repository }}/git/refs/heads/release -X DELETE || true

--- a/knope.toml
+++ b/knope.toml
@@ -7,10 +7,14 @@ owner = "quasor"
 repo = "WAIL"
 
 [[workflows]]
-name = "release"
+name = "prepare-release"
 
 [[workflows.steps]]
 type = "PrepareRelease"
+
+[[workflows.steps]]
+type = "Command"
+command = "git switch -c release"
 
 [[workflows.steps]]
 type = "Command"
@@ -22,7 +26,10 @@ command = "git commit -m 'chore: prepare release'"
 
 [[workflows.steps]]
 type = "Command"
-command = "git push"
+command = "git push --force --set-upstream origin release"
+
+[[workflows]]
+name = "release"
 
 [[workflows.steps]]
 type = "Release"


### PR DESCRIPTION
## Summary
- Split the monolithic `knope release` workflow into two phases to work with branch protection rules
- **Phase 1** (`auto-release.yml`): On push to main, runs `knope prepare-release` which bumps versions and opens a PR from a `release` branch
- **Phase 2** (`release-on-merge.yml`): When the release PR is merged, creates the GitHub release + tag via API and triggers the artifact build

## Problem
`knope release` was trying to `git push` a version-bump commit directly to `main`, which branch protection blocks (`GH013: Changes must be made through a pull request`). See [failed run](https://github.com/quasor/WAIL/actions/runs/22598756160/job/65475367748).

## Test plan
- [ ] Merge this PR to main
- [ ] Verify `Prepare Release` workflow runs and opens a "chore: prepare release" PR
- [ ] Merge the release PR
- [ ] Verify `Release on Merge` workflow creates the GitHub release and triggers artifact builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)