### PR TITLE
fix: evict stale peer entries on reconnect

### DIFF
--- a/.changeset/fix-reconnect-slot-affinity.md
+++ b/.changeset/fix-reconnect-slot-affinity.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+Fix reconnecting peers being mapped to a different channel slot.
+
+When a peer crashed and reconnected with a new peer_id before the old connection was cleaned up, the old slot remained occupied, forcing the reconnecting peer onto a new slot. The session now evicts the stale peer_id when a Hello arrives with an identity that already belongs to a different tracked peer, freeing the slot for the reconnecting peer to reclaim via affinity.

--- a/crates/wail-audio/src/ring.rs
+++ b/crates/wail-audio/src/ring.rs
@@ -1493,4 +1493,178 @@ mod tests {
         // Silence after audio
         assert_eq!(output[32], 0.0);
     }
+
+    // --- Tests: reconnect with same peer_id (WebRTC-level reconnect, no new peer_id) ---
+
+    /// When the WebRTC connection drops and reconnects without a new peer_id
+    /// (session retries the same connection), no PeerLeft IPC is sent.
+    /// The session sends PeerJoined again with the same peer_id and identity.
+    /// The ring must keep the peer on the same slot — the slot was never freed.
+    #[test]
+    fn same_peer_id_reconnect_keeps_same_slot() {
+        let mut ring = make_ring();
+        let input = vec![0.0f32; 128];
+        let mut output = vec![0.0f32; 128];
+
+        // Initial connection: peer-a joins and is assigned slot 0
+        ring.notify_peer_joined("peer-a", "identity-alice");
+        ring.process(&input, &mut output, 0.0);
+        ring.feed_remote("peer-a", 0, 0, vec![0.3f32; 128]);
+        ring.process(&input, &mut output, 16.0);
+
+        let slot_a = ring.active_peer_slots()
+            .iter()
+            .find(|(_, pid, _)| pid == "peer-a")
+            .unwrap()
+            .0;
+
+        // WebRTC reconnect: PeerJoined IPC re-sent with same peer_id/identity,
+        // but NO PeerLeft was sent (slot is still active)
+        ring.notify_peer_joined("peer-a", "identity-alice");
+
+        // Audio resumes from the same peer_id
+        ring.feed_remote("peer-a", 0, 1, vec![0.5f32; 128]);
+        ring.process(&input, &mut output, 32.0);
+
+        let active = ring.active_peer_slots();
+        let slot_after = active.iter()
+            .find(|(_, pid, _)| pid == "peer-a")
+            .unwrap()
+            .0;
+
+        assert_eq!(slot_after, slot_a,
+            "Same peer_id reconnect must stay on the same slot");
+        assert_eq!(active.len(), 1, "Only one peer should be tracked");
+    }
+
+    // --- Tests: reconnect with stale peer (regression for session eviction fix) ---
+
+    /// Without session-side eviction the old peer's slot stays active, blocking
+    /// the reconnecting peer from reclaiming it via affinity.
+    ///
+    /// This documents the bug at the ring level: if `remove_peer` is NOT called
+    /// before the new peer_id arrives, the reconnecting peer ends up on a
+    /// different slot.  The fix in session.rs detects this via identity matching
+    /// and calls `remove_peer` (sending PeerLeft IPC) before `notify_peer_joined`.
+    #[test]
+    fn reconnect_without_eviction_gets_different_slot() {
+        let mut ring = make_ring();
+        let input = vec![0.0f32; 128];
+        let mut output = vec![0.0f32; 128];
+
+        // peer-a joins and is assigned slot 0 via audio
+        ring.notify_peer_joined("peer-a", "identity-alice");
+        ring.process(&input, &mut output, 0.0);
+        ring.feed_remote("peer-a", 0, 0, vec![0.3f32; 128]);
+        ring.process(&input, &mut output, 16.0);
+
+        let slot_a = ring.active_peer_slots()
+            .iter()
+            .find(|(_, pid, _)| pid == "peer-a")
+            .unwrap()
+            .0;
+
+        // Simulate the bug: peer-a-new arrives with the same identity but
+        // remove_peer("peer-a") was never called — the old slot is still active.
+        ring.notify_peer_joined("peer-a-new", "identity-alice");
+        ring.feed_remote("peer-a-new", 0, 1, vec![0.5f32; 128]);
+        ring.process(&input, &mut output, 32.0);
+
+        let active = ring.active_peer_slots();
+        let slot_new = active.iter()
+            .find(|(_, pid, _)| pid == "peer-a-new")
+            .unwrap()
+            .0;
+
+        // Without eviction peer-a-new cannot reclaim peer-a's slot (still active)
+        assert_ne!(slot_new, slot_a,
+            "Without eviction the new peer_id gets a different slot");
+        // Both the stale and the new peer are tracked simultaneously
+        assert_eq!(active.len(), 2);
+    }
+
+    /// With session-side eviction the sequence is: remove_peer(old) →
+    /// notify_peer_joined(new, same identity).  The ring restores the original
+    /// slot via affinity.  This is the behaviour guaranteed by the fix in
+    /// session.rs that calls remove_peer when it detects two peer_ids sharing
+    /// the same identity.
+    #[test]
+    fn eviction_before_reconnect_reclaims_slot() {
+        let mut ring = make_ring();
+        let input = vec![0.0f32; 128];
+        let mut output = vec![0.0f32; 128];
+
+        // peer-a joins and is assigned slot 0
+        ring.notify_peer_joined("peer-a", "identity-alice");
+        ring.process(&input, &mut output, 0.0);
+        ring.feed_remote("peer-a", 0, 0, vec![0.3f32; 128]);
+        ring.process(&input, &mut output, 16.0);
+
+        let slot_a = ring.active_peer_slots()
+            .iter()
+            .find(|(_, pid, _)| pid == "peer-a")
+            .unwrap()
+            .0;
+
+        // Session eviction: PeerLeft IPC → remove_peer; PeerJoined IPC → notify_peer_joined
+        ring.remove_peer("peer-a");
+        ring.notify_peer_joined("peer-a-new", "identity-alice");
+
+        ring.feed_remote("peer-a-new", 0, 1, vec![0.5f32; 128]);
+        ring.process(&input, &mut output, 32.0);
+
+        let active = ring.active_peer_slots();
+        let slot_new = active.iter()
+            .find(|(_, pid, _)| pid == "peer-a-new")
+            .unwrap()
+            .0;
+
+        assert_eq!(slot_new, slot_a,
+            "After eviction the reconnecting peer reclaims its original slot");
+        assert_eq!(active.len(), 1);
+    }
+
+    /// Two peers are active. One peer reconnects with a new peer_id (old slot
+    /// occupied).  The session evicts the stale entry.  The reconnecting peer
+    /// reclaims their original slot; the other peer is unaffected.
+    #[test]
+    fn eviction_with_bystander_peer_unaffected() {
+        let mut ring = make_ring();
+        let input = vec![0.0f32; 128];
+        let mut output = vec![0.0f32; 128];
+
+        ring.notify_peer_joined("peer-a", "identity-alice");
+        ring.notify_peer_joined("peer-b", "identity-bob");
+        ring.process(&input, &mut output, 0.0);
+        ring.feed_remote("peer-a", 0, 0, vec![0.3f32; 128]);
+        ring.feed_remote("peer-b", 0, 0, vec![0.7f32; 128]);
+        ring.process(&input, &mut output, 16.0);
+
+        let slot_a = ring.active_peer_slots()
+            .iter()
+            .find(|(_, pid, _)| pid == "peer-a")
+            .unwrap()
+            .0;
+        let slot_b = ring.active_peer_slots()
+            .iter()
+            .find(|(_, pid, _)| pid == "peer-b")
+            .unwrap()
+            .0;
+        assert_ne!(slot_a, slot_b);
+
+        // Session evicts peer-a (reconnect detected) and registers new peer_id
+        ring.remove_peer("peer-a");
+        ring.notify_peer_joined("peer-a-new", "identity-alice");
+
+        ring.feed_remote("peer-a-new", 0, 1, vec![0.5f32; 128]);
+        ring.feed_remote("peer-b", 0, 1, vec![0.7f32; 128]);
+        ring.process(&input, &mut output, 32.0);
+
+        let active = ring.active_peer_slots();
+        let new_a = active.iter().find(|(_, pid, _)| pid == "peer-a-new").unwrap().0;
+        let new_b = active.iter().find(|(_, pid, _)| pid == "peer-b").unwrap().0;
+
+        assert_eq!(new_a, slot_a, "peer-a-new reclaims peer-a's original slot");
+        assert_eq!(new_b, slot_b, "peer-b is unaffected by peer-a's reconnect");
+    }
 }

--- a/crates/wail-tauri/src/session.rs
+++ b/crates/wail-tauri/src/session.rs
@@ -707,6 +707,64 @@ async fn session_loop(
                         ui_info!(&app, "Hello from {name_display} ({pid})");
                         peer_names.insert(pid.clone(), name.clone());
                         if let Some(ref rid) = remote_identity {
+                            // Evict any stale peer_id that holds this identity.
+                            // This happens when a peer crashes and reconnects with a new peer_id
+                            // before the old connection has been cleaned up — without eviction the
+                            // old slot would still be occupied, forcing the reconnecting peer onto
+                            // a new slot and breaking channel affinity.
+                            let old_pid: Option<String> = peer_identities
+                                .iter()
+                                .find(|(p, ident)| ident.as_str() == rid.as_str() && p.as_str() != pid.as_str())
+                                .map(|(p, _)| p.clone());
+
+                            if let Some(ref old) = old_pid {
+                                ui_info!(&app, "Peer {name_display} reconnected with new peer_id (old={old}, new={pid}) — evicting stale entry");
+
+                                // Notify recv plugins to free the old slot
+                                if !ipc_recv_writers.is_empty() {
+                                    let evict_msg = IpcMessage::encode_peer_left(old);
+                                    let evict_frame = IpcFramer::encode_frame(&evict_msg);
+                                    let mut dead = Vec::new();
+                                    for (id, writer) in &mut ipc_recv_writers {
+                                        if writer.write_all(&evict_frame).await.is_err() {
+                                            dead.push(*id);
+                                        }
+                                    }
+                                    for id in &dead {
+                                        ui_warn!(&app, "Removing failed IPC writer (conn {id})");
+                                    }
+                                    ipc_recv_writers.retain(|(id, _)| !dead.contains(id));
+                                }
+
+                                // Free session-side slots and store affinity for the identity
+                                let old_keys: Vec<(String, u16)> = peer_slots.keys()
+                                    .filter(|(p, _)| p == old)
+                                    .cloned()
+                                    .collect();
+                                for key in old_keys {
+                                    if let Some(slot) = peer_slots.remove(&key) {
+                                        slot_occupied[slot] = false;
+                                        slot_affinity.insert((rid.clone(), key.1), slot);
+                                    }
+                                }
+
+                                // Clean up old peer from all tracking maps
+                                peer_identities.remove(old);
+                                peer_names.remove(old);
+                                hello_sent.remove(old);
+                                peer_reconnect_attempts.remove(old);
+                                peer_last_seen.remove(old);
+                                peer_audio_recv_count.remove(old);
+                                peer_audio_recv_prev.remove(old);
+                                peer_prev_status.remove(old);
+
+                                // Close stale WebRTC connection
+                                mesh.remove_peer(old).await;
+
+                                // Notify UI
+                                let _ = app.emit("peer:left", PeerLeftEvent { peer_id: old.clone() });
+                            }
+
                             peer_identities.insert(pid.clone(), rid.clone());
 
                             // Assign slot for stream 0 (mirror recv plugin's logic for UI labeling)


### PR DESCRIPTION
When a peer crashes and reconnects with a new peer_id before the old WebRTC connection is cleaned up, the stale entry remains in tracking maps, occupying the original channel slot and forcing the reconnecting peer onto a different slot.

This fix detects reconnects by identity matching. When a Hello arrives with an identity already held by a different peer_id, the session evicts the stale entry: sends PeerLeft IPC, frees slots with affinity storage, cleans up all tracking maps, closes the stale connection, and emits a peer:left event. The new peer then reclaims its original slot via the affinity mechanism.

Four new tests document the behavior: same-peer-id reconnect (no eviction), reconnect without eviction (bug case), reconnect with eviction (fix), and eviction with a bystander peer (no side effects).

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>