### PR TITLE
fix: homebrew double-nested plugins and stale release artifacts

### DIFF
--- a/.changeset/fix-release-artifacts.md
+++ b/.changeset/fix-release-artifacts.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+### Fixed
+- Fix Homebrew formula installing doubly-nested plugin bundles (e.g. `wail-plugin-send.clap/wail-plugin-send.clap/Contents/...`)
+- Fix release workflow uploading stale Tauri installer artifacts from cached `target` directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Build plugin
         run: cargo xtask build-plugin
 
+      - name: Clean stale Tauri bundles
+        run: rm -rf target/release/bundle/
+
       - name: Build Tauri app
         run: cargo tauri build --bundles dmg
 
@@ -174,6 +177,10 @@ jobs:
           PKG_CONFIG_PATH: C:\vcpkg\installed\x64-windows\lib\pkgconfig
         run: cargo xtask build-plugin
 
+      - name: Clean stale Tauri bundles
+        run: Remove-Item -Recurse -Force target\release\bundle -ErrorAction SilentlyContinue
+        shell: pwsh
+
       - name: Build Tauri app
         env:
           PKG_CONFIG_PATH: C:\vcpkg\installed\x64-windows\lib\pkgconfig
@@ -250,6 +257,9 @@ jobs:
 
       - name: Build plugin
         run: cargo xtask build-plugin
+
+      - name: Clean stale Tauri bundles
+        run: rm -rf target/release/bundle/
 
       - name: Build Tauri app
         run: cargo tauri build --bundles appimage,deb

--- a/homebrew/wail.rb
+++ b/homebrew/wail.rb
@@ -44,10 +44,10 @@ class Wail < Formula
 
     # Install plugin bundles to #{lib}. Run `wail-install-plugins` afterwards
     # to copy them to ~/Library/Audio/Plug-Ins/.
-    (lib/"wail-plugin-send.clap").install Dir["target/bundled/wail-plugin-send.clap/"]
-    (lib/"wail-plugin-recv.clap").install Dir["target/bundled/wail-plugin-recv.clap/"]
-    (lib/"wail-plugin-send.vst3").install Dir["target/bundled/wail-plugin-send.vst3/"]
-    (lib/"wail-plugin-recv.vst3").install Dir["target/bundled/wail-plugin-recv.vst3/"]
+    (lib/"wail-plugin-send.clap").install Dir["target/bundled/wail-plugin-send.clap/*"]
+    (lib/"wail-plugin-recv.clap").install Dir["target/bundled/wail-plugin-recv.clap/*"]
+    (lib/"wail-plugin-send.vst3").install Dir["target/bundled/wail-plugin-send.vst3/*"]
+    (lib/"wail-plugin-recv.vst3").install Dir["target/bundled/wail-plugin-recv.vst3/*"]
 
     # Install the plugin installation helper script (useful for manual reinstall).
     bin.install "scripts/wail-install-plugins.sh" => "wail-install-plugins"


### PR DESCRIPTION
## Summary
- **Homebrew formula**: Changed `Dir["target/bundled/<name>/"]` → `Dir["target/bundled/<name>/*"]` so plugin contents are installed directly, not wrapped in an extra directory layer. This caused `wail-install-plugins` to create `wail-plugin-send.clap/wail-plugin-send.clap/Contents/...` instead of `wail-plugin-send.clap/Contents/...`.
- **Release workflow**: Added `rm -rf target/release/bundle/` before each `cargo tauri build` on all 3 platforms. The cached `target` directory retained old Tauri bundle output, causing stale versioned files to be uploaded (e.g. `WAIL_0.4.10_amd64.deb` in the v0.4.13 release).
- **Cleanup**: Deleted the stale `WAIL_0.4.10_amd64.deb` and `WAIL_0.4.10_x64-setup.exe` from the v0.4.13 release.

## Test plan
- [ ] `brew install --build-from-source quasor/wail/wail` — verify `find $(brew --prefix)/Cellar/wail/*/lib/wail-plugin-send.clap` shows `Contents/` directly (no nested `.clap` dir)
- [ ] `wail-install-plugins` — verify `~/Library/Audio/Plug-Ins/CLAP/wail-plugin-send.clap/Contents/MacOS/wail-plugin-send` exists
- [ ] Next release should produce only correctly-versioned `.deb` and `.exe` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)