### PR TITLE
Fix peer list layout alignment (Issue #128)

### DIFF
--- a/.changeset/fix-peer-alignment.md
+++ b/.changeset/fix-peer-alignment.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix peer list alignment: separate slot label and peer name into distinct flex items so they are evenly distributed alongside the status badge and RTT display.

--- a/crates/wail-tauri/ui/main.js
+++ b/crates/wail-tauri/ui/main.js
@@ -525,7 +525,7 @@ async function setupListeners() {
         const status = sl.status || 'connecting';
         const statusClass = `peer-status status-${status}`;
         return `<div class="peer-item">
-          <span class="peer-name"><span class="peer-slot">Slot ${sl.slot}</span>${name}</span>
+          <span class="peer-slot">Slot ${sl.slot}</span><span class="peer-name">${name}</span>
           <span class="${statusClass}">${escapeHtml(status)}</span>
           <span class="peer-rtt">${rtt}</span>
         </div>`;

--- a/crates/wail-tauri/ui/style.css
+++ b/crates/wail-tauri/ui/style.css
@@ -426,7 +426,6 @@ summary {
 }
 
 .peer-slot {
-  margin-left: 6px;
   font-size: 10px;
   color: var(--fg-dim);
   font-weight: 400;


### PR DESCRIPTION
Fixes #128

Separates the slot label and peer name into distinct flex children of the peer-item container. This leverages the existing `justify-content: space-between` on the flex parent to evenly distribute the slot, name, status badge, and RTT display.

Previously, the slot and name were nested together, causing them to render with no space between them and appear as a single visual unit. Now all four elements are spaced evenly across the row.