### PR TITLE
fix: add error logging for buffer return channel failures

### DIFF
--- a/.changeset/buffer-return-channel.md
+++ b/.changeset/buffer-return-channel.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Eliminate audio-thread buffer allocation via a return channel between the IPC encoding thread and IntervalRing. After warmup (2-3 intervals), the audio thread becomes completely allocation-free.

--- a/crates/wail-plugin-send/src/lib.rs
+++ b/crates/wail-plugin-send/src/lib.rs
@@ -399,7 +399,9 @@ fn ipc_thread_send(
 
                     // Return the buffer to the audio thread for reuse
                     samples.clear();
-                    let _ = buf_return_tx.try_send(samples);
+                    if let Err(e) = buf_return_tx.try_send(samples) {
+                        tracing::warn!("Buffer return failed: {e}");
+                    }
 
                     if write_failed {
                         break;


### PR DESCRIPTION
Address CLAUDE.md error handling requirements by logging at warn! level when the buffer return channel fails to send. Improves observability for the zero-allocation buffer rotation mechanism.

Also adds changeset file to satisfy versioning and release requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)