### PR TITLE
fix: add pkg-config build dep for Homebrew Opus discovery

### DIFF
--- a/homebrew/wail.rb
+++ b/homebrew/wail.rb
@@ -19,6 +19,7 @@ class Wail < Formula
   head "https://github.com/quasor/WAIL.git", branch: "main", submodules: true
 
   depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
   depends_on "rust" => :build
   depends_on "opus"
   depends_on :macos # requires macOS WebKit (used by Tauri)


### PR DESCRIPTION
## Summary
- `brew install` fails because `audiopus_sys` can't find the installed Opus library via pkg-config (binary not in PATH), falls back to building from source via CMake, and CMake 4.x rejects the old `cmake_minimum_required()`
- Adds `depends_on "pkg-config" => :build` so pkg-config can discover the Homebrew-installed Opus, avoiding the CMake source build entirely

## Test plan
- [ ] `brew install --build-from-source quasor/wail/wail` succeeds
- [ ] Build log shows audiopus_sys finding Opus via pkg-config (no "Building Opus via CMake" message)

🫠 Reluctantly assisted by Claude Code