### PR TITLE
fix: correct changeset frontmatter format for knope

### DIFF
--- a/.changeset/auto-release-setup.md
+++ b/.changeset/auto-release-setup.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-Add automatic releases on PR merge to main via GitHub Actions.

--- a/.changeset/fix-audio-recv-tcp-buffer.md
+++ b/.changeset/fix-audio-recv-tcp-buffer.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-Fix audio receive failure after plugin split: send and recv plugins now identify themselves via IPC role bytes, and the session only forwards received audio to recv plugin connections. This prevents TCP buffer bloat on the send plugin's connection (which never reads forwarded audio), fixing the deadlock that caused no `[AUDIO RECV]` events. Adds AudioStatus message for remote audio pipeline health monitoring, improves DC state tracking with responder on_open callback, and escalates audio drop logs to warn level.

--- a/.changeset/fix-brew-postinstall.md
+++ b/.changeset/fix-brew-postinstall.md
@@ -1,5 +1,0 @@
----
-wail-tauri: patch
----
-
-Fix brew postinstall sandbox EPERM by removing post_install and relying on wail-install-plugins script

--- a/.changeset/fix-homebrew-locked-build.md
+++ b/.changeset/fix-homebrew-locked-build.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-Fix Homebrew `brew install --build-from-source` failing with `--locked` error by syncing Cargo.lock during release preparation

--- a/.changeset/fix-homebrew-pkgconf.md
+++ b/.changeset/fix-homebrew-pkgconf.md
@@ -1,5 +1,0 @@
----
-wail-tauri: patch
----
-
-Fix Homebrew build by pointing pkg-config to pkgconf binary and deploying formula changes to tap

--- a/.changeset/fix-release-branch-protection.md
+++ b/.changeset/fix-release-branch-protection.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-Split CI release into two phases (prepare-release PR + release-on-merge) to work with branch protection rules

--- a/.changeset/gate-audio-on-lock.md
+++ b/.changeset/gate-audio-on-lock.md
@@ -1,6 +1,5 @@
 ---
-"wail-tauri": patch
-"wail-net": patch
+default: patch
 ---
 
 fix: gate audio sending until beat-locked when joining a room with existing peers

--- a/.changeset/homebrew-formula.md
+++ b/.changeset/homebrew-formula.md
@@ -1,5 +1,0 @@
----
-"wail-tauri": minor
----
-
-Add Homebrew from-source installation support. Users on macOS can now install WAIL and its DAW plugins directly from source via `brew tap quasor/wail && brew install quasor/wail/wail`. A new `cargo xtask bundle-plugin` command assembles CLAP/VST3 plugin bundles without requiring `cargo-nih-plug` to be installed globally. A `wail-install-plugins` helper script copies the installed plugin bundles to `~/Library/Audio/Plug-Ins/`.

--- a/.changeset/honeybadger-integration.md
+++ b/.changeset/honeybadger-integration.md
@@ -1,5 +1,0 @@
----
-"wail-tauri": minor
----
-
-Add Honeybadger error monitoring. Panics and session errors are now reported to the Honeybadger dashboard.

--- a/.changeset/local-session-recording.md
+++ b/.changeset/local-session-recording.md
@@ -1,5 +1,5 @@
 ---
-type: minor
+default: minor
 ---
 
 Add local session recording to the WAIL app. New recording options in the Advanced settings panel let you capture jam sessions as WAV files to disk. Supports recording per-peer stems (separate WAV per participant) or a single mixed WAV. Includes configurable recording directory, retention policy (auto-delete old sessions after N days), and a live recording indicator with file size display in the session view.

--- a/.changeset/multi-send-streams.md
+++ b/.changeset/multi-send-streams.md
@@ -1,5 +1,5 @@
 ---
-type: minor
+default: minor
 ---
 
 Enable multiple WAIL Send plugin instances to send independent audio streams to the same peer. Each unique (peer_id, stream_id) pair gets its own auxiliary output slot in the Recv plugin. Send plugin includes stream_index parameter (0-30). Audio wire format bumped to v2 with stream_id encoding. Server enforces global capacity limit (SUM of stream_counts ≤ 31 per room) with 409 response on overflow.

--- a/.changeset/opus-bytes-stats.md
+++ b/.changeset/opus-bytes-stats.md
@@ -1,5 +1,0 @@
----
-bump: patch
----
-
-Show bytes sent/received for compressed Opus audio payload in session stats UI. Displays formatted byte counts (B/KB/MB) below the audio interval counts, helping users monitor network bandwidth usage.

--- a/.changeset/public-rooms.md
+++ b/.changeset/public-rooms.md
@@ -1,5 +1,5 @@
 ---
-type: minor
+default: minor
 ---
 
 Add public rooms: rooms created without a password are listed in a browsable directory. Both the desktop app and web listener show a "Public Rooms" tab with auto-refreshing room list. Signaling server gains `?action=list` and `?action=update` endpoints.

--- a/.changeset/reablink-readme.md
+++ b/.changeset/reablink-readme.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-Add ReaBlink link to README for REAPER users. REAPER doesn't have native Ableton Link support, so the Getting Started section now mentions ReaBlink, a REAPER extension that adds Link support.

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -58,7 +58,7 @@ jobs:
             echo "No changesets or conventional commits found. Creating fallback patch changeset."
             mkdir -p .changeset
             COMMIT_MSG=$(git log -1 --format='%s')
-            printf -- '---\ntype: patch\n---\n\n%s\n' "$COMMIT_MSG" > .changeset/auto-patch.md
+            printf -- '---\ndefault: patch\n---\n\n%s\n' "$COMMIT_MSG" > .changeset/auto-patch.md
           fi
 
       - name: Run knope prepare-release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,15 @@ knope document-change
 
 This creates a markdown file in `.changeset/` describing what changed and the bump type (major/minor/patch). Commit the changeset file with your PR. Conventional commit messages (`feat:`, `fix:`, `feat!:`) also work and are picked up automatically.
 
+**Changeset frontmatter format:** The YAML frontmatter must use `default: <type>` (e.g., `default: minor`). Do NOT use `type: <type>` or package names — knope silently ignores unrecognized package keys. Example:
+```markdown
+---
+default: minor
+---
+
+Description of the change.
+```
+
 ### Release pipeline (automated via GitHub Actions)
 
 Releases are fully automated — no manual `knope` commands needed:


### PR DESCRIPTION
## Summary

Knope changeset frontmatter requires `default: <type>` for single-package configs, but 10 stale changeset files used `type: <type>` or package-specific syntax which knope silently ignored. This caused all releases to be patch-bumps regardless of actual change type (e.g., `feat:` commits should trigger minor bumps, not patch).

## Changes

- Delete 10 stale changeset files for already-released features
- Fix 4 unreleased changeset files to use `default: <type>` format  
- Fix CI fallback in auto-release.yml to use `default: patch`
- Update CLAUDE.md with correct changeset format documentation

The next auto-release workflow will now correctly produce v0.5.0 (minor) instead of v0.4.16 (patch), fixing PR #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)