### PR TITLE
feat: add Homebrew from-source installation support

### DIFF
--- a/.changeset/homebrew-formula.md
+++ b/.changeset/homebrew-formula.md
@@ -1,0 +1,5 @@
+---
+"wail-tauri": minor
+---
+
+Add Homebrew from-source installation support. Users on macOS can now install WAIL and its DAW plugins directly from source via `brew tap quasor/wail && brew install quasor/wail/wail`. A new `cargo xtask bundle-plugin` command assembles CLAP/VST3 plugin bundles without requiring `cargo-nih-plug` to be installed globally. A `wail-install-plugins` helper script copies the installed plugin bundles to `~/Library/Audio/Plug-Ins/`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,44 @@ on:
         type: string
 
 jobs:
+  # Build a "fat" source tarball that includes the vendor/link git submodule.
+  # GitHub's auto-generated archives omit submodule contents, so we produce our
+  # own tarball and upload it as a release artifact.  The Homebrew formula uses
+  # this tarball as its `url` so that the Ableton Link SDK is available during
+  # `brew install --build-from-source`.
+  build-homebrew-tarball:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+          submodules: recursive
+
+      - name: Create fat source tarball
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          VERSION="${TAG#v}"
+          STAGING="wail-${VERSION}"
+          # Export the repo tree (excludes .git) into a named staging directory
+          mkdir -p "/tmp/${STAGING}"
+          git archive --format=tar HEAD | tar -x -C "/tmp/${STAGING}"
+          # Overlay the submodule contents (git archive omits them)
+          cp -r vendor/link "/tmp/${STAGING}/vendor/link"
+          # Package and compute checksum
+          tar -czf "wail-${VERSION}-src.tar.gz" -C /tmp "${STAGING}"
+          sha256sum "wail-${VERSION}-src.tar.gz" | awk '{print $1}' > "wail-${VERSION}-src.tar.gz.sha256"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wail-homebrew-src
+          path: |
+            wail-*-src.tar.gz
+            wail-*-src.tar.gz.sha256
+
   build-macos:
     runs-on: macos-latest
     steps:
@@ -232,7 +270,7 @@ jobs:
           path: dist/
 
   create-release:
-    needs: [build-macos, build-windows, build-linux]
+    needs: [build-macos, build-windows, build-linux, build-homebrew-tarball]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -243,10 +281,12 @@ jobs:
         id: tag
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            TAG="${{ inputs.tag }}"
           else
-            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+            TAG="${GITHUB_REF#refs/tags/}"
           fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Zip platform artifacts
         run: |
@@ -263,6 +303,7 @@ jobs:
           echo "msi=$(ls wail-release-windows/*.msi 2>/dev/null | head -1 || true)" >> "$GITHUB_OUTPUT"
           echo "appimage=$(ls wail-release-linux/*.AppImage 2>/dev/null | head -1 || true)" >> "$GITHUB_OUTPUT"
           echo "deb=$(ls wail-release-linux/*.deb 2>/dev/null | head -1 || true)" >> "$GITHUB_OUTPUT"
+          echo "src_tarball=$(ls wail-homebrew-src/wail-*-src.tar.gz 2>/dev/null | head -1 || true)" >> "$GITHUB_OUTPUT"
 
       - uses: softprops/action-gh-release@v2
         with:
@@ -277,3 +318,30 @@ jobs:
             ${{ steps.files.outputs.msi }}
             ${{ steps.files.outputs.appimage }}
             ${{ steps.files.outputs.deb }}
+            ${{ steps.files.outputs.src_tarball }}
+
+      # Update the Homebrew tap formula with the new version and SHA256.
+      # Requires a HOMEBREW_TAP_TOKEN secret with push access to quasor/homebrew-wail.
+      # If the secret is not configured, this step is skipped gracefully.
+      - name: Update Homebrew tap
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          [ -z "${GH_TOKEN}" ] && echo "HOMEBREW_TAP_TOKEN not set, skipping tap update." && exit 0
+          VERSION="${{ steps.tag.outputs.version }}"
+          SHA=$(cat wail-homebrew-src/wail-*-src.tar.gz.sha256 | head -1)
+          URL="https://github.com/quasor/WAIL/releases/download/v${VERSION}/wail-${VERSION}-src.tar.gz"
+
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/quasor/homebrew-wail.git" tap
+          sed -i \
+            "s|url \".*\"|url \"${URL}\"|" \
+            tap/Formula/wail.rb
+          sed -i \
+            "s|sha256 \".*\"|sha256 \"${SHA}\"|" \
+            tap/Formula/wail.rb
+          cd tap
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git commit -am "Update wail to v${VERSION}"
+          git push

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6359,7 +6359,7 @@ dependencies = [
 
 [[package]]
 name = "wail-audio"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "audiopus",
@@ -6369,7 +6369,7 @@ dependencies = [
 
 [[package]]
 name = "wail-core"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "rusty_link",
@@ -6381,7 +6381,7 @@ dependencies = [
 
 [[package]]
 name = "wail-net"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -6402,7 +6402,7 @@ dependencies = [
 
 [[package]]
 name = "wail-plugin-recv"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "assert_no_alloc",
@@ -6414,7 +6414,7 @@ dependencies = [
 
 [[package]]
 name = "wail-plugin-send"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "assert_no_alloc",
@@ -6426,7 +6426,7 @@ dependencies = [
 
 [[package]]
 name = "wail-plugin-test"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "clack-host",
  "tokio 1.49.0",
@@ -6437,7 +6437,7 @@ dependencies = [
 
 [[package]]
 name = "wail-tauri"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ Download the latest release from the [Releases page](https://github.com/quasor/W
 
 **macOS** — Open the DMG and drag WAIL to Applications. Run the included `.pkg` installer to install the audio plugins.
 
+**macOS (Homebrew, from source)** — Build and install directly from source:
+
+```sh
+brew tap quasor/wail
+brew install quasor/wail/wail
+wail-install-plugins   # copies CLAP/VST3 plugins to ~/Library/Audio/Plug-Ins/
+```
+
+This builds the WAIL binary and DAW plugins from source. Note: the Homebrew install provides the `wail` command-line binary. For the full macOS `.app` bundle (dock icon, menu bar), use the DMG installer above.
+
 **Windows** — Run the `.exe` installer. Copy the bundled `.clap` and `.vst3` plugin files to your DAW's plugin directory.
 
 **Linux** — Install the `.deb` package (`sudo dpkg -i wail_*.deb`) or download the AppImage and make it executable (`chmod +x WAIL_*.AppImage`). Copy the plugin files to `~/.clap/` and `~/.vst3/`.

--- a/homebrew/wail.rb
+++ b/homebrew/wail.rb
@@ -1,0 +1,72 @@
+# WAIL Homebrew Formula
+#
+# This file is the source of truth for the Homebrew formula.
+# It is copied automatically to the quasor/homebrew-wail tap on each release.
+# The `url` and `sha256` fields below are updated by the release workflow.
+#
+# To install:
+#   brew tap quasor/wail
+#   brew install quasor/wail/wail
+#   wail-install-plugins
+
+class Wail < Formula
+  desc "Sync Ableton Link sessions across the internet with intervalic audio"
+  homepage "https://github.com/quasor/WAIL"
+  # url and sha256 are updated automatically by the release workflow
+  url "https://github.com/quasor/WAIL/releases/download/v0.4.5/wail-0.4.5-src.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  license "MIT"
+  head "https://github.com/quasor/WAIL.git", branch: "main", submodules: true
+
+  depends_on "cmake" => :build
+  depends_on "rust" => :build
+  depends_on "opus"
+  depends_on :macos # requires macOS WebKit (used by Tauri)
+
+  def install
+    # Build the main app binary.
+    # Note: this produces the raw wail-tauri binary, not a full .app bundle.
+    # For the polished macOS .app, use the DMG from the Releases page instead.
+    system "cargo", "build", "--release", "--package", "wail-tauri", "--locked"
+    bin.install "target/release/wail-tauri" => "wail"
+
+    # Build and assemble CLAP/VST3 plugin bundles without requiring cargo-nih-plug.
+    system "cargo", "run", "--package", "xtask", "--release", "--locked", "--", "bundle-plugin"
+
+    # Install plugin bundles to #{lib}. Run `wail-install-plugins` afterwards
+    # to copy them to ~/Library/Audio/Plug-Ins/.
+    (lib/"wail-plugin-send.clap").install Dir["target/bundled/wail-plugin-send.clap/"]
+    (lib/"wail-plugin-recv.clap").install Dir["target/bundled/wail-plugin-recv.clap/"]
+    (lib/"wail-plugin-send.vst3").install Dir["target/bundled/wail-plugin-send.vst3/"]
+    (lib/"wail-plugin-recv.vst3").install Dir["target/bundled/wail-plugin-recv.vst3/"]
+
+    # Install the plugin installation helper script.
+    bin.install "scripts/wail-install-plugins.sh" => "wail-install-plugins"
+  end
+
+  def caveats
+    <<~EOS
+      To install the DAW plugins into your Audio/Plug-Ins directories, run:
+        wail-install-plugins
+
+      This copies the CLAP and VST3 bundles to:
+        ~/Library/Audio/Plug-Ins/CLAP/
+        ~/Library/Audio/Plug-Ins/VST3/
+
+      Then rescan plugins in your DAW.
+
+      Note: `wail` launches the app binary directly. For the polished macOS .app
+      bundle (dock icon, native menu bar), download the DMG from:
+        https://github.com/quasor/WAIL/releases
+    EOS
+  end
+
+  test do
+    assert_predicate bin/"wail", :exist?
+    assert_predicate bin/"wail-install-plugins", :exist?
+    assert_predicate lib/"wail-plugin-send.clap", :exist?
+    assert_predicate lib/"wail-plugin-recv.clap", :exist?
+    assert_predicate lib/"wail-plugin-send.vst3", :exist?
+    assert_predicate lib/"wail-plugin-recv.vst3", :exist?
+  end
+end

--- a/scripts/wail-install-plugins.sh
+++ b/scripts/wail-install-plugins.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Install WAIL DAW plugins to the user's Audio/Plug-Ins directories.
+#
+# Usage:
+#   wail-install-plugins [PREFIX]
+#
+# PREFIX defaults to the Homebrew prefix (brew --prefix). Override it to point
+# at a directory that contains the plugin bundles under lib/:
+#
+#   wail-install-plugins /opt/homebrew          # default when installed via Homebrew
+#   wail-install-plugins /path/to/target/bundled  # when building from source locally
+
+set -euo pipefail
+
+# Determine plugin bundle source directory.
+if [ $# -ge 1 ]; then
+    PREFIX="$1"
+else
+    PREFIX="$(brew --prefix 2>/dev/null)" || {
+        echo "error: could not determine Homebrew prefix; pass the plugin directory as an argument." >&2
+        exit 1
+    }
+fi
+
+SRC_DIR="${PREFIX}/lib"
+CLAP_DEST="${HOME}/Library/Audio/Plug-Ins/CLAP"
+VST3_DEST="${HOME}/Library/Audio/Plug-Ins/VST3"
+
+mkdir -p "$CLAP_DEST" "$VST3_DEST"
+
+install_bundle() {
+    local src="$1"
+    local dest_dir="$2"
+    local name
+    name="$(basename "$src")"
+
+    if [ ! -e "$src" ]; then
+        echo "warning: $src not found, skipping." >&2
+        return
+    fi
+
+    local dest="${dest_dir}/${name}"
+    if [ -e "$dest" ]; then
+        rm -rf "$dest"
+    fi
+    cp -r "$src" "$dest"
+    echo "Installed: $dest"
+}
+
+install_bundle "${SRC_DIR}/wail-plugin-send.clap" "$CLAP_DEST"
+install_bundle "${SRC_DIR}/wail-plugin-recv.clap" "$CLAP_DEST"
+install_bundle "${SRC_DIR}/wail-plugin-send.vst3" "$VST3_DEST"
+install_bundle "${SRC_DIR}/wail-plugin-recv.vst3" "$VST3_DEST"
+
+echo ""
+echo "Done. Rescan plugins in your DAW to pick up the changes."

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -14,7 +14,8 @@ cargo xtask <TASK> [OPTIONS]
 
 TASKS:
   install         Build and install plugins to system plugin directories
-  build-plugin    Build the CLAP and VST3 plugin bundles
+  build-plugin    Build the CLAP and VST3 plugin bundles (requires cargo-nih-plug)
+  bundle-plugin   Build and assemble plugin bundles without cargo-nih-plug
   install-plugin  Build (optional) and install to system plugin directories
   package-plugin  Create a macOS .pkg installer (macOS only)
   run-tauri       Run the Tauri desktop app in dev mode
@@ -24,7 +25,7 @@ TASKS:
 OPTIONS (install):
   --no-plugin-build  Skip plugin build; use existing bundles in target/bundled/
 
-OPTIONS (build-plugin, install-plugin):
+OPTIONS (build-plugin, bundle-plugin, install-plugin):
   --debug         Build in debug mode instead of release
 
 OPTIONS (install-plugin):
@@ -43,6 +44,7 @@ EXAMPLES:
   cargo xtask install
   cargo xtask install --no-plugin-build
   cargo xtask build-plugin
+  cargo xtask bundle-plugin
   cargo xtask install-plugin
   cargo xtask install-plugin --no-build
   cargo xtask package-plugin
@@ -67,6 +69,10 @@ fn main() -> Result<()> {
         Some("build-plugin") => {
             args.remove(0);
             build_plugin(&args)
+        }
+        Some("bundle-plugin") => {
+            args.remove(0);
+            bundle_plugin(&args)
         }
         Some("install-plugin") => {
             args.remove(0);
@@ -122,6 +128,171 @@ fn build_plugin(args: &[String]) -> Result<()> {
     println!("  target/bundled/wail-plugin-recv.vst3");
     println!("\nBuilt with profile: {profile}");
     Ok(())
+}
+
+/// Assemble CLAP and VST3 plugin bundles without requiring an external
+/// `cargo-nih-plug` installation. Intended for CI and Homebrew formula builds.
+///
+/// On macOS each format is a bundle directory:
+///   PluginName.clap/Contents/MacOS/PluginName + Info.plist
+///   PluginName.vst3/Contents/MacOS/PluginName + Info.plist
+///
+/// On Linux, CLAP is a flat renamed .so; VST3 uses the x86_64-linux layout.
+/// On Windows, CLAP is a flat renamed .dll; VST3 uses the x86_64-win layout.
+fn bundle_plugin(args: &[String]) -> Result<()> {
+    let release = !args.contains(&"--debug".to_string());
+    let profile = if release { "release" } else { "debug" };
+
+    let root = workspace_dir();
+    let version = cargo_version(&root)?;
+
+    // (cargo-package-name, lib-stem, display-name, bundle-id-prefix)
+    let plugins: &[(&str, &str, &str, &str)] = &[
+        (
+            "wail-plugin-send",
+            "wail_plugin_send",
+            "WAIL Send",
+            "com.wail.wail-plugin-send",
+        ),
+        (
+            "wail-plugin-recv",
+            "wail_plugin_recv",
+            "WAIL Recv",
+            "com.wail.wail-plugin-recv",
+        ),
+    ];
+
+    for &(pkg, lib, display_name, bundle_id) in plugins {
+        println!("Building {pkg} ({profile})...");
+        let mut cmd = Command::new(env!("CARGO"));
+        cmd.args(["build", "--package", pkg, "--lib"]);
+        if release {
+            cmd.arg("--release");
+        }
+        cmd.current_dir(&root);
+        run_cmd(cmd).with_context(|| format!("cargo build {pkg} failed"))?;
+
+        let out = root.join("target").join(profile);
+        let bundled = root.join("target/bundled");
+        fs::create_dir_all(&bundled)?;
+
+        #[cfg(target_os = "macos")]
+        {
+            let dylib = out.join(format!("lib{lib}.dylib"));
+            if !dylib.exists() {
+                bail!("dylib not found: {}", dylib.display());
+            }
+            for ext in ["clap", "vst3"] {
+                let bundle = bundled.join(format!("{pkg}.{ext}"));
+                let macos_dir = bundle.join("Contents/MacOS");
+                if bundle.exists() {
+                    fs::remove_dir_all(&bundle)?;
+                }
+                fs::create_dir_all(&macos_dir)?;
+                fs::copy(&dylib, macos_dir.join(pkg))
+                    .with_context(|| format!("copy dylib into {pkg}.{ext}"))?;
+                fs::write(
+                    bundle.join("Contents/Info.plist"),
+                    make_plist(pkg, display_name, bundle_id, ext, &version),
+                )?;
+                println!("  Bundled: {}", bundle.display());
+            }
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let so = out.join(format!("lib{lib}.so"));
+            if !so.exists() {
+                bail!("shared library not found: {}", so.display());
+            }
+            // CLAP on Linux: flat renamed .so
+            let clap = bundled.join(format!("{pkg}.clap"));
+            if clap.exists() {
+                fs::remove_file(&clap)?;
+            }
+            fs::copy(&so, &clap)?;
+            println!("  Bundled: {}", clap.display());
+            // VST3 on Linux: bundle with x86_64-linux sub-dir
+            let vst3 = bundled.join(format!("{pkg}.vst3"));
+            if vst3.exists() {
+                fs::remove_dir_all(&vst3)?;
+            }
+            let vst3_dir = vst3.join("Contents/x86_64-linux");
+            fs::create_dir_all(&vst3_dir)?;
+            fs::copy(&so, vst3_dir.join(format!("{pkg}.so")))?;
+            println!("  Bundled: {}", vst3.display());
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            let dll = out.join(format!("{lib}.dll"));
+            if !dll.exists() {
+                bail!("dll not found: {}", dll.display());
+            }
+            // CLAP on Windows: flat renamed .dll
+            let clap = bundled.join(format!("{pkg}.clap"));
+            if clap.exists() {
+                fs::remove_file(&clap)?;
+            }
+            fs::copy(&dll, &clap)?;
+            println!("  Bundled: {}", clap.display());
+            // VST3 on Windows: bundle with x86_64-win sub-dir
+            let vst3 = bundled.join(format!("{pkg}.vst3"));
+            if vst3.exists() {
+                fs::remove_dir_all(&vst3)?;
+            }
+            let vst3_dir = vst3.join("Contents/x86_64-win");
+            fs::create_dir_all(&vst3_dir)?;
+            fs::copy(&dll, vst3_dir.join(format!("{pkg}.vst3")))?;
+            println!("  Bundled: {}", vst3.display());
+        }
+
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+        bail!("bundle-plugin is not supported on this platform");
+    }
+
+    println!("\nPlugin bundles (no cargo-nih-plug required):");
+    println!("  target/bundled/wail-plugin-send.clap");
+    println!("  target/bundled/wail-plugin-send.vst3");
+    println!("  target/bundled/wail-plugin-recv.clap");
+    println!("  target/bundled/wail-plugin-recv.vst3");
+    println!("Built with profile: {profile}");
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn make_plist(
+    executable: &str,
+    display_name: &str,
+    bundle_id: &str,
+    ext: &str,
+    version: &str,
+) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>{executable}</string>
+    <key>CFBundleIdentifier</key>
+    <string>{bundle_id}.{ext}</string>
+    <key>CFBundleName</key>
+    <string>{display_name}</string>
+    <key>CFBundleDisplayName</key>
+    <string>{display_name}</string>
+    <key>CFBundlePackageType</key>
+    <string>BNDL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>{version}</string>
+    <key>CFBundleVersion</key>
+    <string>{version}</string>
+    <key>NSHumanReadableCopyright</key>
+    <string>MIT</string>
+</dict>
+</plist>
+"#
+    )
 }
 
 fn install_plugin(args: &[String]) -> Result<()> {


### PR DESCRIPTION
## Summary

Add full Homebrew support for installing WAIL and its DAW plugins from source on macOS. Users can now run:

```sh
brew tap quasor/wail
brew install quasor/wail/wail
wail-install-plugins
```

This includes a new `cargo xtask bundle-plugin` subcommand that assembles CLAP/VST3 plugins cross-platform without requiring `cargo-nih-plug` to be installed globally, a helper script for plugin installation, and release workflow enhancements to generate fat source tarballs with git submodule content and auto-update the Homebrew tap.

## Changes

- **xtask**: Add `bundle-plugin` subcommand that builds and assembles `.clap`/`.vst3` plugin bundles for macOS (bundle directories), Linux (flat files with VST3 x86_64-linux layout), and Windows (flat DLLs with VST3 x86_64-win layout).
- **scripts**: Add `wail-install-plugins.sh` helper to copy installed plugins to `~/Library/Audio/Plug-Ins/`.
- **homebrew**: Add `wail.rb` formula that builds the app binary and plugins from source.
- **release.yml**: Add `build-homebrew-tarball` job to generate tarballs with `vendor/link` submodule included; add tap auto-update step.
- **README.md**: Document Homebrew installation path.
- **Changeset**: Document the feature for release notes.

## Test plan

- [ ] Verify `cargo xtask bundle-plugin` produces correct bundle structure on macOS
- [ ] Verify `wail-install-plugins.sh` copies plugins to the right location
- [ ] Test Homebrew formula locally: `brew install --build-from-source ./homebrew/wail.rb`
- [ ] Verify plugins are installed to `lib/` and can be copied with `wail-install-plugins`
- [ ] On release, verify tarball is generated with submodule and uploaded to release
- [ ] If HOMEBREW_TAP_TOKEN is set, verify tap repo is auto-updated with URL and SHA256

🤖 Generated with [Claude Code](https://claude.com/claude-code)