### PR TITLE
docs: update guides and create DEVELOPMENT.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ WAIL synchronizes Ableton Link sessions across the internet using WebRTC DataCha
 ## Project Structure
 
 ```
-Cargo workspace with 6 crates:
+Cargo workspace with 7 crates:
 
 crates/
 ├── wail-core/           Core sync library (no networking)
@@ -19,11 +19,21 @@ crates/
 │   ├── codec.rs          Opus encode/decode (audiopus)
 │   ├── ring.rs           NINJAM-style interval ring buffer (record + playback)
 │   ├── interval.rs       AudioInterval type, IntervalRecorder, IntervalPlayer
-│   └── wire.rs           Binary wire format for audio over DataChannels
+│   ├── wire.rs           Binary wire format for audio over DataChannels
+│   ├── bridge.rs         AudioBridge: wraps ring + Opus codec for send/recv
+│   ├── ipc.rs            IPC framing protocol (length-prefixed messages)
+│   └── pipeline.rs       Encode/decode pipeline (interval → wire → DataChannel)
 ├── wail-net/            Networking layer
-│   ├── lib.rs            PeerMesh: manages all WebRTC connections
+│   ├── lib.rs            PeerMesh + ICE server config (Metered TURN)
 │   ├── signaling.rs      HTTP polling signaling client
 │   └── peer.rs           WebRTC peer with "sync" + "audio" DataChannels
+├── wail-tauri/          Tauri desktop app (session orchestration)
+│   ├── main.rs           App entry point
+│   ├── lib.rs            Tauri setup and plugin registration
+│   ├── commands.rs       Tauri IPC commands (join/leave room, etc.)
+│   ├── events.rs         Tauri event types for frontend
+│   ├── session.rs        Session state machine (Link + WebRTC + audio)
+│   └── recorder.rs       Local session recording
 ├── wail-plugin-send/    CLAP/VST3 send plugin (captures DAW audio)
 │   ├── lib.rs            Plugin entry point, send-only IPC thread
 │   └── params.rs         Plugin parameters (empty — defaults hardcoded)
@@ -31,8 +41,10 @@ crates/
 │   ├── lib.rs            Plugin entry point, recv-only IPC thread
 │   └── params.rs         Plugin parameters (empty — defaults hardcoded)
 
+xtask/                   Build tasks (build-plugin, install-plugin, build-tauri, etc.)
+
 val-town/
-└── signaling.ts      HTTP signaling server (deployed to Val Town)
+└── main.ts           HTTP signaling server (deployed to Val Town)
 
 vendor/
 └── link/             Ableton Link 4.0.0 beta SDK (git submodule)
@@ -63,14 +75,13 @@ cargo tauri dev
 - `audiopus` - Opus audio codec (libopus bindings)
 - `nih_plug` (git) - CLAP/VST3 plugin framework
 - `tokio` - Async runtime
-- `clap` - CLI parsing
 
 ## Architecture
 
 ### Sync Flow
 Each WAIL peer:
 1. Joins local Ableton Link session (LAN multicast)
-2. Connects to HTTP signaling server to join a password-protected "room"
+2. Connects to HTTP signaling server to join a room (public or password-protected)
 3. Establishes WebRTC DataChannels with remote peers (P2P)
 4. Polls Link at 50Hz, broadcasts tempo/phase changes
 5. Applies remote tempo changes to local Link session
@@ -81,7 +92,7 @@ NINJAM-style double-buffer pattern with two separate plugins:
 1. **WAIL Send** plugin captures DAW audio into record slot for current interval
 2. At interval boundary: record slot → Opus encode → IPC → wail-app → WebRTC DataChannel
 3. **WAIL Recv** plugin receives remote intervals via IPC, decoded and mixed into playback slot
-4. Playback slot feeds audio output to DAW (main bus + 7 per-peer aux outputs)
+4. Playback slot feeds audio output to DAW (main bus + up to 15 per-peer aux outputs)
 5. Latency = exactly 1 interval (by design, like NINJAM)
 
 Two WebRTC DataChannels per peer:
@@ -106,7 +117,7 @@ Binary header (48 bytes) + Opus data:
 ## Testing
 
 ```sh
-cargo test                    # run all tests (~104 tests)
+cargo test                    # run all tests (~114 tests)
 cargo test -p wail-core       # core library tests only
 cargo test -p wail-audio      # audio tests (codec, ring buffer, wire format)
 ```
@@ -148,28 +159,28 @@ knope document-change
 
 This creates a markdown file in `.changeset/` describing what changed and the bump type (major/minor/patch). Commit the changeset file with your PR. Conventional commit messages (`feat:`, `fix:`, `feat!:`) also work and are picked up automatically.
 
-### Cutting a release
+### Release pipeline (automated via GitHub Actions)
 
-```sh
-knope release              # bump version, update CHANGELOG.md, commit, push, create GitHub release
-knope release --dry-run    # preview without making changes
-```
+Releases are fully automated — no manual `knope` commands needed:
 
-`PrepareRelease` consumes all `.changeset/` files + conventional commits since the last tag, determines the version bump, updates versioned files and `CHANGELOG.md`, then `Release` creates the GitHub release and git tag.
+1. **Push to `main`** → `auto-release.yml` runs `knope prepare-release`, which consumes `.changeset/` files + conventional commits, bumps versions, updates `CHANGELOG.md`, and opens/updates a PR from the `release` branch → `main`.
+2. **Merge the release PR** → `release-on-merge.yml` runs `knope release` (creates GitHub release + git tag) and dispatches artifact builds.
+3. **`release.yml`** builds platform artifacts (macOS, Windows, Linux — plugins + Tauri app installers) and uploads them to the GitHub release.
 
 ### Rules for agents
 
 - **Always create a changeset** for user-facing work. Run `knope document-change` or manually create a `.changeset/<short-name>.md` file.
 - **Never manually edit version numbers** in `Cargo.toml` or `tauri.conf.json` — knope handles this.
-- **Never manually create git tags** for releases — `knope release` handles tagging.
+- **Never manually create git tags** for releases — GitHub Actions handles tagging.
+- **Never run `knope release` or `knope prepare-release` locally** — GitHub Actions runs both automatically.
 - Use conventional commit prefixes: `feat:`, `fix:`, `chore:`, `feat!:` (breaking).
 
 ## Common Tasks
 
 - **Add a new sync message**: Add variant to `SyncMessage` in `crates/wail-core/src/protocol.rs`, handle in `crates/wail-tauri/src/session.rs` select loop
 - **Change Link polling rate**: `POLL_INTERVAL` in `crates/wail-core/src/link.rs`
-- **Add STUN/TURN servers**: `RTCIceServer` list in `crates/wail-net/src/peer.rs`
-- **Change Opus bitrate**: Default in send plugin params (`crates/wail-plugin-send/src/params.rs`)
+- **Add STUN/TURN servers**: ICE server config in `crates/wail-net/src/lib.rs` (includes dynamic Metered TURN credentials)
+- **Change Opus bitrate**: `AudioBridge::new()` bitrate_kbps param in `crates/wail-audio/src/bridge.rs`
 - **Modify wire format**: `crates/wail-audio/src/wire.rs` (bump version byte)
 - **Adjust ring buffer crossfade**: `IntervalPlayer::new()` crossfade_ms param
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,96 @@
+# Development
+
+## How It Works
+
+Each WAIL peer joins a local Ableton Link session and connects to a lightweight signaling server to discover other peers. Once peers find each other, they establish direct WebRTC connections with two DataChannels each:
+
+- **sync** — JSON text messages for tempo, beat, phase, and clock synchronization
+- **audio** — binary messages carrying Opus-encoded audio intervals
+
+Audio uses a NINJAM-style double-buffer pattern: the Send plugin records the current interval from the DAW, and at the interval boundary the completed recording is Opus-encoded and sent to all peers. Remote intervals are decoded, mixed, and played back one interval behind — latency equals exactly one interval by design.
+
+```
+DAW A → [WAIL Send] → record → Opus encode → DataChannel → remote peer
+         [WAIL Recv] ← play  ← Opus decode  ← DataChannel ← remote peer
+```
+
+## Project Structure
+
+```
+Cargo workspace with 7 crates:
+
+crates/
+├── wail-core/           Core sync library (no networking)
+├── wail-audio/          Audio encoding, intervalic ring buffer, IPC framing
+├── wail-net/            WebRTC peer mesh and signaling client
+├── wail-tauri/          Tauri desktop app (session orchestration)
+├── wail-plugin-send/    CLAP/VST3 send plugin (captures DAW audio)
+├── wail-plugin-recv/    CLAP/VST3 receive plugin (plays remote audio)
+
+xtask/                   Build tasks (build-plugin, install-plugin, build-tauri, etc.)
+
+val-town/
+└── main.ts              HTTP signaling server (deployed to Val Town)
+
+vendor/
+└── link/                Ableton Link 4.0.0 beta SDK (git submodule)
+```
+
+## Build from Source
+
+Requires: **Rust 1.75+**, CMake 3.14+, a C++ compiler, and libopus-dev.
+
+**Linux build dependencies (Debian/Ubuntu):**
+
+```sh
+sudo apt-get install libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
+  librsvg2-dev libxdo-dev libssl-dev patchelf libopus-dev cmake g++
+```
+
+```sh
+git submodule update --init --recursive   # fetch Ableton Link SDK
+cargo build                               # build workspace
+```
+
+### Plugins
+
+Install the bundler once, then use `cargo xtask`:
+
+```sh
+cargo install --git https://github.com/robbert-vdh/nih-plug.git cargo-nih-plug
+
+cargo xtask build-plugin        # build CLAP + VST3 bundles → target/bundled/
+cargo xtask install-plugin      # build and install to system plugin directories
+cargo xtask install-plugin --no-build  # install already-built bundles
+```
+
+Plugin directories:
+- **macOS** — `~/Library/Audio/Plug-Ins/{CLAP,VST3}/`
+- **Linux** — `~/.clap/` and `~/.vst3/`
+- **Windows** — `%COMMONPROGRAMFILES%\{CLAP,VST3}\`
+
+### Tauri App
+
+```sh
+cargo tauri dev          # run in development mode
+cargo xtask build-tauri  # production build (builds plugins first)
+```
+
+## Testing
+
+```sh
+cargo test                    # all tests (~114 unit + integration)
+cargo test -p wail-core       # core library tests
+cargo test -p wail-audio      # audio codec, ring buffer, wire format
+cargo test -p wail-net        # networking + WebRTC integration tests
+```
+
+Some integration tests are marked `#[ignore]` because they require external resources:
+
+```sh
+# Requires internet access — hits the live Metered API and asserts valid TURN credentials are returned
+cargo test -p wail-net -- --ignored fetch_metered_ice_servers_live
+
+# Requires coturn installed (brew install coturn) — full WebRTC path through a local TURN relay
+cargo test -p wail-net -- --ignored two_peers_exchange_audio_via_turn
+```

--- a/README.md
+++ b/README.md
@@ -1,24 +1,39 @@
 # WAIL — WebRTC Audio Interchange for Link
 
-WAIL synchronizes [Ableton Link](https://www.ableton.com/link/) sessions across the internet using WebRTC DataChannels. Musicians on different networks can sync tempo, phase, and interval boundaries as if they were on the same LAN. Intervalic audio (NINJAM-style) is captured, Opus-encoded, and transmitted over WebRTC DataChannels. A CLAP/VST3 plugin provides DAW integration.
+WAIL synchronizes [Ableton Link](https://www.ableton.com/link/) sessions across the internet using WebRTC. Musicians on different networks can sync tempo, phase, and interval boundaries as if they were on the same LAN, with intervalic audio (NINJAM-style) captured, Opus-encoded, and transmitted peer-to-peer.
 
 ## Install
 
 Download the latest release from the [Releases page](https://github.com/quasor/WAIL/releases).
 
-**macOS** — Open the DMG and drag WAIL to Applications. For the audio plugins, run the included `.pkg` installer.
+**macOS** — Open the DMG and drag WAIL to Applications. Run the included `.pkg` installer to install the audio plugins.
 
-**Windows** — Run the NSIS installer. Plugins are bundled as CLAP and VST3 files — copy them to your DAW's plugin directory.
+**Windows** — Run the `.exe` installer. Copy the bundled `.clap` and `.vst3` plugin files to your DAW's plugin directory.
 
-**Linux** — Download the AppImage and make it executable (`chmod +x WAIL_*.AppImage`), or install the `.deb` package with `sudo dpkg -i wail_*.deb`. Copy the plugin files to `~/.clap/` and `~/.vst3/`.
+**Linux** — Install the `.deb` package (`sudo dpkg -i wail_*.deb`) or download the AppImage and make it executable (`chmod +x WAIL_*.AppImage`). Copy the plugin files to `~/.clap/` and `~/.vst3/`.
 
-> **Important:** Enable Ableton Link in your DAW before using WAIL. In Ableton Live, go to Preferences > Link, Tempo, MIDI and turn on "Show Link Toggle" then enable Link. Other DAWs have similar settings — check your DAW's documentation for Link support.
+## Getting Started
+
+1. **Launch the WAIL app.**
+
+2. **Enable Ableton Link in your DAW.** WAIL relies on Link for tempo and phase sync.
+   - *Ableton Live:* Preferences > Link, Tempo, MIDI > turn on "Show Link Toggle", then enable Link in the transport bar.
+   - *Bitwig Studio:* Settings > Synchronization > enable Link.
+   - Other DAWs — check your DAW's documentation for Link support.
+
+3. **Load WAIL Send** on the track or bus you want to share. This plugin captures audio and sends it to your peers at each interval boundary.
+
+4. **Load WAIL Recv** on a separate track to hear remote peers. It decodes incoming audio and provides a main mix output plus per-peer auxiliary outputs.
+
+5. **Join a room** in the WAIL app. Enter a room name and your display name. Set a password to create a private room, or leave it blank for a public room. You can also browse existing public rooms from the "Public Rooms" tab.
+
+6. **Play.** Audio is recorded for the duration of each interval (default: 4 bars), then transmitted to all connected peers. Playback runs one interval behind — this latency-by-design is how NINJAM-style sync works.
 
 ## Components
 
 WAIL has three components that work together:
 
-- **WAIL app** — The standalone desktop app that handles networking. It connects to the signaling server, establishes WebRTC peer connections, and bridges audio and sync data between the DAW plugins and remote peers. Launch it before opening your DAW session.
+- **WAIL app** — The desktop app that handles networking. It connects to the signaling server, establishes WebRTC peer connections, and bridges audio and sync data between the DAW plugins and remote peers.
 
 - **WAIL Send** (CLAP/VST3 plugin) — Place this on a track or bus in your DAW to capture audio. At each interval boundary, the recorded audio is Opus-encoded and sent to all connected peers via the WAIL app.
 
@@ -26,91 +41,15 @@ WAIL has three components that work together:
 
 ## Troubleshooting
 
-**No sync / peers not connecting** — Make sure Ableton Link is enabled in your DAW. WAIL relies on Link for tempo and phase sync. In Ableton Live: Preferences > Link, Tempo, MIDI > enable Link. In Bitwig: Settings > Synchronization > enable Link.
+**No sync / peers not connecting** — Make sure Ableton Link is enabled in your DAW. WAIL relies on Link for tempo and phase sync.
 
 **No audio from remote peers** — Verify that both WAIL Send and WAIL Recv plugins are loaded and the WAIL app is running and connected to the same room.
 
-**Changing tempo mid-jam** — Not recommended. WAIL uses NINJAM-style intervals, so audio is recorded and played back in full interval chunks. If you change the tempo, the current interval must finish before the new tempo takes effect. All peers will hear a glitch as the old interval (recorded at the previous tempo) plays back while the new interval begins recording at the new tempo. If you do need to change tempo, agree on it beforehand and have one person change it — Link will propagate it to all peers within a few seconds.
+**Changing tempo mid-jam** — Not recommended. WAIL uses NINJAM-style intervals, so audio is recorded and played back in full interval chunks. If you change the tempo, the current interval must finish before the new tempo takes effect. If you do need to change tempo, agree on it beforehand and have one person change it — Link will propagate it to all peers within a few seconds.
 
-## How it works
+## Development
 
-Each WAIL peer joins a local Ableton Link session and connects to a lightweight HTTP signaling server to discover other peers. Rooms are password-protected — the first peer to join sets the password; subsequent peers must provide the matching password. Once peers discover each other, they establish direct WebRTC connections with two DataChannels each:
-
-- **sync** — JSON text messages for tempo, beat, phase, and clock synchronization
-- **audio** — binary wire-format messages carrying Opus-encoded audio intervals
-
-Audio uses a NINJAM-style double-buffer pattern: the plugin records the current interval from the DAW, and at the interval boundary the completed recording is Opus-encoded and sent to all peers. Remote intervals are decoded, mixed, and played back one interval behind — latency equals exactly one interval by design.
-
-```
-DAW A → [CLAP Plugin] → record → Opus encode → DataChannel → remote peer
-                       ← play  ← Opus decode ← DataChannel ← remote peer
-```
-
-## Project structure
-
-```
-crates/
-├── wail-core/        Core sync library (no networking)
-├── wail-audio/       Audio encoding and intervalic ring buffer
-├── wail-net/         WebRTC peer mesh and signaling client
-├── wail-plugin/      CLAP/VST3 plugin (nih-plug)
-├── wail-app/         CLI binary
-
-val-town/
-└── signaling.ts      HTTP signaling server (deployed to Val Town)
-```
-
-## Build from source
-
-Requires: **Rust 1.75+**, CMake 3.14+, a C++ compiler, and libopus-dev.
-
-**Linux build dependencies (Debian/Ubuntu):**
-```sh
-sudo apt-get install libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
-  librsvg2-dev libxdo-dev libssl-dev patchelf libopus-dev cmake g++
-```
-
-```sh
-git submodule update --init --recursive   # fetch Ableton Link SDK
-cargo build                               # build workspace
-```
-
-### Plugin
-
-Install the bundler once, then use `cargo xtask`:
-
-```sh
-cargo install --git https://github.com/robbert-vdh/nih-plug.git cargo-nih-plug
-
-cargo xtask build-plugin        # build CLAP + VST3 bundles → target/bundled/
-cargo xtask install-plugin      # build and install to system plugin directories
-cargo xtask install-plugin --no-build  # install already-built bundles
-```
-
-Plugin directories:
-- **macOS** — `~/Library/Audio/Plug-Ins/{CLAP,VST3}/`
-- **Linux** — `~/.clap/` and `~/.vst3/`
-- **Windows** — `%COMMONPROGRAMFILES%\{CLAP,VST3}\`
-
-### Running
-
-```sh
-# Two peers in the same room — different IPC ports so they don't collide
-cargo xtask run-peer --room jam --password mysecret                   # peer A
-cargo xtask run-peer --room jam --password mysecret --ipc-port 9192   # peer B
-```
-
-All `run-peer` flags map directly to `wail-app join` options (see `--help`).
-Both `--room` and `--password` are required. The first peer to join a room sets the password; others must match it.
-
-## Testing
-
-```sh
-cargo test                    # all tests (~104 unit + integration)
-cargo test -p wail-core       # core library tests
-cargo test -p wail-audio      # audio codec, ring buffer, wire format
-cargo test -p wail-net        # networking + WebRTC integration tests
-```
+See [DEVELOPMENT.md](DEVELOPMENT.md) for build instructions, project structure, and testing.
 
 ## License
 


### PR DESCRIPTION
## Summary

Comprehensive documentation overhaul addressing three areas:

1. **CLAUDE.md (developer guide)** — Fixed 15+ stale references: corrected crate count (6→7), added missing crates (wail-tauri, xtask) and files (bridge.rs, ipc.rs, pipeline.rs), updated val-town filename (signaling.ts→main.ts), removed non-existent clap dependency, updated audio output count (7→15 peers), fixed test count (104→114), documented the actual automated GitHub release pipeline, and added rules prohibiting manual `knope release` commands.

2. **README.md (end-user guide)** — Completely rewritten for clarity: new numbered "Getting Started" section (launch app → enable Link → load plugins → join room → play), removed 60 lines of developer content, simplified install instructions per platform, replaced jargon with user-facing language.

3. **DEVELOPMENT.md (new file)** — Created as a home for technical content relocated from README: "How It Works" architecture explanation, build-from-source instructions, plugin development guide, test suite documentation.

These changes ensure end users get practical step-by-step instructions while developers get detailed technical references, with no stale information in either place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)