### PR TITLE
fix: call audio_gate.on_peer_list() for all peer counts

### DIFF
--- a/crates/wail-tauri/src/session.rs
+++ b/crates/wail-tauri/src/session.rs
@@ -508,10 +508,10 @@ async fn session_loop(
                         }
                     }
                     Ok(Some(wail_net::MeshEvent::PeerListReceived(n))) => {
+                        audio_gate.on_peer_list(n);
                         if n == 0 {
                             ui_info!(&app, "First peer in room — audio send ungated");
                         } else {
-                            audio_gate.on_peer_list(n);
                             ui_info!(&app, "Joined room with {n} peer(s) — audio send gated until beat sync");
                         }
                     }


### PR DESCRIPTION
## Summary
Fixes a bug where audio sending would remain permanently gated after reconnecting to an empty room. When PeerListReceived(0) was received in the n == 0 branch, audio_gate.on_peer_list(0) was never called to ungate. This meant that after signaling reconnection set the gate to true, there was no way to lift it back (no remote peers would send StateSnapshot messages to trigger on_beat_synced()).

## Changes
Moved audio_gate.on_peer_list(n) before the if/else block in the PeerListReceived handler so it's called unconditionally for both empty (n=0) and non-empty rooms. All 5 unit tests pass, including first_peer_reconnects_to_empty_room which specifically validates this scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)