### PR TITLE
docs: update install instructions and add signaling server deploy workflow

### DIFF
--- a/.github/workflows/deploy-signaling.yml
+++ b/.github/workflows/deploy-signaling.yml
@@ -1,0 +1,26 @@
+name: Deploy signaling server
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - val-town/main.ts
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Install vt
+        run: deno install -grAf jsr:@valtown/vt
+
+      - name: Push to Val Town
+        working-directory: val-town
+        env:
+          VAL_TOWN_API_KEY: ${{ secrets.VAL_TOWN_API_KEY }}
+        run: vt push

--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ brew tap MostDistant/wail
 brew install MostDistant/wail/wail
 ```
 
-This builds the WAIL binary and DAW plugins from source. The CLAP and VST3 plugins are automatically installed to `~/Library/Audio/Plug-Ins/` — just rescan plugins in your DAW. Note: the Homebrew install provides the `wail` command-line binary. For the full macOS `.app` bundle (dock icon, menu bar), use the DMG installer above.
+This builds the WAIL binary and DAW plugins from source. After installation, run the plugin installer to copy the CLAP and VST3 bundles into your DAW's plugin directories:
+
+```sh
+wail-install-plugins
+```
+
+Then rescan plugins in your DAW. Note: the Homebrew install provides the `wail` command-line binary. For the full macOS `.app` bundle (dock icon, menu bar), use the DMG installer above.
 
 **Windows** — Run the `.exe` installer. Copy the bundled `.clap` and `.vst3` plugin files to your DAW's plugin directory.
 


### PR DESCRIPTION
## Summary

- Updates README to document the `wail-install-plugins` step required after Homebrew installation
- Adds GitHub Actions workflow to automatically deploy the signaling server to Val Town when `val-town/main.ts` changes on main

The Homebrew install previously claimed plugins were "automatically installed" — this clarifies the actual process and automates server deployments.

🤖 Generated with Claude Code