### PR TITLE
fix: set SO_REUSEADDR on IPC listener to allow rapid reconnects

### DIFF
--- a/.changeset/fix-ipc-reuseaddr.md
+++ b/.changeset/fix-ipc-reuseaddr.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix Windows reconnect error "Only one usage of each socket address" (os error 10048) by setting SO_REUSEADDR on the IPC TCP listener before binding.

--- a/crates/wail-tauri/src/session.rs
+++ b/crates/wail-tauri/src/session.rs
@@ -237,8 +237,13 @@ async fn session_loop(
         ui_info!(&app, "Test tone ENABLED — will generate sine tones at interval boundaries");
     }
 
-    // IPC: listen for plugin connections
-    let ipc_listener = tokio::net::TcpListener::bind(("127.0.0.1", ipc_port)).await?;
+    // IPC: listen for plugin connections.
+    // Use TcpSocket builder to set SO_REUSEADDR before binding, so that reconnecting
+    // quickly after a disconnect doesn't fail with WSAEADDRINUSE (os error 10048) on Windows.
+    let tcp_socket = tokio::net::TcpSocket::new_v4()?;
+    tcp_socket.set_reuseaddr(true)?;
+    tcp_socket.bind(std::net::SocketAddr::from(([127, 0, 0, 1], ipc_port)))?;
+    let ipc_listener = tcp_socket.listen(128)?;
     ui_info!(&app, "IPC listening on port {ipc_port}");
 
     let mut ipc_pool = IpcWriterPool::new();


### PR DESCRIPTION
## Summary

Fix Windows WSAEADDRINUSE (os error 10048) crash when reconnecting quickly after a session disconnect. The IPC TCP listener now uses `TcpSocket::set_reuseaddr()` before binding to allow port 9191 reuse, matching standard server socket behavior.

## Changes

- `crates/wail-tauri/src/session.rs:241` — Replace plain `TcpListener::bind()` with a `TcpSocket` builder that sets `SO_REUSEADDR = true`
- `.changeset/fix-ipc-reuseaddr.md` — Patch release changeset

## Verification

- Build: `cargo build -p wail-tauri` ✅
- Windows: Reconnect immediately after disconnect — no more "Session error: Only one usage of each socket address"
- macOS/Linux: No behavior change (SO_REUSEADDR is already the default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)