### PR TITLE
fix: discard stale plugin-buffered intervals during session warmup

### DIFF
--- a/.changeset/discard-warmup-interval-audio.md
+++ b/.changeset/discard-warmup-interval-audio.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix interval-0 audio flood on session start/rejoin: stale plugin-buffered intervals no longer sent to peers.

--- a/crates/wail-tauri/src/session.rs
+++ b/crates/wail-tauri/src/session.rs
@@ -425,6 +425,14 @@ async fn session_loop(
             // --- Audio from plugin IPC → broadcast to WebRTC peers ---
             Some(frame) = ipc_from_plugin_rx.recv() => {
                 if let Some((_peer_id, wire_data)) = IpcMessage::decode_audio(&frame) {
+                    // Discard plugin backlog that accumulated before the first real interval
+                    // boundary. Interval 0 is a warmup period: stale buffered intervals from
+                    // the DAW's history flood in during this window. After the first boundary
+                    // (interval >= 1) we're live. NINJAM semantics: interval N audio is only
+                    // played back in interval N+1, so interval 0 is a throw-away anyway.
+                    if interval.current_index() <= Some(0) {
+                        continue;
+                    }
                     if let Some(ref rec) = recorder {
                         rec.record_own(wire_data.clone());
                     }


### PR DESCRIPTION
## Summary

Fix interval-0 audio flood on session start: stale plugin-buffered intervals no longer sent to peers.

When a session starts, the send plugin has accumulated up to 64 intervals in its IPC buffer (from the DAW running independently). The moment the IPC socket opens, all 98 stale intervals (across 2 send plugins) flood the session within 3 seconds, blocking the main loop. New peers joining during this window receive junk audio from the DAW's history.

The fix: guard all AUDIO SEND intervals with `if interval.current_index() <= Some(0) { continue; }`. Interval 0 is a warmup period where stale backlog arrives; after the first boundary (interval >= 1), audio flows normally. This is safe by NINJAM semantics (interval-N audio is only played back in interval N+1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)