### PR TITLE
docs: add ReaBlink link for REAPER users

### DIFF
--- a/.changeset/reablink-readme.md
+++ b/.changeset/reablink-readme.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Add ReaBlink link to README for REAPER users. REAPER doesn't have native Ableton Link support, so the Getting Started section now mentions ReaBlink, a REAPER extension that adds Link support.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This builds the WAIL binary and DAW plugins from source. The CLAP and VST3 plugi
 2. **Enable Ableton Link in your DAW.** WAIL relies on Link for tempo and phase sync.
    - *Ableton Live:* Preferences > Link, Tempo, MIDI > turn on "Show Link Toggle", then enable Link in the transport bar.
    - *Bitwig Studio:* Settings > Synchronization > enable Link.
+   - *REAPER:* Install [ReaBlink](https://github.com/ak5k/reablink), which adds Ableton Link support via a REAPER extension.
    - Other DAWs — check your DAW's documentation for Link support.
 
 3. **Load WAIL Send** on the track or bus you want to share. This plugin captures audio and sends it to your peers at each interval boundary.


### PR DESCRIPTION
## Summary
Added ReaBlink link to the README's Getting Started section. REAPER users can now see how to enable Ableton Link support for WAIL.

## Changes
- Added REAPER-specific instructions linking to ReaBlink in step 2 of Getting Started
- Created changeset file for the next patch release