### PR TITLE
fix: simplify release skill search command

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -9,7 +9,7 @@ Find and merge the open release PR (titled "chore: prepare release").
 
 ## Instructions
 
-1. Run: `gh pr list --state open --search "chore: prepare release v" --head release --base main --json number,title,url --limit 5`
+1. Run: `gh pr list --state open --head release --base main --json number,title,url --limit 5`
 2. If no PRs are found, tell the user there is no pending release PR.
 3. If one PR is found, merge it: `gh pr merge <number> --merge --delete-branch`
 4. If multiple PRs match (unlikely), list them and ask the user which one to merge.


### PR DESCRIPTION
Remove redundant --search filter from the release skill's gh pr list command. The --head release --base main branch filter is sufficient to identify release PRs and more reliable than combining with text search.

This fixes an issue where the release skill was unable to find open release PRs due to the text filter conflicting with the branch name filters.