### PR TITLE
Fix Homebrew --locked build failure

### DIFF
--- a/.changeset/fix-homebrew-locked-build.md
+++ b/.changeset/fix-homebrew-locked-build.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Fix Homebrew `brew install --build-from-source` failing with `--locked` error by syncing Cargo.lock during release preparation

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -33,6 +33,8 @@ jobs:
           curl -sSfL "https://github.com/knope-dev/knope/releases/latest/download/knope-x86_64-unknown-linux-musl.tgz" \
             | tar -xz --strip-components=1 -C /usr/local/bin/
 
+      - uses: dtolnay/rust-toolchain@stable
+
       - name: Ensure changeset exists for patch release
         run: |
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6359,7 +6359,7 @@ dependencies = [
 
 [[package]]
 name = "wail-audio"
-version = "0.4.5"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "audiopus",
@@ -6369,7 +6369,7 @@ dependencies = [
 
 [[package]]
 name = "wail-core"
-version = "0.4.5"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "rusty_link",
@@ -6381,7 +6381,7 @@ dependencies = [
 
 [[package]]
 name = "wail-net"
-version = "0.4.5"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -6402,7 +6402,7 @@ dependencies = [
 
 [[package]]
 name = "wail-plugin-recv"
-version = "0.4.5"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "assert_no_alloc",
@@ -6414,7 +6414,7 @@ dependencies = [
 
 [[package]]
 name = "wail-plugin-send"
-version = "0.4.5"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "assert_no_alloc",
@@ -6426,7 +6426,7 @@ dependencies = [
 
 [[package]]
 name = "wail-plugin-test"
-version = "0.4.5"
+version = "0.4.7"
 dependencies = [
  "clack-host",
  "tokio 1.49.0",
@@ -6437,7 +6437,7 @@ dependencies = [
 
 [[package]]
 name = "wail-tauri"
-version = "0.4.5"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "chrono",

--- a/knope.toml
+++ b/knope.toml
@@ -14,6 +14,10 @@ type = "PrepareRelease"
 
 [[workflows.steps]]
 type = "Command"
+command = "cargo update --workspace"
+
+[[workflows.steps]]
+type = "Command"
 command = "git switch -c release"
 
 [[workflows.steps]]


### PR DESCRIPTION
## Summary
- Fixes `brew install --build-from-source` failing with `--locked` error
- Added `cargo update --workspace` to release workflow to sync Cargo.lock when versions are bumped
- Added Rust toolchain installation to CI job so cargo is available during release prep
- Fixed currently stale Cargo.lock (7 workspace crates)

## Why
When `knope prepare-release` bumps the workspace version in Cargo.toml, Cargo.lock was not being updated. This caused the release tarball to ship with stale lock entries, making `cargo build --locked` fail for Homebrew users.

Reluctantly assisted by Claude Code