### PR TITLE
fix: exclude private rooms from public server list after restart

### DIFF
--- a/.changeset/fix-private-rooms-in-public-list.md
+++ b/.changeset/fix-private-rooms-in-public-list.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Private (password-protected) rooms no longer appear in the public server list after a server restart.

--- a/crates/wail-net/tests/common/mod.rs
+++ b/crates/wail-net/tests/common/mod.rs
@@ -44,6 +44,9 @@ struct SignalingState {
     peer_senders: HashMap<String, HashMap<String, tokio::sync::mpsc::UnboundedSender<String>>>,
     /// "room:peer_id" keys scheduled to receive `evicted` on next message
     evicted_peers: HashSet<String>,
+    /// Per-room passwords (plaintext) set when the room was first created with a password.
+    /// A room in this map is considered private and excluded from the public /rooms list.
+    room_passwords: HashMap<String, String>,
     config: TestServerConfig,
 }
 
@@ -219,7 +222,7 @@ async fn handle_join_phase(
             }
         }
 
-        // Password check
+        // Global password check (applies to all rooms when config.password is set)
         if let Some(required) = &s.config.password.clone() {
             let sent = password.as_deref().unwrap_or("");
             if sent != required {
@@ -234,6 +237,36 @@ async fn handle_join_phase(
                     .await;
                 let _ = socket.close().await;
                 return None;
+            }
+        }
+
+        // Per-room password check (mirrors Go server behaviour: room is private if
+        // the first peer created it with a password; subsequent joiners must match it).
+        if s.config.password.is_none() {
+            let room_is_new = !s.rooms.contains_key(&room);
+            if let Some(stored) = s.room_passwords.get(&room) {
+                // Room exists and is private — enforce the password.
+                let sent = password.as_deref().unwrap_or("");
+                if sent != stored.as_str() {
+                    let _ = socket
+                        .send(Message::Text(
+                            serde_json::json!({
+                                "type": "join_error",
+                                "code": "unauthorized"
+                            })
+                            .to_string(),
+                        ))
+                        .await;
+                    let _ = socket.close().await;
+                    return None;
+                }
+            } else if room_is_new {
+                // Room is brand new — if the joining peer provides a password, mark it private.
+                if let Some(pw) = &password {
+                    if !pw.is_empty() {
+                        s.room_passwords.insert(room.clone(), pw.clone());
+                    }
+                }
             }
         }
 
@@ -374,6 +407,7 @@ async fn cleanup_peer(state: &SharedState, room: &str, peer_id: &str) {
         peers.retain(|p| p != peer_id);
         if peers.is_empty() {
             s.rooms.remove(room);
+            s.room_passwords.remove(room);
         }
     }
     s.peer_slots.remove(&format!("{room}:{peer_id}"));
@@ -406,9 +440,28 @@ async fn cleanup_peer(state: &SharedState, room: &str, peer_id: &str) {
 // Server startup
 // ---------------------------------------------------------------------------
 
+async fn handle_rooms(State(state): State<SharedState>) -> impl IntoResponse {
+    let s = state.lock().await;
+    let rooms: Vec<serde_json::Value> = s
+        .rooms
+        .iter()
+        .filter(|(name, _)| !s.room_passwords.contains_key(*name))
+        .map(|(name, peers)| {
+            serde_json::json!({
+                "room": name,
+                "peer_count": peers.len(),
+                "display_names": [],
+                "created_at": 0_i64,
+            })
+        })
+        .collect();
+    Json(serde_json::json!({ "rooms": rooms }))
+}
+
 fn build_app(state: SharedState) -> Router {
     Router::new()
         .route("/ws", get(handle_ws))
+        .route("/rooms", get(handle_rooms))
         .with_state(state)
 }
 

--- a/crates/wail-net/tests/signaling_tests.rs
+++ b/crates/wail-net/tests/signaling_tests.rs
@@ -8,6 +8,7 @@ mod common;
 use std::time::Duration;
 
 use common::{start_configured_signaling_server, TestServerConfig};
+use wail_net::signaling::list_public_rooms;
 use wail_net::PeerMesh;
 
 // ---------------------------------------------------------------
@@ -253,6 +254,49 @@ async fn room_recreatable_after_last_peer_leaves() {
     )
     .await;
     assert!(result.is_ok(), "New peer should create room with new password");
+}
+
+/// Private (password-protected) rooms are excluded from the public room list.
+/// Public rooms are included.
+#[tokio::test(flavor = "multi_thread")]
+async fn private_room_not_in_public_list() {
+    let _ = tracing_subscriber::fmt().with_env_filter("info").try_init();
+
+    let server = start_configured_signaling_server(TestServerConfig::default()).await;
+    let ice = wail_net::default_ice_servers();
+
+    // peer-a joins a private room with a password
+    let (_mesh_private, _, _) = PeerMesh::connect_full(
+        &server.url, "secret-room", "peer-a", Some("hunter2"),
+        ice.clone(), false, 1, None,
+    )
+    .await
+    .expect("peer-a should join secret-room with password");
+
+    // peer-b joins a public room without a password
+    let (_mesh_public, _, _) = PeerMesh::connect_with_ice(
+        &server.url, "open-room", "peer-b", None, ice,
+    )
+    .await
+    .expect("peer-b should join open-room");
+
+    // Give the server a moment to register both rooms
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let rooms = list_public_rooms(&server.url)
+        .await
+        .expect("list_public_rooms should succeed");
+
+    let room_names: Vec<&str> = rooms.iter().map(|r| r.room.as_str()).collect();
+
+    assert!(
+        room_names.contains(&"open-room"),
+        "open-room should appear in the public list, got: {room_names:?}"
+    );
+    assert!(
+        !room_names.contains(&"secret-room"),
+        "secret-room should NOT appear in the public list, got: {room_names:?}"
+    );
 }
 
 /// `stream_count > 1` consumes multiple capacity slots.

--- a/signaling-server/main.go
+++ b/signaling-server/main.go
@@ -102,6 +102,9 @@ func openDB() *sql.DB {
 	// Clean stale peers from previous run
 	cutoff := time.Now().Unix() - stalePeerSec
 	db.Exec("DELETE FROM peers WHERE last_seen < ?", cutoff)
+	// Remove rooms whose peers were all stale/crashed — prevents a public ghost room
+	// from persisting across a restart and blocking private re-creation of the same name.
+	db.Exec("DELETE FROM rooms WHERE room NOT IN (SELECT DISTINCT room FROM peers)")
 	return db
 }
 


### PR DESCRIPTION
## Summary

- Fixed private (password-protected) rooms leaking into the public server list after a signaling server restart.
- The Go server now cleans up orphaned rooms (those with no active peers) on startup, preventing stale public room entries from blocking private room recreation.
- The Rust test server now tracks per-room passwords and filters private rooms from the `/rooms` endpoint, with a new test to verify the behavior.

## Test Plan

- Run `cargo test -p wail-net` to verify the new test passes and all existing tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)