### PR TITLE
feat: show bytes sent/received for Opus audio in session stats UI

### DIFF
--- a/.changeset/opus-bytes-stats.md
+++ b/.changeset/opus-bytes-stats.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Show bytes sent/received for compressed Opus audio payload in session stats UI. Displays formatted byte counts (B/KB/MB) below the audio interval counts, helping users monitor network bandwidth usage.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6359,7 +6359,7 @@ dependencies = [
 
 [[package]]
 name = "wail-audio"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "audiopus",
@@ -6369,7 +6369,7 @@ dependencies = [
 
 [[package]]
 name = "wail-core"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "rusty_link",
@@ -6381,7 +6381,7 @@ dependencies = [
 
 [[package]]
 name = "wail-net"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -6402,7 +6402,7 @@ dependencies = [
 
 [[package]]
 name = "wail-plugin-recv"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "assert_no_alloc",
@@ -6414,7 +6414,7 @@ dependencies = [
 
 [[package]]
 name = "wail-plugin-send"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "assert_no_alloc",
@@ -6426,7 +6426,7 @@ dependencies = [
 
 [[package]]
 name = "wail-plugin-test"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "clack-host",
  "tokio 1.49.0",
@@ -6437,7 +6437,7 @@ dependencies = [
 
 [[package]]
 name = "wail-tauri"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/wail-tauri/src/events.rs
+++ b/crates/wail-tauri/src/events.rs
@@ -50,6 +50,8 @@ pub struct StatusUpdate {
     pub interval_bars: u32,
     pub audio_sent: u64,
     pub audio_recv: u64,
+    pub audio_bytes_sent: u64,
+    pub audio_bytes_recv: u64,
     pub audio_dc_open: bool,
     pub plugin_connected: bool,
     pub test_tone_enabled: bool,

--- a/crates/wail-tauri/src/session.rs
+++ b/crates/wail-tauri/src/session.rs
@@ -172,6 +172,8 @@ async fn session_loop(
     // Audio interval stats
     let mut audio_intervals_sent: u64 = 0;
     let mut audio_intervals_received: u64 = 0;
+    let mut audio_bytes_sent: u64 = 0;
+    let mut audio_bytes_recv: u64 = 0;
 
     // Test tone state
     let mut test_tone_enabled = test_tone;
@@ -342,6 +344,7 @@ async fn session_loop(
                 if let Some((_peer_id, wire_data)) = IpcMessage::decode_audio(&frame) {
                     mesh.broadcast_audio(&wire_data).await;
                     audio_intervals_sent += 1;
+                    audio_bytes_sent += wire_data.len() as u64;
                     let peers = mesh.connected_peers();
                     ui_info!(&app, "[AUDIO SEND] wire={} bytes, peers=[{}], total_sent={}", wire_data.len(), peers.join(", "), audio_intervals_sent);
 
@@ -501,6 +504,7 @@ async fn session_loop(
             // --- Incoming audio data from peers → forward to plugin ---
             Some((from, data)) = audio_rx.recv() => {
                 audio_intervals_received += 1;
+                audio_bytes_recv += data.len() as u64;
                 let peer_name = peer_names.get(&from).and_then(|n| n.as_deref()).unwrap_or(&from);
 
                 match AudioWire::decode(&data) {
@@ -590,7 +594,7 @@ async fn session_loop(
                             mesh.broadcast(&SyncMessage::IntervalBoundary { index: idx }).await;
                             if test_tone_enabled {
                                 if let Some(ref mut encoder) = test_tone_encoder {
-                                    send_test_tone(&app, &mesh, encoder, &mut rng, idx, last_broadcast_bpm, bars, quantum, &mut audio_intervals_sent).await;
+                                    send_test_tone(&app, &mesh, encoder, &mut rng, idx, last_broadcast_bpm, bars, quantum, &mut audio_intervals_sent, &mut audio_bytes_sent).await;
                                 }
                             }
                         }
@@ -611,7 +615,7 @@ async fn session_loop(
                             mesh.broadcast(&SyncMessage::IntervalBoundary { index: idx }).await;
                             if test_tone_enabled {
                                 if let Some(ref mut encoder) = test_tone_encoder {
-                                    send_test_tone(&app, &mesh, encoder, &mut rng, idx, last_broadcast_bpm, bars, quantum, &mut audio_intervals_sent).await;
+                                    send_test_tone(&app, &mesh, encoder, &mut rng, idx, last_broadcast_bpm, bars, quantum, &mut audio_intervals_sent, &mut audio_bytes_sent).await;
                                 }
                             }
                         }
@@ -653,6 +657,8 @@ async fn session_loop(
                         interval_bars: interval.bars(),
                         audio_sent: audio_intervals_sent,
                         audio_recv: audio_intervals_received,
+                        audio_bytes_sent,
+                        audio_bytes_recv,
                         audio_dc_open: dc_open,
                         plugin_connected: !ipc_recv_writers.is_empty(),
                         test_tone_enabled,
@@ -693,6 +699,7 @@ async fn send_test_tone(
     bars: u32,
     quantum: f64,
     audio_intervals_sent: &mut u64,
+    audio_bytes_sent: &mut u64,
 ) {
     let freq: f32 = rng.gen_range(220.0..=880.0);
     let sample_rate: u32 = 48000;
@@ -738,6 +745,7 @@ async fn send_test_tone(
 
             mesh.broadcast_audio(&wire_data).await;
             *audio_intervals_sent += 1;
+            *audio_bytes_sent += wire_data.len() as u64;
 
             let ready_msg = SyncMessage::AudioIntervalReady {
                 interval_index: idx,

--- a/crates/wail-tauri/ui/index.html
+++ b/crates/wail-tauri/ui/index.html
@@ -128,6 +128,7 @@
     <div class="stat-group">
       <label>Audio</label>
       <span id="session-audio">0 sent / 0 recv</span>
+      <span id="session-audio-bytes" class="audio-bytes">0 B sent / 0 B recv</span>
     </div>
 
     <div class="stat-group">

--- a/crates/wail-tauri/ui/main.js
+++ b/crates/wail-tauri/ui/main.js
@@ -55,6 +55,12 @@ function saveSettings() {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
 }
 
+function formatBytes(n) {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 loadSettings();
 
 // Restore recording options visibility after settings load
@@ -213,6 +219,7 @@ function showSession(room) {
   document.getElementById('session-room').textContent = room;
   document.getElementById('peer-list').innerHTML = '<span class="empty">No peers connected</span>';
   document.getElementById('session-audio').textContent = '0 sent / 0 recv';
+  document.getElementById('session-audio-bytes').textContent = '0 B sent / 0 B recv';
   document.getElementById('session-plugin').textContent = 'disconnected';
   document.getElementById('session-plugin').className = '';
   document.getElementById('session-link-peers').textContent = '0';
@@ -326,6 +333,8 @@ async function setupListeners() {
     document.getElementById('session-link-peers').textContent = s.link_peers;
     document.getElementById('session-audio').textContent =
       `${s.audio_sent} sent / ${s.audio_recv} recv`;
+    document.getElementById('session-audio-bytes').textContent =
+      `${formatBytes(s.audio_bytes_sent)} sent / ${formatBytes(s.audio_bytes_recv)} recv`;
     document.getElementById('session-interval').textContent = `${s.interval_bars} bars`;
     document.getElementById('session-plugin').textContent =
       s.plugin_connected ? 'connected' : 'disconnected';

--- a/crates/wail-tauri/ui/style.css
+++ b/crates/wail-tauri/ui/style.css
@@ -302,6 +302,11 @@ summary {
   font-size: 11px;
 }
 
+.audio-bytes {
+  color: var(--fg-dim);
+  font-size: 11px;
+}
+
 /* Test tone toggle */
 .test-tone-row {
   display: flex;


### PR DESCRIPTION
## Summary
Display formatted byte counts (B/KB/MB) for compressed Opus audio payload below the existing interval counts in the session stats UI. Tracks total bytes transmitted over WebRTC DataChannels, helping users monitor network bandwidth usage.

## Changes
- Backend: Added `audio_bytes_sent` and `audio_bytes_recv` to `StatusUpdate` struct, accumulated from wire data during send and receive operations
- Frontend: Added `formatBytes()` helper to display bytes in human-readable format (B/KB/MB) and updated UI to show bytes stat below interval counts
- Styling: Secondary stat display with de-emphasized styling matching existing patterns

## Test plan
- Run `cargo build -p wail-tauri` to verify compilation
- Run `cargo test --lib` to confirm all tests pass
- Visual verification: Launch app with test tone enabled and observe bytes counts incrementing alongside interval counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)