### PR TITLE
docs: update release command description

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -5,7 +5,7 @@ allowed-tools: [Bash]
 
 # Release
 
-Find and merge the open release PR (titled "chore: prepare release v*").
+Find and merge the open release PR (titled "chore: prepare release").
 
 ## Instructions
 


### PR DESCRIPTION
Update the release command documentation to remove the asterisk wildcard from the PR title pattern, matching the actual behavior of the command.