### PR TITLE
feat: add local session recording with stems/mixed modes (#23)

### DIFF
--- a/.changeset/local-session-recording.md
+++ b/.changeset/local-session-recording.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+Add local session recording to the WAIL app. New recording options in the Advanced settings panel let you capture jam sessions as WAV files to disk. Supports recording per-peer stems (separate WAV per participant) or a single mixed WAV. Includes configurable recording directory, retention policy (auto-delete old sessions after N days), and a live recording indicator with file size display in the session view.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,8 +641,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -1908,6 +1910,12 @@ checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
 ]
+
+[[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "html5ever"
@@ -5677,6 +5685,8 @@ name = "wail-tauri"
 version = "0.4.3"
 dependencies = [
  "anyhow",
+ "chrono",
+ "hound",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/crates/wail-tauri/Cargo.toml
+++ b/crates/wail-tauri/Cargo.toml
@@ -19,3 +19,5 @@ tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 anyhow = { workspace = true }
 rand = { workspace = true }
+hound = "3.5"
+chrono = { version = "0.4", features = ["serde"] }

--- a/crates/wail-tauri/src/commands.rs
+++ b/crates/wail-tauri/src/commands.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use tauri::{Manager, State};
 use tracing::{info, warn};
 
+use crate::recorder::RecordingConfig;
 use crate::session::{SessionCommand, SessionConfig, SessionHandle};
 
 pub type SessionState = Mutex<Option<SessionHandle>>;
@@ -57,6 +58,10 @@ pub fn join_room(
     turn_url: Option<String>,
     turn_username: Option<String>,
     turn_credential: Option<String>,
+    recording_enabled: Option<bool>,
+    recording_directory: Option<String>,
+    recording_stems: Option<bool>,
+    recording_retention_days: Option<u32>,
 ) -> Result<JoinResult, String> {
     let mut session = state.lock().map_err(|e| e.to_string())?;
     if session.is_some() {
@@ -77,6 +82,17 @@ pub fn join_room(
         turn_url,
         turn_username,
         turn_credential,
+        recording: if recording_enabled.unwrap_or(false) {
+            Some(RecordingConfig {
+                enabled: true,
+                directory: recording_directory
+                    .unwrap_or_else(|| crate::recorder::default_recording_dir().unwrap_or_default()),
+                stems: recording_stems.unwrap_or(false),
+                retention_days: recording_retention_days.unwrap_or(30),
+            })
+        } else {
+            None
+        },
     };
 
     let handle = crate::session::spawn_session(app, config).map_err(|e| e.to_string())?;
@@ -249,4 +265,27 @@ fn copy_dir_all(src: &std::path::Path, dst: &std::path::Path) -> anyhow::Result<
         }
     }
     Ok(())
+}
+
+#[tauri::command]
+pub fn get_default_recording_dir() -> Result<String, String> {
+    crate::recorder::default_recording_dir().map_err(|e| e.to_string())
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CleanupResult {
+    pub deleted_count: u32,
+    pub freed_bytes: u64,
+}
+
+#[tauri::command]
+pub async fn cleanup_recordings(directory: String, retention_days: u32) -> Result<CleanupResult, String> {
+    tokio::task::spawn_blocking(move || {
+        let (deleted_count, freed_bytes) =
+            crate::recorder::cleanup_old_sessions(std::path::Path::new(&directory), retention_days)
+                .map_err(|e| e.to_string())?;
+        Ok(CleanupResult { deleted_count, freed_bytes })
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }

--- a/crates/wail-tauri/src/events.rs
+++ b/crates/wail-tauri/src/events.rs
@@ -53,6 +53,8 @@ pub struct StatusUpdate {
     pub audio_dc_open: bool,
     pub plugin_connected: bool,
     pub test_tone_enabled: bool,
+    pub recording: bool,
+    pub recording_size_bytes: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/wail-tauri/src/lib.rs
+++ b/crates/wail-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod commands;
 pub mod events;
+mod recorder;
 mod session;
 
 use commands::SessionState;
@@ -33,6 +34,8 @@ pub fn run() {
             commands::install_plugins,
             commands::check_plugins_installed,
             commands::list_public_rooms,
+            commands::get_default_recording_dir,
+            commands::cleanup_recordings,
         ])
         .run(tauri::generate_context!())
         .expect("error while running WAIL");

--- a/crates/wail-tauri/src/recorder.rs
+++ b/crates/wail-tauri/src/recorder.rs
@@ -1,0 +1,533 @@
+use std::collections::HashMap;
+use std::io::BufWriter;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tracing::{info, warn};
+
+use wail_audio::{AudioDecoder, AudioWire};
+
+/// Configuration for local session recording.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecordingConfig {
+    pub enabled: bool,
+    pub directory: String,
+    pub stems: bool,
+    pub retention_days: u32,
+}
+
+/// Commands sent from the session loop to the writer task.
+enum RecordCommand {
+    OwnInterval { wire_data: Vec<u8> },
+    PeerInterval { peer_id: String, display_name: Option<String>, wire_data: Vec<u8> },
+    Finalize,
+}
+
+/// Peer metadata for session.json.
+#[derive(Serialize)]
+struct PeerEntry {
+    peer_id: String,
+    display_name: Option<String>,
+}
+
+/// Session metadata written to session.json on finalize.
+#[derive(Serialize)]
+struct SessionMetadata {
+    version: u32,
+    room: String,
+    started_at: String,
+    ended_at: String,
+    sample_rate: u32,
+    channels: u16,
+    stems: bool,
+    peers: Vec<PeerEntry>,
+    files: Vec<String>,
+}
+
+/// Manages recording for a single session.
+/// Audio is sent via channel and written on a blocking task.
+pub struct SessionRecorder {
+    tx: mpsc::UnboundedSender<RecordCommand>,
+    bytes_written: Arc<AtomicU64>,
+}
+
+impl SessionRecorder {
+    /// Start a new recording session.
+    pub fn start(config: RecordingConfig, room: &str) -> Result<Self> {
+        // Run cleanup before starting
+        if config.retention_days > 0 {
+            if let Err(e) = cleanup_old_sessions(Path::new(&config.directory), config.retention_days) {
+                warn!("Recording cleanup failed: {e}");
+            }
+        }
+
+        let session_dir = create_session_dir(&config.directory, room)?;
+        let (tx, rx) = mpsc::unbounded_channel();
+        let bytes_written = Arc::new(AtomicU64::new(0));
+        let bytes_clone = bytes_written.clone();
+
+        let room_owned = room.to_string();
+        info!(dir = %session_dir.display(), "Recording session to disk");
+
+        tokio::task::spawn_blocking(move || {
+            let mut writer = RecorderWriter::new(config, session_dir, room_owned, bytes_clone);
+            writer.run(rx);
+        });
+
+        Ok(Self { tx, bytes_written })
+    }
+
+    pub fn record_own(&self, wire_data: Vec<u8>) {
+        let _ = self.tx.send(RecordCommand::OwnInterval { wire_data });
+    }
+
+    pub fn record_peer(&self, peer_id: String, display_name: Option<String>, wire_data: Vec<u8>) {
+        let _ = self.tx.send(RecordCommand::PeerInterval { peer_id, display_name, wire_data });
+    }
+
+    pub fn finalize(&self) {
+        let _ = self.tx.send(RecordCommand::Finalize);
+    }
+
+    pub fn bytes_written(&self) -> u64 {
+        self.bytes_written.load(Ordering::Relaxed)
+    }
+}
+
+/// Internal writer state running on a blocking task.
+struct RecorderWriter {
+    config: RecordingConfig,
+    session_dir: PathBuf,
+    room: String,
+    bytes_written: Arc<AtomicU64>,
+    started_at: chrono::DateTime<chrono::Utc>,
+    /// Per-source WAV writers keyed by source id ("self" or peer_id)
+    writers: HashMap<String, StemWriter>,
+    /// Per-source Opus decoders
+    decoders: HashMap<String, AudioDecoder>,
+    /// Peer metadata for session.json
+    peers: HashMap<String, Option<String>>,
+    /// For mixed mode: buffer decoded PCM per interval index, keyed by index
+    mix_buffer: HashMap<i64, Vec<f32>>,
+    /// Highest interval index seen so far
+    max_interval: Option<i64>,
+    /// The mix writer (used in mixed mode only)
+    mix_writer: Option<StemWriter>,
+    /// Detected sample rate and channels from first interval
+    sample_rate: Option<u32>,
+    channels: Option<u16>,
+}
+
+struct StemWriter {
+    writer: hound::WavWriter<BufWriter<std::fs::File>>,
+    path: PathBuf,
+    samples_written: u64,
+}
+
+impl StemWriter {
+    fn new(path: &Path, sample_rate: u32, channels: u16) -> Result<Self> {
+        let spec = hound::WavSpec {
+            channels,
+            sample_rate,
+            bits_per_sample: 32,
+            sample_format: hound::SampleFormat::Float,
+        };
+        let file = std::fs::File::create(path)?;
+        let buf = BufWriter::new(file);
+        let writer = hound::WavWriter::new(buf, spec)?;
+        Ok(Self {
+            writer,
+            path: path.to_path_buf(),
+            samples_written: 0,
+        })
+    }
+
+    fn write_samples(&mut self, samples: &[f32]) -> Result<()> {
+        for &s in samples {
+            self.writer.write_sample(s)?;
+        }
+        self.samples_written += samples.len() as u64;
+        Ok(())
+    }
+
+    fn finalize(self) -> Result<()> {
+        self.writer.finalize()?;
+        Ok(())
+    }
+}
+
+impl RecorderWriter {
+    fn new(config: RecordingConfig, session_dir: PathBuf, room: String, bytes_written: Arc<AtomicU64>) -> Self {
+        Self {
+            config,
+            session_dir,
+            room,
+            bytes_written,
+            started_at: chrono::Utc::now(),
+            writers: HashMap::new(),
+            decoders: HashMap::new(),
+            peers: HashMap::new(),
+            mix_buffer: HashMap::new(),
+            max_interval: None,
+            mix_writer: None,
+            sample_rate: None,
+            channels: None,
+        }
+    }
+
+    fn run(&mut self, rx: mpsc::UnboundedReceiver<RecordCommand>) {
+        // Use blocking_recv in the spawn_blocking context
+        let mut rx = rx;
+        loop {
+            match rx.blocking_recv() {
+                Some(RecordCommand::OwnInterval { wire_data }) => {
+                    self.handle_interval("self", None, &wire_data);
+                }
+                Some(RecordCommand::PeerInterval { peer_id, display_name, wire_data }) => {
+                    self.peers.entry(peer_id.clone()).or_insert(display_name.clone());
+                    self.handle_interval(&peer_id, display_name.as_deref(), &wire_data);
+                }
+                Some(RecordCommand::Finalize) => {
+                    self.finalize();
+                    return;
+                }
+                None => {
+                    // Channel closed — session ended without explicit finalize
+                    self.finalize();
+                    return;
+                }
+            }
+        }
+    }
+
+    fn handle_interval(&mut self, source_id: &str, display_name: Option<&str>, wire_data: &[u8]) {
+        let interval = match AudioWire::decode(wire_data) {
+            Ok(i) => i,
+            Err(e) => {
+                warn!(source = source_id, "Recording: failed to decode wire data: {e}");
+                return;
+            }
+        };
+
+        // Detect format from first interval
+        if self.sample_rate.is_none() {
+            self.sample_rate = Some(interval.sample_rate);
+            self.channels = Some(interval.channels);
+        }
+
+        let sr = interval.sample_rate;
+        let ch = interval.channels;
+
+        // Get or create decoder for this source
+        let decoder = self.decoders.entry(source_id.to_string()).or_insert_with(|| {
+            match AudioDecoder::new(sr, ch) {
+                Ok(d) => d,
+                Err(e) => {
+                    warn!(source = source_id, "Recording: failed to create decoder: {e}");
+                    // Return a dummy — we'll handle the error on decode
+                    AudioDecoder::new(48000, 1).expect("fallback decoder")
+                }
+            }
+        });
+
+        let pcm = match decoder.decode_interval(&interval.opus_data) {
+            Ok(pcm) => pcm,
+            Err(e) => {
+                warn!(source = source_id, "Recording: failed to decode opus: {e}");
+                return;
+            }
+        };
+
+        if self.config.stems {
+            self.write_stems(source_id, display_name, sr, ch, &pcm);
+        } else {
+            self.write_mixed(source_id, display_name, sr, ch, interval.index, &pcm);
+        }
+
+        self.update_bytes_written();
+    }
+
+    fn write_stems(&mut self, source_id: &str, display_name: Option<&str>, sr: u32, ch: u16, pcm: &[f32]) {
+        // Create writer lazily
+        if !self.writers.contains_key(source_id) {
+            let filename = stem_filename(source_id, display_name);
+            let path = self.session_dir.join(&filename);
+            match StemWriter::new(&path, sr, ch) {
+                Ok(w) => {
+                    info!(file = %path.display(), "Recording: opened stem file");
+                    self.writers.insert(source_id.to_string(), w);
+                }
+                Err(e) => {
+                    warn!(source = source_id, "Recording: failed to create WAV file: {e}");
+                    return;
+                }
+            }
+        }
+
+        if let Some(writer) = self.writers.get_mut(source_id) {
+            if let Err(e) = writer.write_samples(pcm) {
+                warn!(source = source_id, "Recording: WAV write failed: {e}");
+            }
+        }
+    }
+
+    fn write_mixed(&mut self, _source_id: &str, _display_name: Option<&str>, sr: u32, ch: u16, interval_index: i64, pcm: &[f32]) {
+        // Flush any earlier intervals before processing the new one
+        if let Some(max) = self.max_interval {
+            if interval_index > max {
+                // Flush all intervals up to (but not including) the current one
+                self.flush_mix_buffer(sr, ch);
+            }
+        }
+        self.max_interval = Some(self.max_interval.map_or(interval_index, |m| m.max(interval_index)));
+
+        // Sum this source's PCM into the mix buffer for this interval
+        let buf = self.mix_buffer.entry(interval_index).or_default();
+        if buf.is_empty() {
+            buf.extend_from_slice(pcm);
+        } else {
+            // Sum: extend if this source is longer, add sample-by-sample
+            if pcm.len() > buf.len() {
+                buf.resize(pcm.len(), 0.0);
+            }
+            for (i, &s) in pcm.iter().enumerate() {
+                buf[i] += s;
+            }
+        }
+    }
+
+    fn flush_mix_buffer(&mut self, sr: u32, ch: u16) {
+        // Collect all interval indices except the current max (which may still be accumulating)
+        let max = match self.max_interval {
+            Some(m) => m,
+            None => return,
+        };
+
+        let to_flush: Vec<i64> = self.mix_buffer.keys()
+            .filter(|&&idx| idx < max)
+            .copied()
+            .collect();
+
+        // Sort to write in order
+        let mut to_flush = to_flush;
+        to_flush.sort();
+
+        for idx in to_flush {
+            if let Some(pcm) = self.mix_buffer.remove(&idx) {
+                // Ensure mix writer exists
+                if self.mix_writer.is_none() {
+                    let path = self.session_dir.join("mix.wav");
+                    match StemWriter::new(&path, sr, ch) {
+                        Ok(w) => {
+                            info!(file = %path.display(), "Recording: opened mix file");
+                            self.mix_writer = Some(w);
+                        }
+                        Err(e) => {
+                            warn!("Recording: failed to create mix WAV: {e}");
+                            return;
+                        }
+                    }
+                }
+
+                if let Some(ref mut writer) = self.mix_writer {
+                    if let Err(e) = writer.write_samples(&pcm) {
+                        warn!("Recording: mix WAV write failed: {e}");
+                    }
+                }
+            }
+        }
+    }
+
+    fn update_bytes_written(&self) {
+        let mut total = 0u64;
+        for w in self.writers.values() {
+            // 4 bytes per f32 sample
+            total += w.samples_written * 4;
+        }
+        if let Some(ref w) = self.mix_writer {
+            total += w.samples_written * 4;
+        }
+        self.bytes_written.store(total, Ordering::Relaxed);
+    }
+
+    fn finalize(&mut self) {
+        let sr = self.sample_rate.unwrap_or(48000);
+        let ch = self.channels.unwrap_or(1);
+
+        // Flush remaining mix buffer
+        if !self.config.stems {
+            // Flush everything including the current max
+            if let Some(max) = self.max_interval {
+                // Temporarily bump max so flush_mix_buffer flushes everything
+                self.max_interval = Some(max + 1);
+                self.flush_mix_buffer(sr, ch);
+            }
+        }
+
+        // Collect file names for metadata
+        let mut files = Vec::new();
+
+        // Finalize all stem writers
+        let writers = std::mem::take(&mut self.writers);
+        for (source_id, writer) in writers {
+            let filename = writer.path.file_name()
+                .map(|f| f.to_string_lossy().to_string())
+                .unwrap_or_else(|| format!("{source_id}.wav"));
+            files.push(filename);
+            if let Err(e) = writer.finalize() {
+                warn!(source = source_id, "Recording: failed to finalize WAV: {e}");
+            }
+        }
+
+        // Finalize mix writer
+        if let Some(writer) = self.mix_writer.take() {
+            files.push("mix.wav".to_string());
+            if let Err(e) = writer.finalize() {
+                warn!("Recording: failed to finalize mix WAV: {e}");
+            }
+        }
+
+        // Write session.json
+        let peers: Vec<PeerEntry> = self.peers.iter()
+            .map(|(id, name)| PeerEntry {
+                peer_id: id.clone(),
+                display_name: name.clone(),
+            })
+            .collect();
+
+        let metadata = SessionMetadata {
+            version: 1,
+            room: self.room.clone(),
+            started_at: self.started_at.to_rfc3339(),
+            ended_at: chrono::Utc::now().to_rfc3339(),
+            sample_rate: sr,
+            channels: ch,
+            stems: self.config.stems,
+            peers,
+            files,
+        };
+
+        let meta_path = self.session_dir.join("session.json");
+        match serde_json::to_string_pretty(&metadata) {
+            Ok(json) => {
+                if let Err(e) = std::fs::write(&meta_path, json) {
+                    warn!("Recording: failed to write session.json: {e}");
+                }
+            }
+            Err(e) => {
+                warn!("Recording: failed to serialize session.json: {e}");
+            }
+        }
+
+        self.update_bytes_written();
+        info!(dir = %self.session_dir.display(), "Recording finalized");
+    }
+}
+
+/// Generate a filename for a stem WAV file.
+fn stem_filename(source_id: &str, display_name: Option<&str>) -> String {
+    if source_id == "self" {
+        return "self.wav".to_string();
+    }
+    let name_part = display_name
+        .map(|n| sanitize_filename(n))
+        .unwrap_or_else(|| "anonymous".to_string());
+    format!("peer_{name_part}_{source_id}.wav")
+}
+
+/// Sanitize a string for use in filenames.
+fn sanitize_filename(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
+        .take(32)
+        .collect()
+}
+
+/// Create the session recording directory.
+fn create_session_dir(base: &str, room: &str) -> Result<PathBuf> {
+    let now = chrono::Local::now();
+    let timestamp = now.format("%Y-%m-%d_%H-%M-%S").to_string();
+    let safe_room = sanitize_filename(room);
+    let dir_name = format!("{timestamp}_{safe_room}");
+    let dir = Path::new(base).join(dir_name);
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+/// Delete recording sessions older than retention_days.
+pub fn cleanup_old_sessions(base_dir: &Path, retention_days: u32) -> Result<(u32, u64)> {
+    if retention_days == 0 {
+        return Ok((0, 0));
+    }
+
+    let cutoff = chrono::Utc::now() - chrono::Duration::days(retention_days as i64);
+    let mut deleted = 0u32;
+    let mut freed = 0u64;
+
+    if !base_dir.exists() {
+        return Ok((0, 0));
+    }
+
+    let entries = match std::fs::read_dir(base_dir) {
+        Ok(e) => e,
+        Err(_) => return Ok((0, 0)),
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+
+        let name = entry.file_name().to_string_lossy().to_string();
+        // Parse date from directory name: YYYY-MM-DD_HH-MM-SS_room
+        if let Some(date_str) = name.get(..19) {
+            if let Ok(date) = chrono::NaiveDateTime::parse_from_str(date_str, "%Y-%m-%d_%H-%M-%S") {
+                let dt = date.and_utc();
+                if dt < cutoff {
+                    let size = dir_size(&entry.path());
+                    if let Err(e) = std::fs::remove_dir_all(entry.path()) {
+                        warn!(dir = %entry.path().display(), "Failed to delete old recording: {e}");
+                        continue;
+                    }
+                    deleted += 1;
+                    freed += size;
+                    info!(dir = %entry.path().display(), "Deleted old recording session");
+                }
+            }
+        }
+    }
+
+    Ok((deleted, freed))
+}
+
+/// Calculate the total size of a directory recursively.
+fn dir_size(path: &Path) -> u64 {
+    let mut size = 0u64;
+    if let Ok(entries) = std::fs::read_dir(path) {
+        for entry in entries.flatten() {
+            if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                size += dir_size(&entry.path());
+            } else {
+                size += entry.metadata().map(|m| m.len()).unwrap_or(0);
+            }
+        }
+    }
+    size
+}
+
+/// Returns the platform-appropriate default recording directory.
+pub fn default_recording_dir() -> Result<String> {
+    let home = std::env::var("HOME")
+        .map_err(|_| anyhow::anyhow!("HOME environment variable not set"))?;
+    let dir = Path::new(&home).join("Music").join("WAIL Sessions");
+    Ok(dir.to_string_lossy().to_string())
+}

--- a/crates/wail-tauri/src/session.rs
+++ b/crates/wail-tauri/src/session.rs
@@ -15,6 +15,7 @@ use wail_net::PeerMesh;
 
 use crate::events::*;
 use crate::emit_log;
+use crate::recorder::{RecordingConfig, SessionRecorder};
 
 /// Shorthand: log to tracing + emit to UI
 macro_rules! ui_info {
@@ -66,6 +67,7 @@ pub struct SessionConfig {
     pub turn_url: Option<String>,
     pub turn_username: Option<String>,
     pub turn_credential: Option<String>,
+    pub recording: Option<RecordingConfig>,
 }
 
 pub fn spawn_session(app: AppHandle, config: SessionConfig) -> Result<SessionHandle> {
@@ -109,6 +111,7 @@ async fn session_loop(
         turn_url,
         turn_username,
         turn_credential,
+        recording: recording_config,
     } = config;
 
     ui_info!(&app, "Starting peer {peer_id} as {display_name} in room {room} (BPM {bpm}, {bars} bars, quantum {quantum})");
@@ -198,6 +201,23 @@ async fn session_loop(
     let mut next_conn_id: usize = 0;
     let (ipc_from_plugin_tx, mut ipc_from_plugin_rx) = mpsc::channel::<Vec<u8>>(64);
     let (ipc_disconnect_tx, mut ipc_disconnect_rx) = mpsc::channel::<usize>(16);
+
+    // Initialize local recording if configured
+    let recorder: Option<SessionRecorder> = match recording_config {
+        Some(ref cfg) if cfg.enabled => {
+            match SessionRecorder::start(cfg.clone(), &room) {
+                Ok(r) => {
+                    ui_info!(&app, "Recording enabled: {}", cfg.directory);
+                    Some(r)
+                }
+                Err(e) => {
+                    ui_warn!(&app, "Failed to start recording: {e}");
+                    None
+                }
+            }
+        }
+        _ => None,
+    };
 
     ui_info!(&app, "Waiting for peers...");
 
@@ -316,6 +336,10 @@ async fn session_loop(
                     audio_intervals_sent += 1;
                     let peers = mesh.connected_peers();
                     ui_info!(&app, "[AUDIO SEND] wire={} bytes, peers=[{}], total_sent={}", wire_data.len(), peers.join(", "), audio_intervals_sent);
+
+                    if let Some(ref rec) = recorder {
+                        rec.record_own(wire_data);
+                    }
                 }
             }
 
@@ -505,6 +529,11 @@ async fn session_loop(
                     }
                 }
 
+                if let Some(ref rec) = recorder {
+                    let name = peer_names.get(&from).and_then(|n| n.clone());
+                    rec.record_peer(from.clone(), name, data.clone());
+                }
+
                 if !ipc_recv_writers.is_empty() {
                     let msg = IpcMessage::encode_audio(&from, &data);
                     let frame = IpcFramer::encode_frame(&msg);
@@ -619,6 +648,8 @@ async fn session_loop(
                         audio_dc_open: dc_open,
                         plugin_connected: !ipc_recv_writers.is_empty(),
                         test_tone_enabled,
+                        recording: recorder.is_some(),
+                        recording_size_bytes: recorder.as_ref().map_or(0, |r| r.bytes_written()),
                     });
 
                     // Broadcast audio pipeline status to remote peers
@@ -632,6 +663,12 @@ async fn session_loop(
                 }
             }
         }
+    }
+
+    // Finalize recording if active
+    if let Some(ref rec) = recorder {
+        rec.finalize();
+        ui_info!(&app, "Recording finalized");
     }
 
     Ok(())

--- a/crates/wail-tauri/ui/index.html
+++ b/crates/wail-tauri/ui/index.html
@@ -51,6 +51,29 @@
               <input type="checkbox" id="test-tone">
               <label for="test-tone" class="remember-label">Enable test tone (no plugin needed)</label>
             </div>
+
+            <div class="recording-section">
+              <div class="remember-row">
+                <input type="checkbox" id="recording-enabled">
+                <label for="recording-enabled" class="remember-label">Record session locally</label>
+              </div>
+
+              <div id="recording-options" style="display:none">
+                <label for="recording-dir">Recording directory</label>
+                <div class="bpm-row">
+                  <input type="text" id="recording-dir" placeholder="~/Music/WAIL Sessions">
+                  <button type="button" id="browse-recording-dir" class="small-btn" style="width:auto;margin-top:0">Browse</button>
+                </div>
+
+                <div class="remember-row" style="margin-top:8px">
+                  <input type="checkbox" id="recording-stems">
+                  <label for="recording-stems" class="remember-label">Record per-peer stems (vs single mix)</label>
+                </div>
+
+                <label for="recording-retention">Keep recordings for (days, 0 = forever)</label>
+                <input type="number" id="recording-retention" value="30" min="0" max="365">
+              </div>
+            </div>
           </div>
         </details>
 
@@ -125,6 +148,14 @@
       <div class="test-tone-row">
         <span id="session-test-tone">OFF</span>
         <button type="button" id="toggle-test-tone-btn" class="small-btn">Enable</button>
+      </div>
+    </div>
+
+    <div class="stat-group" id="recording-stat" style="display:none">
+      <label>Recording</label>
+      <div class="recording-row">
+        <span id="session-recording" class="rec-badge">REC</span>
+        <span id="recording-size">0 MB</span>
       </div>
     </div>
 

--- a/crates/wail-tauri/ui/main.js
+++ b/crates/wail-tauri/ui/main.js
@@ -21,7 +21,7 @@ let roomRefreshTimer = null;
 
 // --- Remember settings ---
 const STORAGE_KEY = 'wail-settings';
-const rememberFields = ['room', 'password', 'display-name', 'server', 'bars', 'quantum', 'ipc-port', 'test-tone', 'turn-url', 'turn-username', 'turn-credential'];
+const rememberFields = ['room', 'password', 'display-name', 'server', 'bars', 'quantum', 'ipc-port', 'test-tone', 'turn-url', 'turn-username', 'turn-credential', 'recording-enabled', 'recording-dir', 'recording-stems', 'recording-retention'];
 
 function loadSettings() {
   try {
@@ -56,6 +56,11 @@ function saveSettings() {
 }
 
 loadSettings();
+
+// Restore recording options visibility after settings load
+if (document.getElementById('recording-enabled').checked) {
+  document.getElementById('recording-options').style.display = '';
+}
 
 document.getElementById('remember').addEventListener('change', () => {
   if (!document.getElementById('remember').checked) {
@@ -147,6 +152,10 @@ async function joinPublicRoom(room) {
     turnUrl: document.getElementById('turn-url').value || null,
     turnUsername: document.getElementById('turn-username').value || null,
     turnCredential: document.getElementById('turn-credential').value || null,
+    recordingEnabled: document.getElementById('recording-enabled').checked,
+    recordingDirectory: document.getElementById('recording-dir').value || null,
+    recordingStems: document.getElementById('recording-stems').checked,
+    recordingRetentionDays: parseInt(document.getElementById('recording-retention').value) || 30,
   };
   if (!params.displayName.trim()) {
     showError(joinError, 'Display name is required');
@@ -164,6 +173,26 @@ async function joinPublicRoom(room) {
 }
 
 document.getElementById('refresh-rooms-btn').addEventListener('click', fetchPublicRooms);
+
+// --- Recording options toggle ---
+document.getElementById('recording-enabled').addEventListener('change', (e) => {
+  document.getElementById('recording-options').style.display = e.target.checked ? '' : 'none';
+});
+
+document.getElementById('browse-recording-dir').addEventListener('click', async () => {
+  try {
+    const dir = await invoke('get_default_recording_dir');
+    document.getElementById('recording-dir').value = dir;
+  } catch (err) {
+    console.error('Failed to get default recording dir:', err);
+  }
+});
+
+// Populate default recording dir on load
+invoke('get_default_recording_dir').then(dir => {
+  const el = document.getElementById('recording-dir');
+  if (!el.value) el.value = dir;
+}).catch(() => {});
 
 function showJoin() {
   joinScreen.style.display = '';
@@ -188,6 +217,8 @@ function showSession(room) {
   document.getElementById('session-interval').textContent = '-';
   testToneEnabled = document.getElementById('test-tone').checked;
   updateTestToneUI();
+  document.getElementById('recording-stat').style.display =
+    document.getElementById('recording-enabled').checked ? '' : 'none';
 }
 
 function updateTestToneUI() {
@@ -226,6 +257,10 @@ joinForm.addEventListener('submit', async (e) => {
     turnUrl: document.getElementById('turn-url').value || null,
     turnUsername: document.getElementById('turn-username').value || null,
     turnCredential: document.getElementById('turn-credential').value || null,
+    recordingEnabled: document.getElementById('recording-enabled').checked,
+    recordingDirectory: document.getElementById('recording-dir').value || null,
+    recordingStems: document.getElementById('recording-stems').checked,
+    recordingRetentionDays: parseInt(document.getElementById('recording-retention').value) || 30,
   };
 
   try {
@@ -302,6 +337,13 @@ async function setupListeners() {
     // Sync test tone state
     testToneEnabled = s.test_tone_enabled;
     updateTestToneUI();
+
+    // Update recording status
+    if (s.recording) {
+      document.getElementById('recording-stat').style.display = '';
+      const mb = (s.recording_size_bytes / (1024 * 1024)).toFixed(1);
+      document.getElementById('recording-size').textContent = `${mb} MB`;
+    }
 
     // Update peer list
     const peerList = document.getElementById('peer-list');

--- a/crates/wail-tauri/ui/style.css
+++ b/crates/wail-tauri/ui/style.css
@@ -412,3 +412,32 @@ summary {
   color: var(--fg-dim);
   margin-right: 6px;
 }
+
+/* Recording */
+.recording-section {
+  margin-top: 12px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.recording-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.rec-badge {
+  display: inline-block;
+  background: var(--error);
+  color: #fff;
+  font-size: 11px;
+  font-weight: bold;
+  padding: 2px 6px;
+  border-radius: 3px;
+  animation: rec-blink 1.5s ease-in-out infinite;
+}
+
+@keyframes rec-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}


### PR DESCRIPTION
## Summary

Add local recording capability to the WAIL app. Users can record jam sessions as WAV files to disk with:
- Configurable recording directory
- Choice between per-peer stems (separate WAV per participant) or single mixed WAV
- Retention policy (auto-delete old sessions after N days, default 30)

## Implementation

SessionRecorder runs on a tokio blocking task, tapping audio at two points in the session loop: own captured audio before broadcast, and remote peer audio before IPC forward. Opus decoding to PCM happens on the blocking task to avoid blocking the real-time select loop. Writes session.json metadata including peer list and file manifest on finalize.

UI adds recording controls in the Advanced section of the join form, and displays a blinking REC indicator with live file size in the session view. Settings are persisted to localStorage.

## Test plan

- [x] All 108 existing tests pass (wail-core, wail-audio, wail-net)
- [x] Builds cleanly with new dependencies (hound, chrono)
- [ ] Manual test: start session with recording enabled + test tone, verify WAV files created in ~/Music/WAIL Sessions
- [ ] Manual test: verify recorded files are playable
- [ ] Manual test: test stems mode with multiple peers, verify separate WAV per peer
- [ ] Manual test: test mixed mode, verify single WAV with summed audio
- [ ] Manual test: verify retention policy deletes old sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)