### PR TITLE
fix: point pkg-config to pkgconf and deploy formula to tap

### DIFF
--- a/.changeset/fix-homebrew-pkgconf.md
+++ b/.changeset/fix-homebrew-pkgconf.md
@@ -1,0 +1,5 @@
+---
+wail-tauri: patch
+---
+
+Fix Homebrew build by pointing pkg-config to pkgconf binary and deploying formula changes to tap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,6 +277,12 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
 
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+          path: source
+          sparse-checkout: homebrew
+
       - name: Determine tag
         id: tag
         run: |
@@ -334,6 +340,9 @@ jobs:
           URL="https://github.com/quasor/WAIL/releases/download/v${VERSION}/wail-${VERSION}-src.tar.gz"
 
           git clone "https://x-access-token:${GH_TOKEN}@github.com/quasor/homebrew-wail.git" tap
+          # Copy full formula from source so all formula changes are deployed
+          cp source/homebrew/wail.rb tap/Formula/wail.rb
+          # Patch URL and SHA for this release
           sed -i \
             "s|url \".*\"|url \"${URL}\"|" \
             tap/Formula/wail.rb

--- a/homebrew/wail.rb
+++ b/homebrew/wail.rb
@@ -25,6 +25,11 @@ class Wail < Formula
   depends_on :macos # requires macOS WebKit (used by Tauri)
 
   def install
+    # Homebrew's superenv pkg-config shim references the legacy "pkg-config"
+    # opt path, but modern Homebrew provides it via "pkgconf". Point the Rust
+    # pkg-config crate directly to the real binary so audiopus_sys finds Opus.
+    ENV["PKG_CONFIG"] = Formula["pkgconf"].opt_bin/"pkg-config"
+
     # CMake 4.x rejects old cmake_minimum_required() values in rusty_link's
     # vendored Ableton Link SDK. This env var tells CMake to accept them.
     ENV["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"


### PR DESCRIPTION
## Summary

Fix Homebrew build by redirecting the Rust pkg-config crate to the real pkgconf binary (since Homebrew's superenv shim is broken with modern pkgconf) and fixing the release workflow to copy the full formula to the tap so prior CMake compatibility fixes actually get deployed.

## Changes

- **homebrew/wail.rb**: Set `ENV["PKG_CONFIG"]` explicitly to bypass broken superenv shim
- **.github/workflows/release.yml**: Copy full formula from source to tap instead of sed-only patching
- **.changeset/fix-homebrew-pkgconf.md**: Document fix as patch release

## Test Plan

- Verify `brew install --build-from-source quasor/wail/wail` succeeds after next release
- Check that formula content changes properly deploy to the Homebrew tap on release

Reluctantly assisted by Claude Code