### PR TITLE
ci: skip CI build on release merges

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   build-macos:
     runs-on: macos-latest
+    if: "!startsWith(github.event.head_commit.message, 'chore: prepare release')"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -81,6 +82,7 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
+    if: "!startsWith(github.event.head_commit.message, 'chore: prepare release')"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -165,6 +167,7 @@ jobs:
 
   build-linux:
     runs-on: ubuntu-22.04
+    if: "!startsWith(github.event.head_commit.message, 'chore: prepare release')"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Skip CI (`build.yml`) jobs when the triggering commit is a release merge. The release workflow (`release.yml`) already builds all platform artifacts, making the simultaneous CI build redundant.

## Changes

Added conditional skip to all three jobs in `.github/workflows/build.yml` (macOS, Windows, Linux):
- Skips when commit message starts with "chore: prepare release"
- Allows all other pushes to `main` to run normally

This eliminates wasted CI minutes on the release merge while preserving full CI validation for all feature/fix merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)