### PR TITLE
chore: update GitHub organization to MostDistant

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,7 +337,7 @@ jobs:
             ${{ steps.files.outputs.src_tarball }}
 
       # Update the Homebrew tap formula with the new version and SHA256.
-      # Requires a HOMEBREW_TAP_TOKEN secret with push access to quasor/homebrew-wail.
+      # Requires a HOMEBREW_TAP_TOKEN secret with push access to MostDistant/homebrew-wail.
       # If the secret is not configured, this step is skipped gracefully.
       - name: Update Homebrew tap
         continue-on-error: true
@@ -347,9 +347,9 @@ jobs:
           [ -z "${GH_TOKEN}" ] && echo "HOMEBREW_TAP_TOKEN not set, skipping tap update." && exit 0
           VERSION="${{ steps.tag.outputs.version }}"
           SHA=$(cat wail-homebrew-src/wail-*-src.tar.gz.sha256 | head -1)
-          URL="https://github.com/quasor/WAIL/releases/download/v${VERSION}/wail-${VERSION}-src.tar.gz"
+          URL="https://github.com/MostDistant/WAIL/releases/download/v${VERSION}/wail-${VERSION}-src.tar.gz"
 
-          git clone "https://x-access-token:${GH_TOKEN}@github.com/quasor/homebrew-wail.git" tap
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/MostDistant/homebrew-wail.git" tap
           # Copy full formula from source so all formula changes are deployed
           cp source/homebrew/wail.rb tap/Formula/wail.rb
           # Patch URL and SHA for this release

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ WAIL synchronizes [Ableton Link](https://www.ableton.com/link/) sessions across 
 
 ## Install
 
-Download the latest release from the [Releases page](https://github.com/quasor/WAIL/releases).
+Download the latest release from the [Releases page](https://github.com/MostDistant/WAIL/releases).
 
 **macOS** — Open the DMG and drag WAIL to Applications. Run the included `.pkg` installer to install the audio plugins.
 
 **macOS (Homebrew, from source)** — Build and install directly from source:
 
 ```sh
-brew tap quasor/wail
-brew install quasor/wail/wail
+brew tap MostDistant/wail
+brew install MostDistant/wail/wail
 ```
 
 This builds the WAIL binary and DAW plugins from source. The CLAP and VST3 plugins are automatically installed to `~/Library/Audio/Plug-Ins/` — just rescan plugins in your DAW. Note: the Homebrew install provides the `wail` command-line binary. For the full macOS `.app` bundle (dock icon, menu bar), use the DMG installer above.

--- a/crates/wail-plugin-recv/src/lib.rs
+++ b/crates/wail-plugin-recv/src/lib.rs
@@ -121,7 +121,7 @@ fn write_peer_to_aux(
 impl Plugin for WailRecvPlugin {
     const NAME: &'static str = "WAIL Recv";
     const VENDOR: &'static str = "WAIL Project";
-    const URL: &'static str = "https://github.com/quasor/WAIL";
+    const URL: &'static str = "https://github.com/MostDistant/WAIL";
     const EMAIL: &'static str = "";
 
     const VERSION: &'static str = env!("CARGO_PKG_VERSION");

--- a/crates/wail-plugin-send/src/lib.rs
+++ b/crates/wail-plugin-send/src/lib.rs
@@ -112,7 +112,7 @@ fn interleave_channels(
 impl Plugin for WailSendPlugin {
     const NAME: &'static str = "WAIL Send";
     const VENDOR: &'static str = "WAIL Project";
-    const URL: &'static str = "https://github.com/quasor/WAIL";
+    const URL: &'static str = "https://github.com/MostDistant/WAIL";
     const EMAIL: &'static str = "";
 
     const VERSION: &'static str = env!("CARGO_PKG_VERSION");

--- a/homebrew/wail.rb
+++ b/homebrew/wail.rb
@@ -1,21 +1,21 @@
 # WAIL Homebrew Formula
 #
 # This file is the source of truth for the Homebrew formula.
-# It is copied automatically to the quasor/homebrew-wail tap on each release.
+# It is copied automatically to the MostDistant/homebrew-wail tap on each release.
 # The `url` and `sha256` fields below are updated by the release workflow.
 #
 # To install:
-#   brew tap quasor/wail
-#   brew install quasor/wail/wail
+#   brew tap MostDistant/wail
+#   brew install MostDistant/wail/wail
 
 class Wail < Formula
   desc "Sync Ableton Link sessions across the internet with intervalic audio"
-  homepage "https://github.com/quasor/WAIL"
+  homepage "https://github.com/MostDistant/WAIL"
   # url and sha256 are updated automatically by the release workflow
-  url "https://github.com/quasor/WAIL/releases/download/v0.4.5/wail-0.4.5-src.tar.gz"
+  url "https://github.com/MostDistant/WAIL/releases/download/v0.4.5/wail-0.4.5-src.tar.gz"
   sha256 "0000000000000000000000000000000000000000000000000000000000000000"
   license "MIT"
-  head "https://github.com/quasor/WAIL.git", branch: "main", submodules: true
+  head "https://github.com/MostDistant/WAIL.git", branch: "main", submodules: true
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
@@ -66,7 +66,7 @@ class Wail < Formula
 
       Note: `wail` launches the app binary directly. For the polished macOS .app
       bundle (dock icon, native menu bar), download the DMG from:
-        https://github.com/quasor/WAIL/releases
+        https://github.com/MostDistant/WAIL/releases
     EOS
   end
 

--- a/knope.toml
+++ b/knope.toml
@@ -3,7 +3,7 @@ versioned_files = ["Cargo.toml", "crates/wail-tauri/tauri.conf.json"]
 changelog = "CHANGELOG.md"
 
 [github]
-owner = "quasor"
+owner = "MostDistant"
 repo = "WAIL"
 
 [[workflows]]


### PR DESCRIPTION
## Summary
Updates all repository references to reflect the organization move from `quasor` to `MostDistant`.

## Changes
- Updated GitHub URLs in README, Homebrew formula, and release workflow
- Updated plugin metadata (send/recv plugins) with new repository URL
- Updated knope.toml GitHub owner configuration
- Updated Homebrew tap references in formula and documentation

Reluctantly assisted by Claude Code.