### PR TITLE
ci: move cross-platform builds from PR to merge queue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches: [main, "claude/**"]
-  pull_request:
+  merge_group:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Move full cross-platform builds (macOS/Windows/Linux) from PR trigger to merge queue trigger
- PRs no longer run CI builds (developer tests locally)
- Merge queue runs full build; ejects PR on build failure
- Reduces CI costs and feedback latency

## Test plan
- [ ] Enable merge queue in repo settings after merge
- [ ] Test opening a PR and clicking "Merge" — should queue and run full build

Reluctantly assisted by Claude Code