### PR TITLE
Fix: suppress audio transmission and warn when Link has no peers

### DIFF
--- a/.changeset/skip-audio-no-link-peers.md
+++ b/.changeset/skip-audio-no-link-peers.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Suppress audio transmission and show a UI warning when Ableton Link has no peers (Link Peers = 0). Without Link running in a DAW, interval boundaries are unsynchronized and transmitting audio serves no purpose.

--- a/crates/wail-tauri/src/session.rs
+++ b/crates/wail-tauri/src/session.rs
@@ -197,6 +197,9 @@ async fn session_loop(
     let mut beat_synced = false;
     let mut audio_gate = AudioSendGate::new();
 
+    // Link peer count — updated every status tick; used to gate audio when Link is not running
+    let mut link_peers: u64 = 0;
+
     // Audio interval stats
     let mut audio_intervals_sent: u64 = 0;
     let mut audio_intervals_received: u64 = 0;
@@ -414,7 +417,7 @@ async fn session_loop(
                     if let Some(ref rec) = recorder {
                         rec.record_own(wire_data.clone());
                     }
-                    if audio_gate.is_gated() {
+                    if audio_gate.is_gated() || link_peers == 0 {
                         continue;
                     }
                     mesh.broadcast_audio(&wire_data).await;
@@ -959,6 +962,7 @@ async fn session_loop(
                     // Update snapshots for next tick
                     peers.flush_audio_recv_prev();
                     audio_intervals_sent_prev = audio_intervals_sent;
+                    link_peers = state.num_peers;
 
                     let _ = app.emit("status:update", StatusUpdate {
                         bpm: state.bpm,

--- a/crates/wail-tauri/ui/index.html
+++ b/crates/wail-tauri/ui/index.html
@@ -146,6 +146,10 @@
       <span id="session-link-peers">0</span>
     </div>
 
+    <div id="link-no-peers-warning" class="warning" style="display:none">
+      Start Ableton Link in your DAW — audio is not being transmitted
+    </div>
+
     <div class="stat-group">
       <label>Peers</label>
       <div id="peer-list" class="peer-list">

--- a/crates/wail-tauri/ui/main.js
+++ b/crates/wail-tauri/ui/main.js
@@ -430,6 +430,8 @@ async function setupListeners() {
       bpmInput.value = s.bpm.toFixed(1);
     }
     document.getElementById('session-link-peers').textContent = s.link_peers;
+    document.getElementById('link-no-peers-warning').style.display =
+      (s.link_peers === 0 && s.plugin_connected) ? '' : 'none';
     document.getElementById('session-audio').textContent =
       `${s.audio_sent} sent / ${s.audio_recv} recv`;
     document.getElementById('session-audio-bytes').textContent =

--- a/crates/wail-tauri/ui/style.css
+++ b/crates/wail-tauri/ui/style.css
@@ -6,6 +6,7 @@
   --accent: #0f3460;
   --accent-bright: #4e9af1;
   --error: #e74c3c;
+  --warn: #f39c12;
   --success: #2ecc71;
   --border: #2a2a4a;
   --radius: 6px;
@@ -300,6 +301,17 @@ summary {
   border: 1px solid var(--error);
   border-radius: var(--radius);
   color: var(--error);
+  font-size: 12px;
+}
+
+/* Warning */
+.warning {
+  margin-top: 12px;
+  padding: 8px 10px;
+  background: rgba(243, 156, 18, 0.15);
+  border: 1px solid var(--warn);
+  border-radius: var(--radius);
+  color: var(--warn);
   font-size: 12px;
 }
 


### PR DESCRIPTION
## Summary
Prevents audio transmission and displays a UI warning when Ableton Link has no connected peers (Link Peers = 0). Without Link running in a DAW, NINJAM-style interval boundaries are unsynchronized, making audio transmission meaningless.

## Changes
- **Backend**: Track `link_peers` count locally in the session loop and guard audio transmission when `link_peers == 0`
- **UI**: Add amber warning banner below Link Peers stat directing users to "Start Ableton Link in your DAW — audio is not being transmitted"
- **Changeset**: Patch-level bump for the fix

## Testing
- Verified audio suppression when `link_peers == 0`
- Verified warning displays only when plugin is connected and Link has no peers
- Verified audio resumes when Link peer count increases

🤖 Generated with [Claude Code](https://claude.com/claude-code)