### PR TITLE
Add audio diagnostics and fix interval config reset

### DIFF
--- a/.changeset/fix-interval-config-reset.md
+++ b/.changeset/fix-interval-config-reset.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix IntervalTracker::set_config to only reset interval tracking when bars or quantum actually change. Previously, receiving a redundant IntervalConfig message (same values) would reset the tracker, briefly re-activating the warmup guard and potentially dropping outgoing audio. Also adds diagnostic logging at interval boundary swaps to help diagnose audio gap issues.

--- a/crates/wail-audio/src/ring.rs
+++ b/crates/wail-audio/src/ring.rs
@@ -518,6 +518,7 @@ impl IntervalRing {
 
         // Take pending_remote, drain it (preserving capacity), then put it back.
         let mut pending = std::mem::take(&mut self.pending_remote);
+        let pending_count = pending.len();
         for mut remote in pending.drain(..) {
             // Assign slot FIRST so we can check needs_fade_in before summing
             let slot_assignment = self.assign_peer_slot(&remote.peer_id, remote.stream_id);
@@ -593,6 +594,22 @@ impl IntervalRing {
         }
         // Put the drained (empty but with capacity) Vec back
         self.pending_remote = pending;
+
+        // Diagnostic: log boundary swap details to identify gap root cause
+        let active_peers: Vec<_> = self.peer_slots.iter()
+            .filter(|s| s.active)
+            .map(|s| {
+                let tail_nonzero = s.crossfade_tail.iter().any(|&v| v != 0.0);
+                format!("{}:{} len={} tail={}", s.peer_id, s.stream_id, s.samples.len(), if tail_nonzero { "audio" } else { "zero" })
+            })
+            .collect();
+        tracing::info!(
+            completed_index = completed_index,
+            pending_count = pending_count,
+            playback_len = self.playback_len,
+            peers = ?active_peers,
+            "INTERVAL SWAP"
+        );
     }
 }
 

--- a/crates/wail-core/src/interval.rs
+++ b/crates/wail-core/src/interval.rs
@@ -59,9 +59,13 @@ impl IntervalTracker {
     }
 
     pub fn set_config(&mut self, bars: u32, quantum: f64) {
-        self.bars = bars.max(1);
-        self.quantum = quantum.max(f64::EPSILON);
-        self.last_interval_index = None; // reset
+        let new_bars = bars.max(1);
+        let new_quantum = quantum.max(f64::EPSILON);
+        if new_bars != self.bars || (new_quantum - self.quantum).abs() > f64::EPSILON {
+            self.bars = new_bars;
+            self.quantum = new_quantum;
+            self.last_interval_index = None; // reset only on actual change
+        }
     }
 
     /// Adopt a remote interval index (NINJAM-style ground-truth sync).
@@ -124,6 +128,29 @@ mod tests {
             // Must not undo the sync
             assert_eq!(tracker.current_index(), Some(2));
         }
+    }
+
+    #[test]
+    fn set_config_does_not_reset_when_values_unchanged() {
+        let mut tracker = IntervalTracker::new(4, 4.0);
+        tracker.update(0.0); // sets last_interval_index = Some(0)
+        assert_eq!(tracker.current_index(), Some(0));
+
+        // Call set_config with same values — should NOT reset
+        tracker.set_config(4, 4.0);
+        assert_eq!(
+            tracker.current_index(),
+            Some(0),
+            "set_config with same values must not reset last_interval_index"
+        );
+
+        // Call set_config with different values — SHOULD reset
+        tracker.set_config(2, 4.0);
+        assert_eq!(
+            tracker.current_index(),
+            None,
+            "set_config with new bars must reset last_interval_index"
+        );
     }
 
     #[test]

--- a/crates/wail-plugin-recv/src/lib.rs
+++ b/crates/wail-plugin-recv/src/lib.rs
@@ -272,6 +272,18 @@ impl Plugin for WailRecvPlugin {
         };
         self.cumulative_samples += num_samples as u64;
 
+        // Sampled diagnostic: log beat position every ~2 seconds (96000 samples at 48kHz)
+        if self.cumulative_samples % 96000 < num_samples as u64 {
+            let interval_index = (beat_position / (DEFAULT_BARS as f64 * DEFAULT_QUANTUM)).floor() as i64;
+            tracing::debug!(
+                beat = format!("{:.2}", beat_position),
+                bpm = format!("{:.1}", bpm),
+                interval = interval_index,
+                playing = transport.playing,
+                "RECV beat"
+            );
+        }
+
         if let Ok(mut bridge_guard) = self.bridge.try_lock() {
             if let Some(ref mut bridge) = *bridge_guard {
                 bridge.update_config(


### PR DESCRIPTION
## Summary

- Fix `IntervalTracker::set_config` to only reset interval tracking when bars or quantum values actually change
- Add diagnostic logging at interval boundary swaps to pinpoint audio gap root cause
- Add sampled beat position logging in recv plugin for timing verification
- Previously, redundant `IntervalConfig` messages would spuriously reset the tracker, briefly re-activating the warmup guard

The diagnostics will help identify whether the recurring audio gaps reported in live sessions are from missing intervals, short audio, or timing mismatches.

## Test plan

- All existing unit tests pass
- New test: `set_config_does_not_reset_when_values_unchanged` verifies the config fix
- Deploy build and reproduce live session with Jeff to examine `INTERVAL SWAP` and `RECV beat` logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)