### PR TITLE
Fix Homebrew build with CMake 4.x

### DIFF
--- a/homebrew/wail.rb
+++ b/homebrew/wail.rb
@@ -24,6 +24,10 @@ class Wail < Formula
   depends_on :macos # requires macOS WebKit (used by Tauri)
 
   def install
+    # CMake 4.x rejects old cmake_minimum_required() values in rusty_link's
+    # vendored Ableton Link SDK. This env var tells CMake to accept them.
+    ENV["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
+
     # Build the main app binary.
     # Note: this produces the raw wail-tauri binary, not a full .app bundle.
     # For the polished macOS .app, use the DMG from the Releases page instead.


### PR DESCRIPTION
## Summary
- Sets `CMAKE_POLICY_VERSION_MINIMUM=3.5` in the Homebrew formula to fix build failures with CMake 4.x
- CMake 4.x (installed by Homebrew) rejects old `cmake_minimum_required(VERSION 3.10)` values in rusty_link's vendored Ableton Link SDK

Grudgingly crafted by Claude Code