### PR TITLE
feat: NINJAM-style streaming audio

### DIFF
--- a/.changeset/streaming-audio.md
+++ b/.changeset/streaming-audio.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+NINJAM-style streaming audio: encode and transmit Opus frames every 20ms during the interval instead of batching the entire interval at the boundary. Receivers buffer frames progressively, improving delivery reliability and enabling shorter interval lengths on high-latency connections.

--- a/crates/wail-audio/src/bridge.rs
+++ b/crates/wail-audio/src/bridge.rs
@@ -216,6 +216,12 @@ impl AudioBridge {
     pub fn bitrate_kbps(&self) -> u32 {
         self.bitrate_kbps
     }
+
+    /// Return the current interval index (from the ring buffer's beat tracking).
+    /// Returns 0 if no interval has started yet.
+    pub fn current_interval_index(&self) -> i64 {
+        self.ring.current_interval().unwrap_or(0)
+    }
 }
 
 #[cfg(test)]

--- a/crates/wail-audio/src/codec.rs
+++ b/crates/wail-audio/src/codec.rs
@@ -107,6 +107,32 @@ impl AudioEncoder {
         Ok(output)
     }
 
+    /// Encode a single 20ms frame of interleaved f32 audio into raw Opus bytes.
+    ///
+    /// Input: interleaved f32 samples for one frame (frame_size * channels samples).
+    /// Zero-pads if the input is shorter than one full frame.
+    /// Returns raw Opus packet bytes (no length prefix).
+    pub fn encode_frame(&mut self, samples: &[f32]) -> Result<Vec<u8>> {
+        let ch = self.channels as usize;
+        let frame_samples = self.frame_size * ch;
+
+        let padded;
+        let frame = if samples.len() < frame_samples {
+            padded = {
+                let mut p = samples.to_vec();
+                p.resize(frame_samples, 0.0);
+                p
+            };
+            &padded
+        } else {
+            &samples[..frame_samples]
+        };
+
+        let mut opus_buf = vec![0u8; 4000];
+        let encoded_len = self.encoder.encode_float(frame, &mut opus_buf)?;
+        Ok(opus_buf[..encoded_len].to_vec())
+    }
+
     pub fn sample_rate(&self) -> u32 {
         self.sample_rate
     }
@@ -259,6 +285,46 @@ mod tests {
 
         // Should decode to at least one frame (960 samples at 48kHz/20ms)
         assert!(decoded.len() >= 960);
+    }
+
+    #[test]
+    fn encode_frame_roundtrip() {
+        let sample_rate = 48000;
+        let channels = 2;
+        let mut encoder = AudioEncoder::new(sample_rate, channels, 128).unwrap();
+        let mut decoder = AudioDecoder::new(sample_rate, channels).unwrap();
+
+        let frame_size = encoder.frame_size(); // 960 for 48kHz
+        let frame_samples = frame_size * channels as usize;
+
+        // Generate one 20ms frame of sine wave
+        let samples: Vec<f32> = (0..frame_samples)
+            .map(|i| {
+                let t = (i / channels as usize) as f32 / sample_rate as f32;
+                (t * 440.0 * 2.0 * std::f32::consts::PI).sin() * 0.5
+            })
+            .collect();
+
+        let opus_bytes = encoder.encode_frame(&samples).unwrap();
+        assert!(!opus_bytes.is_empty());
+        assert!(opus_bytes.len() < 4000);
+
+        // Decode single frame
+        let opus_packet = Packet::try_from(opus_bytes.as_slice()).unwrap();
+        let mut decode_buf = vec![0f32; frame_samples];
+        let mut_signals = MutSignals::try_from(decode_buf.as_mut_slice()).unwrap();
+        let decoded = decoder.decoder.decode_float(Some(opus_packet), mut_signals, false).unwrap();
+        assert_eq!(decoded, frame_size);
+    }
+
+    #[test]
+    fn encode_frame_zero_pads_short_input() {
+        let mut encoder = AudioEncoder::new(48000, 1, 64).unwrap();
+
+        // Short input (less than one frame)
+        let samples = vec![0.5f32; 100];
+        let opus_bytes = encoder.encode_frame(&samples).unwrap();
+        assert!(!opus_bytes.is_empty());
     }
 
     #[test]

--- a/crates/wail-audio/src/interval.rs
+++ b/crates/wail-audio/src/interval.rs
@@ -21,6 +21,28 @@ pub struct AudioInterval {
     pub bars: u32,
 }
 
+/// A single 20ms Opus frame for streaming transmission during an interval.
+///
+/// Unlike `AudioInterval` (which contains an entire interval's worth of encoded audio),
+/// an `AudioFrame` represents one 20ms chunk that can be sent immediately as it's recorded.
+/// The final frame of an interval carries metadata needed to reconstruct the full interval
+/// on the receiver side.
+#[derive(Debug, Clone)]
+pub struct AudioFrame {
+    pub interval_index: i64,
+    pub stream_id: u16,
+    pub frame_number: u32,
+    pub channels: u16,
+    pub opus_data: Vec<u8>,
+    pub is_final: bool,
+    // Metadata — only meaningful when is_final is true:
+    pub sample_rate: u32,
+    pub total_frames: u32,
+    pub bpm: f64,
+    pub quantum: f64,
+    pub bars: u32,
+}
+
 /// Records audio samples into intervals, triggering encoding at interval boundaries.
 ///
 /// Usage in an audio processing callback:

--- a/crates/wail-audio/src/ipc.rs
+++ b/crates/wail-audio/src/ipc.rs
@@ -96,6 +96,7 @@ const IPC_TAG_AUDIO: u8 = 0x01;
 const IPC_TAG_PEER_JOINED: u8 = 0x02;
 const IPC_TAG_PEER_LEFT: u8 = 0x03;
 const IPC_TAG_PEER_NAME: u8 = 0x04;
+const IPC_TAG_AUDIO_FRAME: u8 = 0x05;
 
 /// IPC message encoding for Plugin ↔ App communication.
 ///
@@ -227,6 +228,25 @@ impl IpcMessage {
         Some((peer_id, display_name))
     }
 
+    /// Encode a streaming audio frame message (no peer_id — send plugin only).
+    pub fn encode_audio_frame(wire_data: &[u8]) -> Vec<u8> {
+        let mut msg = Vec::with_capacity(1 + wire_data.len());
+        msg.push(IPC_TAG_AUDIO_FRAME);
+        msg.extend_from_slice(wire_data);
+        msg
+    }
+
+    /// Decode a streaming audio frame message. Returns the AudioFrameWire bytes.
+    pub fn decode_audio_frame(payload: &[u8]) -> Option<Vec<u8>> {
+        if payload.len() < 2 {
+            return None;
+        }
+        if payload[0] != IPC_TAG_AUDIO_FRAME {
+            return None;
+        }
+        Some(payload[1..].to_vec())
+    }
+
     /// Get the tag byte from a payload, if any.
     pub fn tag(payload: &[u8]) -> Option<u8> {
         payload.first().copied()
@@ -238,6 +258,7 @@ pub const IPC_TAG_AUDIO_PUB: u8 = IPC_TAG_AUDIO;
 pub const IPC_TAG_PEER_JOINED_PUB: u8 = IPC_TAG_PEER_JOINED;
 pub const IPC_TAG_PEER_LEFT_PUB: u8 = IPC_TAG_PEER_LEFT;
 pub const IPC_TAG_PEER_NAME_PUB: u8 = IPC_TAG_PEER_NAME;
+pub const IPC_TAG_AUDIO_FRAME_PUB: u8 = IPC_TAG_AUDIO_FRAME;
 
 #[cfg(test)]
 mod tests {
@@ -528,5 +549,34 @@ mod tests {
     fn peer_name_rejects_truncated() {
         assert!(IpcMessage::decode_peer_name(&[]).is_none());
         assert!(IpcMessage::decode_peer_name(&[IPC_TAG_PEER_NAME]).is_none());
+    }
+
+    // --- Audio frame messages ---
+
+    #[test]
+    fn audio_frame_roundtrip() {
+        let wire_data = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let encoded = IpcMessage::encode_audio_frame(&wire_data);
+        assert_eq!(encoded[0], IPC_TAG_AUDIO_FRAME);
+
+        let decoded = IpcMessage::decode_audio_frame(&encoded).unwrap();
+        assert_eq!(decoded, wire_data);
+    }
+
+    #[test]
+    fn audio_frame_rejects_wrong_tag() {
+        let encoded = IpcMessage::encode_audio("peer-1", &[0xAA]);
+        assert!(IpcMessage::decode_audio_frame(&encoded).is_none());
+    }
+
+    #[test]
+    fn audio_frame_rejects_short() {
+        assert!(IpcMessage::decode_audio_frame(&[]).is_none());
+        assert!(IpcMessage::decode_audio_frame(&[IPC_TAG_AUDIO_FRAME]).is_none());
+    }
+
+    #[test]
+    fn audio_frame_tag_constant() {
+        assert_eq!(IPC_TAG_AUDIO_FRAME_PUB, 0x05);
     }
 }

--- a/crates/wail-audio/src/lib.rs
+++ b/crates/wail-audio/src/lib.rs
@@ -11,8 +11,8 @@ mod pipeline;
 
 pub use bridge::AudioBridge;
 pub use codec::{nearest_opus_rate, AudioDecoder, AudioEncoder};
-pub use interval::{AudioInterval, IntervalRecorder};
-pub use ipc::{IpcFramer, IpcMessage, IpcRecvBuffer, IPC_ROLE_RECV, IPC_ROLE_SEND, IPC_TAG_AUDIO_PUB, IPC_TAG_PEER_JOINED_PUB, IPC_TAG_PEER_LEFT_PUB, IPC_TAG_PEER_NAME_PUB};
+pub use interval::{AudioFrame, AudioInterval, IntervalRecorder};
+pub use ipc::{IpcFramer, IpcMessage, IpcRecvBuffer, IPC_ROLE_RECV, IPC_ROLE_SEND, IPC_TAG_AUDIO_FRAME_PUB, IPC_TAG_AUDIO_PUB, IPC_TAG_PEER_JOINED_PUB, IPC_TAG_PEER_LEFT_PUB, IPC_TAG_PEER_NAME_PUB};
 pub use ring::{CompletedInterval, IntervalRing, PeerSlot, MAX_REMOTE_PEERS};
 pub use slot::{ClientChannelMapping, SlotTable};
-pub use wire::AudioWire;
+pub use wire::{AudioFrameWire, AudioWire};

--- a/crates/wail-audio/src/ring.rs
+++ b/crates/wail-audio/src/ring.rs
@@ -495,13 +495,16 @@ impl IntervalRing {
         // the head of the new interval to prevent clicks at interval boundaries.
         for slot in &mut self.peer_slots {
             if slot.active && !slot.samples.is_empty() {
+                // Capture the last XFADE_SAMPLES of the outgoing interval, left-aligned.
+                // The crossfade loop reads tail[0..fade_len], so the captured audio must
+                // start at index 0.
                 let src_len = slot.samples.len().min(XFADE_SAMPLES);
                 let src_start = slot.samples.len() - src_len;
-                let dst_start = XFADE_SAMPLES - src_len;
-                slot.crossfade_tail[..dst_start].fill(0.0);
                 for j in 0..src_len {
-                    slot.crossfade_tail[dst_start + j] = slot.samples[src_start + j];
+                    slot.crossfade_tail[j] = slot.samples[src_start + j];
                 }
+                // Zero the remainder (if the interval was shorter than XFADE_SAMPLES)
+                slot.crossfade_tail[src_len..].fill(0.0);
             }
             // Inactive or empty slots: crossfade_tail stays zero → fade from silence
         }

--- a/crates/wail-audio/src/wire.rs
+++ b/crates/wail-audio/src/wire.rs
@@ -25,6 +25,13 @@ const MAGIC: &[u8; 4] = b"WAIL";
 const VERSION: u8 = 2;
 const HEADER_SIZE: usize = 48;
 
+const FRAME_MAGIC: &[u8; 4] = b"WAIF";
+const FRAME_HEADER_SIZE: usize = 21; // 4+1+2+8+4+2
+const FRAME_FINAL_EXTRA: usize = 28; // 4+4+8+8+4
+
+const FRAME_FLAG_STEREO: u8 = 0x01;
+const FRAME_FLAG_FINAL: u8 = 0x02;
+
 impl AudioWire {
     /// Serialize an AudioInterval into the binary wire format.
     pub fn encode(interval: &super::AudioInterval) -> Vec<u8> {
@@ -127,6 +134,128 @@ impl AudioWire {
             sample_rate,
             channels,
             num_frames,
+            bpm,
+            quantum,
+            bars,
+        })
+    }
+}
+
+/// Binary wire format for streaming audio frames over WebRTC DataChannels.
+///
+/// Each frame carries a single 20ms Opus packet. The final frame of an
+/// interval includes metadata so the receiver can reconstruct an AudioInterval.
+///
+/// Format (all integers are little-endian):
+/// ```text
+/// [4 bytes] magic: "WAIF"
+/// [1 byte]  flags: bit 0 = stereo, bit 1 = final (last frame of interval)
+/// [2 bytes] stream_id: u16
+/// [8 bytes] interval_index: i64
+/// [4 bytes] frame_number: u32  (0-indexed within interval)
+/// [2 bytes] opus_len: u16
+/// [N bytes] opus_data
+///
+/// If final flag set, append:
+/// [4 bytes] sample_rate: u32
+/// [4 bytes] total_frames: u32
+/// [8 bytes] bpm: f64
+/// [8 bytes] quantum: f64
+/// [4 bytes] bars: u32
+/// ```
+pub struct AudioFrameWire;
+
+impl AudioFrameWire {
+    pub fn encode(frame: &super::AudioFrame) -> Vec<u8> {
+        let extra = if frame.is_final { FRAME_FINAL_EXTRA } else { 0 };
+        let mut buf = Vec::with_capacity(FRAME_HEADER_SIZE + frame.opus_data.len() + extra);
+
+        buf.extend_from_slice(FRAME_MAGIC);
+
+        let mut flags: u8 = 0;
+        if frame.channels == 2 {
+            flags |= FRAME_FLAG_STEREO;
+        }
+        if frame.is_final {
+            flags |= FRAME_FLAG_FINAL;
+        }
+        buf.push(flags);
+
+        buf.extend_from_slice(&frame.stream_id.to_le_bytes());
+        buf.extend_from_slice(&frame.interval_index.to_le_bytes());
+        buf.extend_from_slice(&frame.frame_number.to_le_bytes());
+        buf.extend_from_slice(&(frame.opus_data.len() as u16).to_le_bytes());
+        buf.extend_from_slice(&frame.opus_data);
+
+        if frame.is_final {
+            buf.extend_from_slice(&frame.sample_rate.to_le_bytes());
+            buf.extend_from_slice(&frame.total_frames.to_le_bytes());
+            buf.extend_from_slice(&frame.bpm.to_le_bytes());
+            buf.extend_from_slice(&frame.quantum.to_le_bytes());
+            buf.extend_from_slice(&frame.bars.to_le_bytes());
+        }
+
+        buf
+    }
+
+    pub fn decode(data: &[u8]) -> Result<super::AudioFrame> {
+        if data.len() < FRAME_HEADER_SIZE {
+            anyhow::bail!(
+                "Audio frame wire data too short: {} bytes, need at least {FRAME_HEADER_SIZE}",
+                data.len()
+            );
+        }
+
+        if &data[0..4] != FRAME_MAGIC {
+            anyhow::bail!("Invalid audio frame wire magic: {:?}", &data[0..4]);
+        }
+
+        let flags = data[4];
+        let channels = if flags & FRAME_FLAG_STEREO != 0 { 2 } else { 1 };
+        let is_final = flags & FRAME_FLAG_FINAL != 0;
+
+        let stream_id = u16::from_le_bytes(data[5..7].try_into()?);
+        let interval_index = i64::from_le_bytes(data[7..15].try_into()?);
+        let frame_number = u32::from_le_bytes(data[15..19].try_into()?);
+        let opus_len = u16::from_le_bytes(data[19..21].try_into()?) as usize;
+
+        if data.len() < FRAME_HEADER_SIZE + opus_len {
+            anyhow::bail!(
+                "Audio frame wire truncated: expected {} opus bytes, got {}",
+                opus_len,
+                data.len() - FRAME_HEADER_SIZE
+            );
+        }
+
+        let opus_data = data[FRAME_HEADER_SIZE..FRAME_HEADER_SIZE + opus_len].to_vec();
+
+        let (sample_rate, total_frames, bpm, quantum, bars) = if is_final {
+            let meta_start = FRAME_HEADER_SIZE + opus_len;
+            if data.len() < meta_start + FRAME_FINAL_EXTRA {
+                anyhow::bail!(
+                    "Audio frame final metadata truncated: need {} more bytes",
+                    meta_start + FRAME_FINAL_EXTRA - data.len()
+                );
+            }
+            let sr = u32::from_le_bytes(data[meta_start..meta_start + 4].try_into()?);
+            let tf = u32::from_le_bytes(data[meta_start + 4..meta_start + 8].try_into()?);
+            let b = f64::from_le_bytes(data[meta_start + 8..meta_start + 16].try_into()?);
+            let q = f64::from_le_bytes(data[meta_start + 16..meta_start + 24].try_into()?);
+            let bars = u32::from_le_bytes(data[meta_start + 24..meta_start + 28].try_into()?);
+            (sr, tf, b, q, bars)
+        } else {
+            (0, 0, 0.0, 0.0, 0)
+        };
+
+        Ok(super::AudioFrame {
+            interval_index,
+            stream_id,
+            frame_number,
+            channels,
+            opus_data,
+            is_final,
+            sample_rate,
+            total_frames,
             bpm,
             quantum,
             bars,
@@ -323,5 +452,106 @@ mod tests {
         assert_eq!(decoded.stream_id, u16::MAX);
         assert_eq!(decoded.num_frames, large_num_frames);
         assert_eq!(decoded.opus_data, opus_data);
+    }
+
+    // --- AudioFrameWire tests ---
+
+    #[test]
+    fn frame_wire_non_final_roundtrip() {
+        let frame = crate::AudioFrame {
+            interval_index: 42,
+            stream_id: 3,
+            frame_number: 7,
+            channels: 2,
+            opus_data: vec![0xDE, 0xAD, 0xBE, 0xEF],
+            is_final: false,
+            sample_rate: 0,
+            total_frames: 0,
+            bpm: 0.0,
+            quantum: 0.0,
+            bars: 0,
+        };
+
+        let encoded = AudioFrameWire::encode(&frame);
+        assert_eq!(&encoded[0..4], b"WAIF");
+        assert_eq!(encoded[4], FRAME_FLAG_STEREO); // stereo, not final
+        // Total: 21 header + 4 opus = 25 bytes
+        assert_eq!(encoded.len(), 25);
+
+        let decoded = AudioFrameWire::decode(&encoded).unwrap();
+        assert_eq!(decoded.interval_index, 42);
+        assert_eq!(decoded.stream_id, 3);
+        assert_eq!(decoded.frame_number, 7);
+        assert_eq!(decoded.channels, 2);
+        assert_eq!(decoded.opus_data, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+        assert!(!decoded.is_final);
+    }
+
+    #[test]
+    fn frame_wire_final_roundtrip() {
+        let frame = crate::AudioFrame {
+            interval_index: 10,
+            stream_id: 0,
+            frame_number: 399,
+            channels: 1,
+            opus_data: vec![0xAB],
+            is_final: true,
+            sample_rate: 48000,
+            total_frames: 400,
+            bpm: 120.0,
+            quantum: 4.0,
+            bars: 4,
+        };
+
+        let encoded = AudioFrameWire::encode(&frame);
+        assert_eq!(&encoded[0..4], b"WAIF");
+        assert_eq!(encoded[4], FRAME_FLAG_FINAL); // mono + final
+        // Total: 21 header + 1 opus + 28 final metadata = 50
+        assert_eq!(encoded.len(), 50);
+
+        let decoded = AudioFrameWire::decode(&encoded).unwrap();
+        assert_eq!(decoded.interval_index, 10);
+        assert_eq!(decoded.frame_number, 399);
+        assert_eq!(decoded.channels, 1);
+        assert!(decoded.is_final);
+        assert_eq!(decoded.sample_rate, 48000);
+        assert_eq!(decoded.total_frames, 400);
+        assert!((decoded.bpm - 120.0).abs() < f64::EPSILON);
+        assert!((decoded.quantum - 4.0).abs() < f64::EPSILON);
+        assert_eq!(decoded.bars, 4);
+    }
+
+    #[test]
+    fn frame_wire_rejects_bad_magic() {
+        let mut data = vec![0u8; 25];
+        data[0..4].copy_from_slice(b"NOPE");
+        assert!(AudioFrameWire::decode(&data).is_err());
+    }
+
+    #[test]
+    fn frame_wire_rejects_truncated() {
+        assert!(AudioFrameWire::decode(&[0u8; 10]).is_err());
+    }
+
+    #[test]
+    fn frame_wire_rejects_truncated_final_metadata() {
+        let frame = crate::AudioFrame {
+            interval_index: 0,
+            stream_id: 0,
+            frame_number: 0,
+            channels: 1,
+            opus_data: vec![0xAB],
+            is_final: true,
+            sample_rate: 48000,
+            total_frames: 1,
+            bpm: 120.0,
+            quantum: 4.0,
+            bars: 4,
+        };
+
+        let mut encoded = AudioFrameWire::encode(&frame);
+        // Truncate the final metadata
+        encoded.truncate(encoded.len() - 10);
+        assert!(AudioFrameWire::decode(&encoded).is_err());
     }
 }

--- a/crates/wail-plugin-recv/src/lib.rs
+++ b/crates/wail-plugin-recv/src/lib.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::io::{Read as _, Write as _};
 use std::net::TcpStream;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -12,9 +13,9 @@ mod params;
 
 use params::WailRecvParams;
 use wail_audio::{
-    nearest_opus_rate, AudioBridge, AudioDecoder, AudioWire, IpcMessage, IpcRecvBuffer,
-    IPC_ROLE_RECV, IPC_TAG_AUDIO_PUB, IPC_TAG_PEER_JOINED_PUB, IPC_TAG_PEER_LEFT_PUB,
-    IPC_TAG_PEER_NAME_PUB,
+    nearest_opus_rate, AudioBridge, AudioDecoder, AudioFrameWire, IpcMessage,
+    IpcRecvBuffer, IPC_ROLE_RECV, IPC_TAG_AUDIO_PUB, IPC_TAG_PEER_JOINED_PUB,
+    IPC_TAG_PEER_LEFT_PUB, IPC_TAG_PEER_NAME_PUB,
 };
 
 /// Peer lifecycle events sent from IPC thread to audio thread.
@@ -44,6 +45,8 @@ pub struct WailRecvPlugin {
     ipc_incoming_rx: Option<Receiver<(String, u16, i64, Vec<f32>)>>,
     /// Peer lifecycle events from IPC thread (for slot affinity)
     peer_event_rx: Option<Receiver<PeerEvent>>,
+    /// Shutdown flag for the IPC thread (set on re-initialization)
+    ipc_shutdown: Option<Arc<AtomicBool>>,
     /// Pre-allocated playback buffer (reused every process call)
     playback_buf: Vec<f32>,
     /// Pre-allocated per-peer buffers (reused every process call)
@@ -68,6 +71,7 @@ impl Default for WailRecvPlugin {
             sample_rate: 48000.0,
             ipc_incoming_rx: None,
             peer_event_rx: None,
+            ipc_shutdown: None,
             playback_buf: Vec::new(),
             peer_bufs: Default::default(),
             cumulative_samples: 0,
@@ -219,11 +223,19 @@ impl Plugin for WailRecvPlugin {
             }
         }
 
+        // Signal the old IPC thread to shut down before spawning a new one
+        if let Some(ref flag) = self.ipc_shutdown {
+            flag.store(true, Ordering::Relaxed);
+        }
+
         let (in_tx, in_rx) = crossbeam_channel::bounded::<(String, u16, i64, Vec<f32>)>(64);
         self.ipc_incoming_rx = Some(in_rx);
 
         let (peer_tx, peer_rx) = crossbeam_channel::bounded::<PeerEvent>(32);
         self.peer_event_rx = Some(peer_rx);
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        self.ipc_shutdown = Some(shutdown.clone());
 
         let addr = std::env::var("WAIL_IPC_ADDR")
             .unwrap_or_else(|_| DEFAULT_IPC_ADDR.to_string());
@@ -231,12 +243,14 @@ impl Plugin for WailRecvPlugin {
         let ipc_sample_rate = buffer_config.sample_rate as u32;
         let ipc_channels = channels;
 
-        std::thread::Builder::new()
+        if let Err(e) = std::thread::Builder::new()
             .name("wail-ipc-recv".into())
             .spawn(move || {
-                ipc_thread_recv(in_tx, peer_tx, addr, ipc_sample_rate, ipc_channels)
+                ipc_thread_recv(in_tx, peer_tx, addr, ipc_sample_rate, ipc_channels, shutdown)
             })
-            .ok();
+        {
+            nih_error!("WAIL Recv: failed to spawn IPC thread: {}", e);
+        }
 
         nih_log!(
             "WAIL Recv initialized: {}Hz, {} channels, {} bars",
@@ -406,6 +420,116 @@ impl Plugin for WailRecvPlugin {
     }
 }
 
+/// Assembles streaming audio frames into complete intervals for decoding.
+///
+/// Keyed by (interval_index, stream_id, peer_id). Collects Opus frames by
+/// frame_number, and when the final frame arrives, assembles them into the
+/// length-prefixed format that `AudioDecoder::decode_interval` expects.
+struct FrameAssembler {
+    /// (interval_index, stream_id, peer_id) → collected frames
+    pending: HashMap<(i64, u16, String), FrameCollection>,
+}
+
+struct FrameCollection {
+    frames: Vec<Option<Vec<u8>>>,
+    channels: u16,
+    sample_rate: u32,
+    bpm: f64,
+    quantum: f64,
+    bars: u32,
+}
+
+impl FrameAssembler {
+    fn new() -> Self {
+        Self {
+            pending: HashMap::new(),
+        }
+    }
+
+    /// Insert a frame. If it's the final frame, returns assembled opus_data blob
+    /// along with metadata needed to create an AudioInterval.
+    fn insert(
+        &mut self,
+        peer_id: &str,
+        frame: &wail_audio::AudioFrame,
+    ) -> Option<(String, u16, i64, u16, u32, f64, f64, u32, Vec<u8>)> {
+        let key = (frame.interval_index, frame.stream_id, peer_id.to_string());
+
+        let collection = self.pending.entry(key.clone()).or_insert_with(|| FrameCollection {
+            frames: Vec::new(),
+            channels: frame.channels,
+            sample_rate: 0,
+            bpm: 0.0,
+            quantum: 0.0,
+            bars: 0,
+        });
+
+        // Ensure vec is large enough (cap to prevent OOM from malicious peers)
+        let idx = frame.frame_number as usize;
+        const MAX_FRAMES_PER_INTERVAL: usize = 10_000;
+        if idx >= MAX_FRAMES_PER_INTERVAL {
+            tracing::warn!(
+                frame_number = idx,
+                "FrameAssembler: frame_number exceeds maximum, dropping"
+            );
+            return None;
+        }
+        if collection.frames.len() <= idx {
+            collection.frames.resize(idx + 1, None);
+        }
+        collection.frames[idx] = Some(frame.opus_data.clone());
+
+        if frame.is_final {
+            collection.sample_rate = frame.sample_rate;
+            collection.bpm = frame.bpm;
+            collection.quantum = frame.quantum;
+            collection.bars = frame.bars;
+
+            let total = frame.total_frames as usize;
+            let Some(coll) = self.pending.remove(&key) else {
+                tracing::warn!("FrameAssembler: missing collection for key after insert");
+                return None;
+            };
+
+            // Assemble into encode_interval format:
+            // [u32 LE frame_count][u16 LE len][opus bytes]...
+            let mut opus_data = Vec::new();
+            opus_data.extend_from_slice(&(total as u32).to_le_bytes());
+            for i in 0..total {
+                if let Some(Some(data)) = coll.frames.get(i) {
+                    opus_data.extend_from_slice(&(data.len() as u16).to_le_bytes());
+                    opus_data.extend_from_slice(data);
+                } else {
+                    // Missing frame — insert silence marker (zero-length Opus packet
+                    // would fail decoding, so skip with a 0-length entry)
+                    // The decoder will handle this as a gap.
+                    opus_data.extend_from_slice(&0u16.to_le_bytes());
+                }
+            }
+
+            return Some((
+                peer_id.to_string(),
+                frame.stream_id,
+                frame.interval_index,
+                coll.channels,
+                coll.sample_rate,
+                coll.bpm,
+                coll.quantum,
+                coll.bars,
+                opus_data,
+            ));
+        }
+
+        None
+    }
+
+    /// Evict stale entries for intervals older than `current - 2`.
+    fn evict_stale(&mut self, current_interval: i64) {
+        self.pending
+            .retain(|&(idx, _, _), _| idx >= current_interval - 2);
+    }
+}
+
 /// Receive-only IPC thread: reads from TCP, Opus-decodes, sends PCM to audio thread.
 fn ipc_thread_recv(
     incoming_tx: crossbeam_channel::Sender<(String, u16, i64, Vec<f32>)>,
@@ -413,6 +537,7 @@ fn ipc_thread_recv(
     addr: String,
     sample_rate: u32,
     channels: u16,
+    shutdown: Arc<AtomicBool>,
 ) {
     let opus_rate = nearest_opus_rate(sample_rate);
     if opus_rate != sample_rate {
@@ -423,15 +548,15 @@ fn ipc_thread_recv(
         );
     }
 
-    let mut decoder = match AudioDecoder::new(opus_rate, channels) {
-        Ok(dec) => Some(dec),
-        Err(e) => {
-            tracing::warn!(error = %e, "IPC recv thread: failed to create Opus decoder");
-            None
-        }
-    };
+    let mut decoders: HashMap<(String, u16), AudioDecoder> = HashMap::new();
+
+    let mut assembler = FrameAssembler::new();
 
     loop {
+        if shutdown.load(Ordering::Relaxed) {
+            tracing::info!("WAIL Recv IPC thread: shutdown requested, exiting");
+            return;
+        }
         let mut stream = match TcpStream::connect(&addr) {
             Ok(s) => {
                 tracing::info!(addr = %addr, "WAIL Recv IPC connected to wail-app");
@@ -450,8 +575,11 @@ fn ipc_thread_recv(
             continue;
         }
 
-        // No read timeout — we block until data arrives or the connection closes
-        stream.set_read_timeout(None).ok();
+        // Use a read timeout so the thread can detect when channels are disconnected
+        // (e.g., when the DAW re-initializes the plugin and replaces receivers).
+        if let Err(e) = stream.set_read_timeout(Some(Duration::from_secs(5))) {
+            tracing::warn!(error = %e, "WAIL Recv: failed to set read timeout");
+        }
 
         let mut recv_buf = IpcRecvBuffer::new();
         let mut read_buf = [0u8; 65536];
@@ -468,33 +596,54 @@ fn ipc_thread_recv(
                         match IpcMessage::tag(&payload) {
                             Some(IPC_TAG_AUDIO_PUB) => {
                                 if let Some((peer_id, wire_data)) = IpcMessage::decode_audio(&payload) {
-                                    match AudioWire::decode(&wire_data) {
-                                        Ok(interval) => {
-                                            if let Some(ref mut dec) = decoder {
-                                                match dec.decode_interval(&interval.opus_data) {
-                                                    Ok(samples) => {
-                                                        let _ = incoming_tx.try_send((
-                                                            peer_id,
-                                                            interval.stream_id,
-                                                            interval.index,
-                                                            samples,
-                                                        ));
-                                                    }
-                                                    Err(e) => {
-                                                        tracing::warn!(
-                                                            error = %e,
-                                                            "IPC recv: failed to decode Opus audio"
-                                                        );
+                                    // Detect inner wire format by magic: WAIF = streaming frame, WAIL = full interval
+                                    if wire_data.starts_with(b"WAIF") {
+                                        match AudioFrameWire::decode(&wire_data) {
+                                            Ok(frame) => {
+                                                if frame.is_final {
+                                                    assembler.evict_stale(frame.interval_index);
+                                                }
+                                                if let Some((pid, stream_id, interval_idx, ch, sr, _bpm, _q, _bars, opus_data)) =
+                                                    assembler.insert(&peer_id, &frame)
+                                                {
+                                                    let dec_key = (pid.clone(), stream_id);
+                                                    let dec = decoders.entry(dec_key).or_insert_with(|| {
+                                                        let rate = nearest_opus_rate(sr);
+                                                        match AudioDecoder::new(rate, ch) {
+                                                            Ok(d) => d,
+                                                            Err(e) => {
+                                                                tracing::warn!(error = %e, "IPC recv: failed to create decoder, using fallback");
+                                                                AudioDecoder::new(opus_rate, channels).expect("fallback opus decoder at known-good params")
+                                                            }
+                                                        }
+                                                    });
+                                                    match dec.decode_interval(&opus_data) {
+                                                        Ok(samples) => {
+                                                            let _ = incoming_tx.try_send((
+                                                                pid,
+                                                                stream_id,
+                                                                interval_idx,
+                                                                samples,
+                                                            ));
+                                                        }
+                                                        Err(e) => {
+                                                            tracing::warn!(
+                                                                error = %e,
+                                                                "IPC recv: failed to decode assembled Opus audio"
+                                                            );
+                                                        }
                                                     }
                                                 }
                                             }
+                                            Err(e) => {
+                                                tracing::warn!(
+                                                    error = %e,
+                                                    "IPC recv: failed to decode audio frame wire"
+                                                );
+                                            }
                                         }
-                                        Err(e) => {
-                                            tracing::warn!(
-                                                error = %e,
-                                                "IPC recv: failed to decode wire data"
-                                            );
-                                        }
+                                    } else {
+                                        tracing::warn!("IPC recv: unexpected non-WAIF audio data, ignoring");
                                     }
                                 }
                             }
@@ -524,6 +673,14 @@ fn ipc_thread_recv(
                             }
                         }
                     }
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock || e.kind() == std::io::ErrorKind::TimedOut => {
+                    // Read timeout — check if shutdown was requested (plugin re-initialized)
+                    if shutdown.load(Ordering::Relaxed) {
+                        tracing::info!("WAIL Recv IPC thread: shutdown requested, exiting");
+                        return;
+                    }
+                    continue;
                 }
                 Err(_) => {
                     tracing::warn!("WAIL Recv IPC read error — reconnecting");

--- a/crates/wail-plugin-send/src/lib.rs
+++ b/crates/wail-plugin-send/src/lib.rs
@@ -11,8 +11,8 @@ mod params;
 
 use params::WailSendParams;
 use wail_audio::{
-    nearest_opus_rate, AudioBridge, AudioEncoder, AudioInterval, AudioWire, CompletedInterval,
-    IpcFramer, IpcMessage, IPC_ROLE_SEND,
+    nearest_opus_rate, AudioBridge, AudioEncoder, AudioFrame, AudioFrameWire, IpcFramer,
+    IpcMessage, IPC_ROLE_SEND,
 };
 
 /// Default IPC address (overridable via WAIL_IPC_ADDR env var).
@@ -22,13 +22,18 @@ const DEFAULT_BARS: u32 = 4;
 const DEFAULT_QUANTUM: f64 = 4.0;
 const DEFAULT_BITRATE_KBPS: u32 = 128;
 
-/// Raw completed interval with config snapshot, sent from audio thread to IPC
-/// thread for Opus encoding (keeps Opus off the real-time audio callback).
-struct RawInterval {
-    completed: CompletedInterval,
+/// A single 20ms frame of raw PCM, sent from the audio thread to the IPC thread
+/// for immediate Opus encoding and streaming transmission.
+struct RawFrame {
+    samples: Vec<f32>,
+    interval_index: i64,
     stream_id: u16,
-    sample_rate: u32,
+    frame_number: u32,
     channels: u16,
+    is_final: bool,
+    // Metadata for the final frame:
+    sample_rate: u32,
+    total_frames: u32,
     bpm: f64,
     quantum: f64,
     bars: u32,
@@ -46,7 +51,8 @@ pub struct WailSendPlugin {
     params: Arc<WailSendParams>,
     bridge: Arc<Mutex<Option<AudioBridge>>>,
     sample_rate: f32,
-    ipc_outgoing_tx: Option<Sender<RawInterval>>,
+    /// Channel for streaming 20ms frames to the IPC thread
+    frame_tx: Option<Sender<RawFrame>>,
     /// Pre-allocated interleaved input buffer (reused every process call)
     interleave_buf: Vec<f32>,
     /// Pre-allocated dummy playback buffer (bridge.process_rt requires it)
@@ -55,6 +61,14 @@ pub struct WailSendPlugin {
     /// doesn't provide `pos_beats()`.
     cumulative_samples: u64,
     beat_fallback_warned: bool,
+    /// Accumulates interleaved samples until we have a full 20ms frame
+    frame_buffer: Vec<f32>,
+    /// Current interval index for streaming frame dispatch
+    streaming_interval_index: Option<i64>,
+    /// Current frame number within the interval (resets at boundary)
+    streaming_frame_number: u32,
+    /// Opus frame size in samples per channel (set during initialize)
+    opus_frame_size: usize,
 }
 
 impl Default for WailSendPlugin {
@@ -63,11 +77,15 @@ impl Default for WailSendPlugin {
             params: Arc::new(WailSendParams::default()),
             bridge: Arc::new(Mutex::new(None)),
             sample_rate: 48000.0,
-            ipc_outgoing_tx: None,
+            frame_tx: None,
             interleave_buf: Vec::new(),
             playback_buf: Vec::new(),
             cumulative_samples: 0,
             beat_fallback_warned: false,
+            frame_buffer: Vec::new(),
+            streaming_interval_index: None,
+            streaming_frame_number: 0,
+            opus_frame_size: 960, // 20ms at 48kHz, updated in initialize
         }
     }
 }
@@ -158,7 +176,7 @@ impl Plugin for WailSendPlugin {
             .main_input_channels
             .map(|c| c.get() as u16)
             .unwrap_or(2);
-        let mut bridge = AudioBridge::new(
+        let bridge = AudioBridge::new(
             buffer_config.sample_rate as u32,
             channels,
             DEFAULT_BARS,
@@ -170,11 +188,6 @@ impl Plugin for WailSendPlugin {
         self.interleave_buf = vec![0.0f32; max_buf];
         self.playback_buf = vec![0.0f32; max_buf];
 
-        // Buffer return channel: IPC thread sends back empty Vec<f32> after encoding
-        // so the audio thread can reuse it as spare_record (zero alloc after warmup).
-        let (buf_return_tx, buf_return_rx) = crossbeam_channel::bounded::<Vec<f32>>(4);
-        bridge.set_buffer_return_rx(buf_return_rx);
-
         match self.bridge.lock() {
             Ok(mut guard) => *guard = Some(bridge),
             Err(_) => {
@@ -183,8 +196,14 @@ impl Plugin for WailSendPlugin {
             }
         }
 
-        let (out_tx, out_rx) = crossbeam_channel::bounded::<RawInterval>(64);
-        self.ipc_outgoing_tx = Some(out_tx);
+        let (ftx, frx) = crossbeam_channel::bounded::<RawFrame>(512);
+        self.frame_tx = Some(ftx);
+
+        let opus_rate = nearest_opus_rate(buffer_config.sample_rate as u32);
+        self.opus_frame_size = (opus_rate as usize * 20) / 1000;
+        self.frame_buffer = Vec::with_capacity(self.opus_frame_size * channels as usize);
+        self.streaming_interval_index = None;
+        self.streaming_frame_number = 0;
 
         let addr = std::env::var("WAIL_IPC_ADDR")
             .unwrap_or_else(|_| DEFAULT_IPC_ADDR.to_string());
@@ -194,12 +213,14 @@ impl Plugin for WailSendPlugin {
         let ipc_bitrate = DEFAULT_BITRATE_KBPS;
         let ipc_params = self.params.clone();
 
-        std::thread::Builder::new()
+        if let Err(e) = std::thread::Builder::new()
             .name("wail-ipc-send".into())
             .spawn(move || {
-                ipc_thread_send(out_rx, buf_return_tx, addr, ipc_sample_rate, ipc_channels, ipc_bitrate, ipc_params)
+                ipc_thread_send(frx, addr, ipc_sample_rate, ipc_channels, ipc_bitrate, ipc_params)
             })
-            .ok();
+        {
+            nih_error!("WAIL Send: failed to spawn IPC thread: {}", e);
+        }
 
         nih_log!(
             "WAIL Send initialized: {}Hz, {} channels, {} bars",
@@ -213,6 +234,9 @@ impl Plugin for WailSendPlugin {
 
     fn reset(&mut self) {
         self.cumulative_samples = 0;
+        self.frame_buffer.clear();
+        self.streaming_interval_index = None;
+        self.streaming_frame_number = 0;
         if let Ok(mut bridge) = self.bridge.lock() {
             if let Some(ref mut b) = *bridge {
                 b.reset();
@@ -264,32 +288,79 @@ impl Plugin for WailSendPlugin {
                 let playback = &mut self.playback_buf[..buf_size];
                 playback.fill(0.0);
 
-                let completed = permit_alloc(|| {
-                    bridge.process_rt(interleave, playback, beat_position)
+                permit_alloc(|| {
+                    drop(bridge.process_rt(interleave, playback, beat_position));
                 });
 
-                // Send completed intervals to IPC thread for encoding
+                // --- Streaming frame dispatch ---
+                // Accumulate interleaved input into frame_buffer, dispatch
+                // each full 20ms frame to the IPC thread immediately.
                 permit_alloc(|| {
-                    if let Some(ref tx) = self.ipc_outgoing_tx {
+                    if let Some(ref ftx) = self.frame_tx {
                         let sr = bridge.sample_rate();
                         let ch = bridge.channels();
                         let bpm_snap = bridge.bpm();
                         let q = bridge.quantum();
                         let b = bridge.bars();
                         let stream_id = self.params.stream_index.value() as u16;
-                        for c in completed {
-                            let _ = tx.try_send(RawInterval {
-                                completed: c,
+                        let frame_samples = self.opus_frame_size * ch as usize;
+                        let interval_idx = bridge.current_interval_index();
+
+                        // Detect interval boundary: flush partial + mark final
+                        if let Some(prev_idx) = self.streaming_interval_index {
+                            if prev_idx != interval_idx {
+                                // Flush remaining samples as final frame (zero-padded),
+                                // or send an empty final frame so the receiver knows
+                                // the interval is complete.
+                                let samples = std::mem::take(&mut self.frame_buffer);
+                                let total_frames = if samples.is_empty() {
+                                    self.streaming_frame_number
+                                } else {
+                                    self.streaming_frame_number + 1
+                                };
+                                let _ = ftx.try_send(RawFrame {
+                                    samples,
+                                    interval_index: prev_idx,
+                                    stream_id,
+                                    frame_number: self.streaming_frame_number,
+                                    channels: ch,
+                                    is_final: true,
+                                    sample_rate: sr,
+                                    total_frames,
+                                    bpm: bpm_snap,
+                                    quantum: q,
+                                    bars: b,
+                                });
+                                self.streaming_frame_number = 0;
+                            }
+                        }
+                        self.streaming_interval_index = Some(interval_idx);
+
+                        // Feed input into frame buffer
+                        self.frame_buffer.extend_from_slice(interleave);
+
+                        // Dispatch full 20ms frames
+                        while self.frame_buffer.len() >= frame_samples {
+                            let rest = self.frame_buffer.split_off(frame_samples);
+                            let samples = std::mem::replace(&mut self.frame_buffer, rest);
+                            let _ = ftx.try_send(RawFrame {
+                                samples,
+                                interval_index: interval_idx,
                                 stream_id,
-                                sample_rate: sr,
+                                frame_number: self.streaming_frame_number,
                                 channels: ch,
+                                is_final: false,
+                                sample_rate: sr,
+                                total_frames: 0,
                                 bpm: bpm_snap,
                                 quantum: q,
                                 bars: b,
                             });
+                            self.streaming_frame_number += 1;
                         }
                     }
                 });
+
             }
         }
 
@@ -305,13 +376,9 @@ impl Plugin for WailSendPlugin {
     }
 }
 
-/// Send-only IPC thread: Opus-encodes completed intervals and writes to TCP.
-///
-/// After encoding, sends the now-empty sample buffer back through
-/// `buf_return_tx` so the audio thread can reuse it (zero-allocation).
+/// Send-only IPC thread: Opus-encodes 20ms streaming frames and sends them to wail-app.
 fn ipc_thread_send(
-    outgoing_rx: crossbeam_channel::Receiver<RawInterval>,
-    buf_return_tx: Sender<Vec<f32>>,
+    frame_rx: crossbeam_channel::Receiver<RawFrame>,
     addr: String,
     sample_rate: u32,
     channels: u16,
@@ -327,10 +394,10 @@ fn ipc_thread_send(
         );
     }
 
-    let mut encoder = match AudioEncoder::new(opus_rate, channels, bitrate_kbps) {
+    let mut frame_encoder = match AudioEncoder::new(opus_rate, channels, bitrate_kbps) {
         Ok(enc) => Some(enc),
         Err(e) => {
-            tracing::warn!(error = %e, "IPC send thread: failed to create Opus encoder");
+            tracing::warn!(error = %e, "IPC send thread: failed to create streaming Opus encoder");
             None
         }
     };
@@ -358,33 +425,29 @@ fn ipc_thread_send(
             continue;
         }
 
-        loop {
-            // Block waiting for the next interval (with timeout so we detect disconnects)
-            match outgoing_rx.recv_timeout(Duration::from_secs(5)) {
-                Ok(raw) => {
-                    let mut samples = raw.completed.samples;
-                    let sample_count = samples.len();
-                    let mut write_failed = false;
+        let mut write_failed = false;
 
-                    if let Some(ref mut enc) = encoder {
-                        match enc.encode_interval(&samples) {
+        loop {
+            match frame_rx.recv_timeout(Duration::from_secs(5)) {
+                Ok(raw_frame) => {
+                    if let Some(ref mut enc) = frame_encoder {
+                        match enc.encode_frame(&raw_frame.samples) {
                             Ok(opus_data) => {
-                                let num_frames = (sample_count
-                                    / raw.channels as usize)
-                                    as u32;
-                                let interval = AudioInterval {
-                                    index: raw.completed.index,
-                                    stream_id: raw.stream_id,
+                                let audio_frame = AudioFrame {
+                                    interval_index: raw_frame.interval_index,
+                                    stream_id: raw_frame.stream_id,
+                                    frame_number: raw_frame.frame_number,
+                                    channels: raw_frame.channels,
                                     opus_data,
-                                    sample_rate: raw.sample_rate,
-                                    channels: raw.channels,
-                                    num_frames,
-                                    bpm: raw.bpm,
-                                    quantum: raw.quantum,
-                                    bars: raw.bars,
+                                    is_final: raw_frame.is_final,
+                                    sample_rate: raw_frame.sample_rate,
+                                    total_frames: raw_frame.total_frames,
+                                    bpm: raw_frame.bpm,
+                                    quantum: raw_frame.quantum,
+                                    bars: raw_frame.bars,
                                 };
-                                let wire_data = AudioWire::encode(&interval);
-                                let msg = IpcMessage::encode_audio("", &wire_data);
+                                let wire_data = AudioFrameWire::encode(&audio_frame);
+                                let msg = IpcMessage::encode_audio_frame(&wire_data);
                                 let frame = IpcFramer::encode_frame(&msg);
                                 if stream.write_all(&frame).is_err() {
                                     tracing::warn!("WAIL Send IPC write error — reconnecting");
@@ -392,29 +455,22 @@ fn ipc_thread_send(
                                 }
                             }
                             Err(e) => {
-                                tracing::warn!(error = %e, "IPC send: failed to encode interval");
+                                tracing::warn!(error = %e, "IPC send: failed to encode frame");
                             }
                         }
                     }
-
-                    // Return the buffer to the audio thread for reuse
-                    samples.clear();
-                    if let Err(e) = buf_return_tx.try_send(samples) {
-                        tracing::warn!("Buffer return failed: {e}");
-                    }
-
-                    if write_failed {
-                        break;
-                    }
-                }
-                Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
-                    // No data — check if TCP is still alive by writing nothing
-                    // (the next real write will detect if it's broken)
                 }
                 Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {
-                    tracing::info!("WAIL Send IPC: audio channel closed, shutting down");
+                    tracing::info!("WAIL Send IPC: frame channel closed, shutting down");
                     return;
                 }
+                Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
+                    // Timeout — connection check will happen on next write
+                }
+            }
+
+            if write_failed {
+                break;
             }
         }
 

--- a/crates/wail-tauri/src/commands.rs
+++ b/crates/wail-tauri/src/commands.rs
@@ -60,7 +60,6 @@ pub fn join_room(
     bars: Option<u32>,
     quantum: Option<f64>,
     ipc_port: Option<u16>,
-    test_tone: Option<bool>,
     recording_enabled: Option<bool>,
     recording_directory: Option<String>,
     recording_stems: Option<bool>,
@@ -83,7 +82,6 @@ pub fn join_room(
         bars: bars.unwrap_or(4),
         quantum: quantum.unwrap_or(4.0),
         ipc_port: ipc_port.unwrap_or(9191),
-        test_tone: test_tone.unwrap_or(false),
         recording: if recording_enabled.unwrap_or(false) {
             Some(RecordingConfig {
                 enabled: true,
@@ -140,17 +138,6 @@ pub fn set_telemetry(handle: State<'_, TelemetryHandle>, enabled: bool) -> Resul
 pub fn set_log_sharing(handle: State<'_, WsLogHandle>, enabled: bool) -> Result<(), String> {
     handle.set_enabled(enabled);
     info!(enabled, "Peer log sharing toggled");
-    Ok(())
-}
-
-#[tauri::command]
-pub fn set_test_tone(state: State<'_, SessionState>, enabled: bool) -> Result<(), String> {
-    let session = state.lock().map_err(|e| e.to_string())?;
-    if let Some(ref handle) = *session {
-        let _ = handle.cmd_tx.send(SessionCommand::SetTestTone(enabled));
-    } else {
-        warn!("No active session for test tone toggle");
-    }
     Ok(())
 }
 

--- a/crates/wail-tauri/src/events.rs
+++ b/crates/wail-tauri/src/events.rs
@@ -90,7 +90,6 @@ pub struct StatusUpdate {
     pub audio_bytes_recv: u64,
     pub audio_dc_open: bool,
     pub plugin_connected: bool,
-    pub test_tone_enabled: bool,
     pub audio_send_gated: bool,
     pub recording: bool,
     pub recording_size_bytes: u64,

--- a/crates/wail-tauri/src/lib.rs
+++ b/crates/wail-tauri/src/lib.rs
@@ -98,7 +98,6 @@ pub fn run() {
             commands::join_room,
             commands::disconnect,
             commands::change_bpm,
-            commands::set_test_tone,
             commands::set_telemetry,
             commands::set_log_sharing,
             commands::list_public_rooms,

--- a/crates/wail-tauri/src/recorder.rs
+++ b/crates/wail-tauri/src/recorder.rs
@@ -22,7 +22,6 @@ pub struct RecordingConfig {
 
 /// Commands sent from the session loop to the writer task.
 enum RecordCommand {
-    OwnInterval { wire_data: Vec<u8> },
     PeerInterval { peer_id: String, display_name: Option<String>, wire_data: Vec<u8> },
     Finalize,
 }
@@ -81,16 +80,16 @@ impl SessionRecorder {
         Ok(Self { tx, bytes_written })
     }
 
-    pub fn record_own(&self, wire_data: Vec<u8>) {
-        let _ = self.tx.send(RecordCommand::OwnInterval { wire_data });
-    }
-
     pub fn record_peer(&self, peer_id: String, display_name: Option<String>, wire_data: Vec<u8>) {
-        let _ = self.tx.send(RecordCommand::PeerInterval { peer_id, display_name, wire_data });
+        if let Err(e) = self.tx.send(RecordCommand::PeerInterval { peer_id, display_name, wire_data }) {
+            warn!("Recording: failed to send peer interval: {e}");
+        }
     }
 
     pub fn finalize(&self) {
-        let _ = self.tx.send(RecordCommand::Finalize);
+        if let Err(e) = self.tx.send(RecordCommand::Finalize) {
+            warn!("Recording: failed to send finalize command: {e}");
+        }
     }
 
     pub fn bytes_written(&self) -> u64 {
@@ -184,9 +183,6 @@ impl RecorderWriter {
         let mut rx = rx;
         loop {
             match rx.blocking_recv() {
-                Some(RecordCommand::OwnInterval { wire_data }) => {
-                    self.handle_interval("self", None, &wire_data);
-                }
                 Some(RecordCommand::PeerInterval { peer_id, display_name, wire_data }) => {
                     self.peers.entry(peer_id.clone()).or_insert(display_name.clone());
                     self.handle_interval(&peer_id, display_name.as_deref(), &wire_data);
@@ -223,16 +219,23 @@ impl RecorderWriter {
         let ch = interval.channels;
 
         // Get or create decoder for this source
-        let decoder = self.decoders.entry(source_id.to_string()).or_insert_with(|| {
-            match AudioDecoder::new(sr, ch) {
+        if !self.decoders.contains_key(source_id) {
+            let decoder = match AudioDecoder::new(sr, ch) {
                 Ok(d) => d,
                 Err(e) => {
                     warn!(source = source_id, "Recording: failed to create decoder: {e}");
-                    // Return a dummy — we'll handle the error on decode
-                    AudioDecoder::new(48000, 1).expect("fallback decoder")
+                    match AudioDecoder::new(48000, 1) {
+                        Ok(d) => d,
+                        Err(e2) => {
+                            warn!(source = source_id, "Recording: fallback decoder also failed: {e2}");
+                            return;
+                        }
+                    }
                 }
-            }
-        });
+            };
+            self.decoders.insert(source_id.to_string(), decoder);
+        }
+        let decoder = self.decoders.get_mut(source_id).unwrap();
 
         let pcm = match decoder.decode_interval(&interval.opus_data) {
             Ok(pcm) => pcm,

--- a/crates/wail-tauri/src/session.rs
+++ b/crates/wail-tauri/src/session.rs
@@ -6,9 +6,7 @@ use tokio::io::AsyncReadExt;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn, Instrument};
 
-use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
-use wail_audio::{AudioDecoder, AudioEncoder, AudioInterval, AudioWire, ClientChannelMapping, IpcFramer, IpcMessage, IpcRecvBuffer, IPC_ROLE_RECV};
+use wail_audio::{ClientChannelMapping, IpcFramer, IpcMessage, IpcRecvBuffer, IPC_ROLE_RECV};
 use wail_core::{ClockSync, IntervalTracker, LinkBridge, LinkCommand, LinkEvent, SyncMessage};
 use wail_net::PeerMesh;
 
@@ -52,7 +50,6 @@ pub struct SessionHandle {
 
 pub enum SessionCommand {
     ChangeBpm(f64),
-    SetTestTone(bool),
     Disconnect,
 }
 
@@ -73,7 +70,6 @@ pub struct SessionConfig {
     pub bars: u32,
     pub quantum: f64,
     pub ipc_port: u16,
-    pub test_tone: bool,
     pub recording: Option<RecordingConfig>,
     pub stream_count: u16,
 }
@@ -144,7 +140,6 @@ async fn session_loop(
         bars,
         quantum,
         ipc_port,
-        test_tone,
         recording: recording_config,
         stream_count,
     } = config;
@@ -202,40 +197,10 @@ async fn session_loop(
     // Link peer count — updated every status tick; used to gate audio when Link is not running
     let mut link_peers: u64 = 0;
 
-    // Audio interval stats
-    let mut audio_intervals_sent: u64 = 0;
+    // Audio stats
     let mut audio_intervals_received: u64 = 0;
     let mut audio_bytes_sent: u64 = 0;
     let mut audio_bytes_recv: u64 = 0;
-    let mut audio_intervals_sent_prev: u64 = 0;
-
-    // Test tone state
-    let mut test_tone_enabled = test_tone;
-    let mut test_tone_encoder: Option<AudioEncoder> = if test_tone_enabled {
-        match AudioEncoder::new(48000, 1, 64) {
-            Ok(enc) => {
-                ui_info!(&app, "Test tone encoder ready (48kHz mono 64kbps)");
-                Some(enc)
-            }
-            Err(e) => {
-                ui_warn!(&app, "Failed to create test tone encoder: {e}");
-                None
-            }
-        }
-    } else {
-        None
-    };
-    let mut audio_decoder: Option<AudioDecoder> = match AudioDecoder::new(48000, 1) {
-        Ok(dec) => Some(dec),
-        Err(e) => {
-            ui_warn!(&app, "Failed to create audio decoder for logging: {e}");
-            None
-        }
-    };
-    let mut rng = StdRng::from_entropy();
-    if test_tone_enabled {
-        ui_info!(&app, "Test tone ENABLED — will generate sine tones at interval boundaries");
-    }
 
     // IPC: listen for plugin connections.
     // Use TcpSocket builder to set SO_REUSEADDR before binding, so that reconnecting
@@ -304,19 +269,6 @@ async fn session_loop(
                         last_broadcast_bpm = new_bpm;
                         if link_cmd_tx.send(LinkCommand::SetTempo(new_bpm)).is_err() {
                             ui_warn!(&app, "Link bridge stopped");
-                        }
-                    }
-                    SessionCommand::SetTestTone(enabled) => {
-                        test_tone_enabled = enabled;
-                        ui_info!(&app, "Test tone {}", if enabled { "ENABLED" } else { "DISABLED" });
-                        if enabled && test_tone_encoder.is_none() {
-                            match AudioEncoder::new(48000, 1, 64) {
-                                Ok(enc) => {
-                                    ui_info!(&app, "Test tone encoder ready (48kHz mono 64kbps)");
-                                    test_tone_encoder = Some(enc);
-                                }
-                                Err(e) => ui_warn!(&app, "Failed to create test tone encoder: {e}"),
-                            }
                         }
                     }
                     SessionCommand::Disconnect => {
@@ -433,36 +385,20 @@ async fn session_loop(
 
             // --- Audio from plugin IPC → broadcast to WebRTC peers ---
             Some(frame) = ipc_from_plugin_rx.recv() => {
-                if let Some((_peer_id, wire_data)) = IpcMessage::decode_audio(&frame) {
-                    // Discard plugin backlog that accumulated before the first real interval
-                    // boundary. Interval 0 is a warmup period: stale buffered intervals from
-                    // the DAW's history flood in during this window. After the first boundary
-                    // (interval >= 1) we're live. NINJAM semantics: interval N audio is only
-                    // played back in interval N+1, so interval 0 is a throw-away anyway.
+                // Streaming audio frames (20ms Opus chunks, tag 0x05)
+                if let Some(wire_data) = IpcMessage::decode_audio_frame(&frame) {
                     if interval.current_index() <= Some(0) {
                         continue;
-                    }
-                    if let Some(ref rec) = recorder {
-                        rec.record_own(wire_data.clone());
                     }
                     if audio_gate.is_gated() || link_peers == 0 {
                         continue;
                     }
-                    // Clear any stale retry from the previous interval.
-                    audio_retry = None;
                     let failed_peers = mesh.broadcast_audio(&wire_data).await;
-                    audio_intervals_sent += 1;
                     audio_bytes_sent += wire_data.len() as u64;
                     if !failed_peers.is_empty() {
-                        audio_retry = Some((
-                            tokio::time::Instant::now() + Duration::from_millis(250),
-                            failed_peers,
-                            wire_data.clone(),
-                            3,
-                        ));
+                        // Don't retry individual frames — next frame will arrive in 20ms
+                        debug!("Frame send failed for {} peers", failed_peers.len());
                     }
-                    let connected_peers = mesh.connected_peers();
-                    ui_info!(&app, "[AUDIO SEND] wire={} bytes, peers=[{}], total_sent={}", wire_data.len(), connected_peers.join(", "), audio_intervals_sent);
                 }
             }
 
@@ -871,56 +807,6 @@ async fn session_loop(
                 }
                 audio_intervals_received += 1;
                 audio_bytes_recv += data.len() as u64;
-                let peer_name: String = peers.get(&from)
-                    .and_then(|p| p.display_name.clone())
-                    .unwrap_or_else(|| from.clone());
-
-                match AudioWire::decode(&data) {
-                    Ok(audio_interval) => {
-                        // Assign slot for new (peer, stream_id) pairs
-                        let already_had_slot = peers.slot_for(&from, audio_interval.stream_id).is_some();
-                        if let Some(slot) = peers.assign_slot(&from, audio_interval.stream_id) {
-                            if !already_had_slot {
-                                let identity = peers.get(&from).and_then(|p| p.identity.clone()).unwrap_or_else(|| from.clone());
-                                let ccm = ClientChannelMapping::new(&identity, audio_interval.stream_id);
-                                ui_info!(&app, "[{}] {peer_name} stream {} assigned to slot {}", ccm.short_id(), audio_interval.stream_id, slot + 1);
-                            }
-                        }
-
-                        let mut rms_info = String::new();
-                        if let Some(ref mut decoder) = audio_decoder {
-                            match decoder.decode_interval(&audio_interval.opus_data) {
-                                Ok(pcm) => {
-                                    let rms = if pcm.is_empty() {
-                                        0.0
-                                    } else {
-                                        (pcm.iter().map(|s| s * s).sum::<f32>() / pcm.len() as f32).sqrt()
-                                    };
-                                    rms_info = format!(", decoded={} samples, RMS={:.4}", pcm.len(), rms);
-                                }
-                                Err(e) => {
-                                    rms_info = format!(", decode_err={e}");
-                                }
-                            }
-                        }
-                        let slot_label = peers.slot_for(&from, audio_interval.stream_id)
-                            .map(|s| format!("slot={}", s + 1))
-                            .unwrap_or_else(|| "slot=?".to_string());
-                        ui_info!(
-                            &app,
-                            "[AUDIO RECV] {slot_label} peer={peer_name}, interval={}, wire={} bytes, opus={} bytes, sr={}, ch={}, bpm={:.1}{rms_info}",
-                            audio_interval.index,
-                            data.len(),
-                            audio_interval.opus_data.len(),
-                            audio_interval.sample_rate,
-                            audio_interval.channels,
-                            audio_interval.bpm,
-                        );
-                    }
-                    Err(e) => {
-                        ui_warn!(&app, "[AUDIO RECV] peer={peer_name}, wire={} bytes, decode_err={e}", data.len());
-                    }
-                }
 
                 if let Some(ref rec) = recorder {
                     let name = peers.get(&from).and_then(|p| p.display_name.clone());
@@ -962,11 +848,7 @@ async fn session_loop(
                         if let Some(idx) = interval.update(beat) {
                             info!(interval = idx, beat = format!("{:.1}", beat), ">>> INTERVAL BOUNDARY <<<");
                             mesh.broadcast(&SyncMessage::IntervalBoundary { index: idx }).await;
-                            if test_tone_enabled && !audio_gate.is_gated() {
-                                if let Some(ref mut encoder) = test_tone_encoder {
-                                    send_test_tone(&app, &mesh, encoder, &mut rng, idx, last_broadcast_bpm, bars, quantum, &mut audio_intervals_sent, &mut audio_bytes_sent).await;
-                                }
-                            }
+
                         }
                     }
 
@@ -983,11 +865,7 @@ async fn session_loop(
                         if let Some(idx) = interval.update(beat) {
                             info!(interval = idx, beat = format!("{:.1}", beat), ">>> INTERVAL BOUNDARY <<<");
                             mesh.broadcast(&SyncMessage::IntervalBoundary { index: idx }).await;
-                            if test_tone_enabled && !audio_gate.is_gated() {
-                                if let Some(ref mut encoder) = test_tone_encoder {
-                                    send_test_tone(&app, &mesh, encoder, &mut rng, idx, last_broadcast_bpm, bars, quantum, &mut audio_intervals_sent, &mut audio_bytes_sent).await;
-                                }
-                            }
+
                         }
                     }
                 }
@@ -1023,7 +901,7 @@ async fn session_loop(
                 if let Ok(state) = rx.await {
                     let connected = mesh.connected_peers();
                     let dc_open = mesh.any_audio_dc_open();
-                    let is_sending = audio_intervals_sent > audio_intervals_sent_prev;
+                    let is_sending = mesh.any_audio_dc_open();
                     let peer_infos: Vec<PeerInfo> = connected
                         .iter()
                         .map(|p| {
@@ -1118,7 +996,6 @@ async fn session_loop(
 
                     // Update snapshots for next tick
                     peers.flush_audio_recv_prev();
-                    audio_intervals_sent_prev = audio_intervals_sent;
                     link_peers = state.num_peers;
 
                     let _ = app.emit("status:update", StatusUpdate {
@@ -1129,13 +1006,12 @@ async fn session_loop(
                         peers: peer_infos,
                         slots: slot_infos,
                         interval_bars: interval.bars(),
-                        audio_sent: audio_intervals_sent,
+                        audio_sent: 0,
                         audio_recv: audio_intervals_received,
                         audio_bytes_sent,
                         audio_bytes_recv,
                         audio_dc_open: dc_open,
                         plugin_connected: !ipc_pool.is_empty(),
-                        test_tone_enabled,
                         audio_send_gated: audio_gate.is_gated(),
                         recording: recorder.is_some(),
                         recording_size_bytes: recorder.as_ref().map_or(0, |r| r.bytes_written()),
@@ -1144,7 +1020,7 @@ async fn session_loop(
                     // Broadcast audio pipeline status to remote peers
                     let status_msg = SyncMessage::AudioStatus {
                         audio_dc_open: dc_open,
-                        intervals_sent: audio_intervals_sent,
+                        intervals_sent: 0,
                         intervals_received: audio_intervals_received,
                         plugin_connected: !ipc_pool.is_empty(),
                     };
@@ -1163,80 +1039,6 @@ async fn session_loop(
     Ok(())
 }
 
-/// Generate a random sine tone, Opus-encode it, and broadcast as an audio interval.
-async fn send_test_tone(
-    app: &AppHandle,
-    mesh: &PeerMesh,
-    encoder: &mut AudioEncoder,
-    rng: &mut impl Rng,
-    idx: i64,
-    bpm: f64,
-    bars: u32,
-    quantum: f64,
-    audio_intervals_sent: &mut u64,
-    audio_bytes_sent: &mut u64,
-) {
-    let freq: f32 = rng.gen_range(220.0..=880.0);
-    let sample_rate: u32 = 48000;
-    let interval_beats = bars as f64 * quantum;
-    let duration_secs = (interval_beats * 60.0) / bpm.max(1.0);
-    let duration_secs = duration_secs.clamp(0.5, 30.0);
-    let num_samples = (duration_secs * sample_rate as f64).round() as usize;
-
-    let samples: Vec<f32> = (0..num_samples)
-        .map(|i| {
-            let t = i as f32 / sample_rate as f32;
-            (t * freq * 2.0 * std::f32::consts::PI).sin() * 0.5
-        })
-        .collect();
-
-    let rms = (samples.iter().map(|s| s * s).sum::<f32>() / samples.len().max(1) as f32).sqrt();
-
-    ui_info!(
-        app,
-        "[TEST TONE] Interval {idx}: freq={freq:.1}Hz, {num_samples} samples ({duration_secs:.2}s), RMS={rms:.4}, bpm={bpm:.1}"
-    );
-
-    match encoder.encode_interval(&samples) {
-        Ok(opus_data) => {
-            let audio_interval = AudioInterval {
-                index: idx,
-                stream_id: 0,
-                opus_data: opus_data.clone(),
-                sample_rate,
-                channels: 1,
-                num_frames: num_samples as u32,
-                bpm,
-                quantum,
-                bars,
-            };
-            let wire_data = AudioWire::encode(&audio_interval);
-
-            ui_info!(
-                app,
-                "[TEST TONE] Encoded: opus={} bytes, wire={} bytes",
-                opus_data.len(),
-                wire_data.len()
-            );
-
-            let _ = mesh.broadcast_audio(&wire_data).await;
-            *audio_intervals_sent += 1;
-            *audio_bytes_sent += wire_data.len() as u64;
-
-            let ready_msg = SyncMessage::AudioIntervalReady {
-                interval_index: idx,
-                wire_size: wire_data.len() as u32,
-            };
-            mesh.broadcast(&ready_msg).await;
-
-            let connected_peers = mesh.connected_peers();
-            ui_info!(app, "[TEST TONE] Broadcast interval {idx} to peers: [{}]", connected_peers.join(", "));
-        }
-        Err(e) => {
-            ui_warn!(app, "[TEST TONE] Encode failed: {e}");
-        }
-    }
-}
 
 struct AudioSendGate {
     gated: bool,


### PR DESCRIPTION
## Summary

Implements NINJAM-style progressive audio streaming, replacing the previous batch-encode-at-boundary model. Instead of encoding an entire interval (e.g. 8 seconds at 120 BPM / 4 bars) as a single Opus blob sent at the interval boundary, audio is now encoded and transmitted as 20ms Opus frames **during** the interval — so by the time the interval ends, most audio has already arrived at remote peers.

### Why this matters

The old model sent a burst of ~128 KB at the interval boundary, giving the receiver zero margin before playback. On a 200ms RTT connection with a 4-bar interval at 120 BPM, a late burst could miss its playback window entirely. NINJAM-style streaming distributes transmission across the full 8 seconds, providing the maximum possible delivery margin.

### New wire format: WAIF

New magic `b"WAIF"` (vs existing `b"WAIL"`) identifies streaming frames. Each frame is ~70–100 bytes — well under the 1200-byte WACH chunking threshold.

```
[4]  magic: "WAIF"
[1]  flags: bit0=stereo, bit1=final
[2]  stream_id: u16 LE
[8]  interval_index: i64 LE
[4]  frame_number: u32 LE
[2]  opus_len: u16 LE
[N]  opus_data
// Final frame only (+28 bytes):
[4]  sample_rate: u32 LE
[4]  total_frames: u32 LE
[8]  bpm: f64 LE
[8]  quantum: f64 LE
[4]  bars: u32 LE
```

### Changes

**`wail-audio`**
- `interval.rs`: Added `AudioFrame` struct for a single 20ms streaming frame
- `codec.rs`: Added `AudioEncoder::encode_frame()` — encodes exactly one 20ms Opus frame (zero-pads short input)
- `wire.rs`: Added `AudioFrameWire` with `encode()`/`decode()` alongside existing `AudioWire`
- `ipc.rs`: Added `IPC_TAG_AUDIO_FRAME = 0x05`, `encode_audio_frame()`, `decode_audio_frame()`
- `bridge.rs`: Added `current_interval_index()` accessor

**`wail-plugin-send`**
- Removed `RawInterval` batch path entirely
- Added `RawFrame` struct and `frame_tx` channel (bounded 512)
- `process()` accumulates input into `frame_buffer`, dispatches full 20ms frames immediately, flushes partial frame as `is_final=true` at interval boundary
- `ipc_thread_send()` simplified: single `recv_timeout` loop, one Opus encoder, no `crossbeam select!`

**`wail-plugin-recv`**
- Added `FrameAssembler`: collects frames by `(interval_index, stream_id, peer_id)`, assembles opus_data blob on final frame
- On assembly: decodes via per-stream `AudioDecoder` and feeds ring buffer
- Removed WAIL full-interval fallback path

**`wail-tauri/session.rs`**
- WAIF frames (tag 0x05) forwarded immediately to `mesh.broadcast_audio()` — no retry (next frame arrives in 20ms)
- Full-interval WAIL broadcast path removed
- Test tone removed (was WAIL-format only)
- `audio_rx` handler simplified: stats + recorder + IPC forward

**`wail-tauri/recorder.rs`, `commands.rs`, `events.rs`, `lib.rs`**
- Removed `OwnInterval`/`record_own`, `test_tone` param, `set_test_tone` command, `test_tone_enabled` from status event

### Bug fixes (from code review)
- **Missing final frame**: Interval silently dropped when `frame_buffer` empty at boundary — now always sends final frame signal
- **Shared Opus decoder**: Single decoder corrupted multi-peer audio — now per-stream decoders keyed by `(peer_id, stream_id)`
- **OOM protection**: `frame_number` bounded at 10,000 to prevent heap blow-up from untrusted peers
- **IPC thread leak**: Old recv thread never exited on re-initialization — added `AtomicBool` shutdown flag + 5s read timeout
- **unwrap() in production**: `FrameAssembler::insert` uses safe fallback path

## Test plan

- [ ] `cargo xtask test` — all tests pass
- [ ] Load WAIL Send + Recv in DAW, join a room with 2 peers, verify audio streams
- [ ] `RUST_LOG=debug` — confirm frame 0, 1, 2… logs from send plugin, final frame at boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)