### PR TITLE
fix: prevent crash and log spam on plugin reset and disconnect

### DIFF
--- a/.changeset/fix-reset-alloc.md
+++ b/.changeset/fix-reset-alloc.md
@@ -1,0 +1,8 @@
+---
+default: patch
+---
+
+Fix crash when Bitwig (or other hosts) calls start_processing: plugin reset() was
+dropping heap-allocated data (Strings, encoder/decoder objects) inside assert_no_alloc's
+no-alloc zone. Wrapped reset() bodies in permit_alloc, matching the existing pattern
+used in process().

--- a/crates/wail-e2e/src/main.rs
+++ b/crates/wail-e2e/src/main.rs
@@ -72,18 +72,20 @@ async fn main() -> Result<()> {
 
     let room = args.room.unwrap_or_else(|| format!("e2e-{}", &Uuid::new_v4().to_string()[..8]));
     let peer_id = format!("e2e-{}", &Uuid::new_v4().to_string()[..8]);
+    let identity = Uuid::new_v4().to_string();
     let global_timeout = Duration::from_secs(args.timeout);
 
     println!("=== WAIL E2E Test ===");
     println!("Room:       {room}");
     println!("Peer ID:    {peer_id}");
+    println!("Identity:   {identity}");
     println!("Server:     {}", args.server);
     println!("Intervals:  {}", args.intervals);
     println!("Burst:      {}", args.burst_intervals);
     println!("Timeout:    {global_timeout:.0?}");
     println!();
 
-    match timeout(global_timeout, run_test(&args.server, &room, &peer_id, args.intervals, args.burst_intervals)).await {
+    match timeout(global_timeout, run_test(&args.server, &room, &peer_id, &identity, args.intervals, args.burst_intervals)).await {
         Ok(Ok(())) => {
             println!("\n=== ALL TESTS PASSED ===");
             Ok(())
@@ -99,7 +101,7 @@ async fn main() -> Result<()> {
     }
 }
 
-async fn run_test(server_url: &str, room: &str, peer_id: &str, num_intervals: u32, burst_intervals: u32) -> Result<()> {
+async fn run_test(server_url: &str, room: &str, peer_id: &str, identity: &str, num_intervals: u32, burst_intervals: u32) -> Result<()> {
     let mut results: Vec<TestResult> = Vec::new();
 
     // --- Phase 1: ICE servers ---
@@ -186,7 +188,7 @@ async fn run_test(server_url: &str, room: &str, peer_id: &str, num_intervals: u3
 
     // --- Phase 5: Sync message exchange (Hello + Ping/Pong) ---
     let t = Instant::now();
-    let rtt_ms = run_sync_exchange(&mut mesh, &mut sync_rx, peer_id).await?;
+    let rtt_ms = run_sync_exchange(&mut mesh, &mut sync_rx, peer_id, identity).await?;
     results.push(TestResult::pass(
         "Sync",
         format!("Hello exchanged, RTT={rtt_ms:.1}ms"),
@@ -226,12 +228,12 @@ async fn run_test(server_url: &str, room: &str, peer_id: &str, num_intervals: u3
     let detail = if we_reconnect {
         run_reconnect_as_initiator(
             &mut mesh, &mut sync_rx, &mut audio_rx,
-            server_url, room, peer_id, &remote_peer_id,
+            server_url, room, peer_id, identity, &remote_peer_id,
         ).await?
     } else {
         run_reconnect_as_waiter(
             &mut mesh, &mut sync_rx, &mut audio_rx,
-            peer_id, &remote_peer_id,
+            peer_id, identity, &remote_peer_id,
         ).await?
     };
     results.push(TestResult::pass("Reconnect", detail, t.elapsed()));
@@ -311,12 +313,13 @@ async fn run_sync_exchange(
     mesh: &mut PeerMesh,
     sync_rx: &mut mpsc::UnboundedReceiver<(String, SyncMessage)>,
     peer_id: &str,
+    identity: &str,
 ) -> Result<f64> {
-    // Send Hello
+    // Send Hello with a real identity (same as Tauri app does)
     mesh.broadcast(&SyncMessage::Hello {
         peer_id: peer_id.to_string(),
         display_name: Some("e2e-test".into()),
-        identity: None,
+        identity: Some(identity.to_string()),
     })
     .await;
 
@@ -325,6 +328,7 @@ async fn run_sync_exchange(
     mesh.broadcast(&SyncMessage::Ping { id: 1, sent_at_us: ping_sent }).await;
 
     let mut got_hello = false;
+    let mut hello_had_identity = false;
     let mut rtt_us: Option<i64> = None;
 
     let result = timeout(Duration::from_secs(10), async {
@@ -332,7 +336,10 @@ async fn run_sync_exchange(
             tokio::select! {
                 Some((from, msg)) = sync_rx.recv() => {
                     match msg {
-                        SyncMessage::Hello { .. } => { got_hello = true; }
+                        SyncMessage::Hello { identity: ref id, .. } => {
+                            got_hello = true;
+                            hello_had_identity = id.is_some();
+                        }
                         SyncMessage::Ping { id, sent_at_us } => {
                             mesh.send_to(&from, &SyncMessage::Pong {
                                 id,
@@ -357,7 +364,12 @@ async fn run_sync_exchange(
     .await;
 
     match result {
-        Ok(Ok(())) => Ok(rtt_us.unwrap_or(0) as f64 / 1000.0),
+        Ok(Ok(())) => {
+            if !hello_had_identity {
+                warn!("Remote Hello arrived without identity — slot assignment will be skipped on Tauri side");
+            }
+            Ok(rtt_us.unwrap_or(0) as f64 / 1000.0)
+        }
         Ok(Err(e)) => bail!("Sync exchange failed: {e}"),
         Err(_) => {
             let detail = if !got_hello { "no Hello received" } else { "Hello OK but no Pong" };
@@ -565,6 +577,7 @@ async fn run_reconnect_as_initiator(
     server_url: &str,
     room: &str,
     peer_id: &str,
+    identity: &str,
     remote_peer_id: &str,
 ) -> Result<String> {
     println!("Closing WebRTC connection...");
@@ -609,7 +622,7 @@ async fn run_reconnect_as_initiator(
 
     // Verify sync
     println!("Verifying sync after reconnect...");
-    let rtt_ms = run_sync_exchange(mesh, sync_rx, peer_id).await?;
+    let rtt_ms = run_sync_exchange(mesh, sync_rx, peer_id, identity).await?;
     info!(rtt_ms, "Post-reconnect sync OK");
 
     // Verify audio
@@ -632,6 +645,7 @@ async fn run_reconnect_as_waiter(
     sync_rx: &mut mpsc::UnboundedReceiver<(String, SyncMessage)>,
     audio_rx: &mut mpsc::Receiver<(String, Vec<u8>)>,
     peer_id: &str,
+    identity: &str,
     remote_peer_id: &str,
 ) -> Result<String> {
     println!("Waiting for remote peer to disconnect and reconnect...");
@@ -713,7 +727,7 @@ async fn run_reconnect_as_waiter(
 
     // Verify sync
     println!("Verifying sync after reconnect...");
-    let rtt_ms = run_sync_exchange(mesh, sync_rx, peer_id).await?;
+    let rtt_ms = run_sync_exchange(mesh, sync_rx, peer_id, identity).await?;
     info!(rtt_ms, "Post-reconnect sync OK");
 
     // Verify audio

--- a/crates/wail-net/src/peer.rs
+++ b/crates/wail-net/src/peer.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use anyhow::Result;
 use bytes::Bytes;
 use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TrySendError;
 use tracing::{debug, error, info, warn};
 
 /// Max payload per DataChannel message.  Keep each chunk small enough
@@ -61,16 +62,18 @@ fn make_audio_handler(
                     let complete = std::mem::take(&mut state.buffer);
                     *guard = None;
                     debug!("[DC AUDIO IN] reassembled chunked {} bytes", complete.len());
-                    if tx.try_send(complete).is_err() {
+                    if let Err(TrySendError::Full(_)) = tx.try_send(complete) {
                         warn!("[DC AUDIO IN] channel full — dropping reassembled frame");
                     }
+                    // TrySendError::Closed: receiver gone (disconnecting) — silently discard
                 }
             } else {
                 // Non-chunked message (small enough to fit in one DC message)
                 debug!("[DC AUDIO IN] non-chunked {} bytes", data.len());
-                if tx.try_send(data).is_err() {
+                if let Err(TrySendError::Full(_)) = tx.try_send(data) {
                     warn!("[DC AUDIO IN] channel full — dropping frame");
                 }
+                // TrySendError::Closed: receiver gone (disconnecting) — silently discard
             }
         }) as std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
     };

--- a/crates/wail-plugin-recv/src/lib.rs
+++ b/crates/wail-plugin-recv/src/lib.rs
@@ -263,16 +263,21 @@ impl Plugin for WailRecvPlugin {
     }
 
     fn reset(&mut self) {
-        self.cumulative_samples = 0;
-        self.pending_names.clear();
-        for name in &mut self.applied_slot_names {
-            *name = None;
-        }
-        if let Ok(mut bridge) = self.bridge.lock() {
-            if let Some(ref mut b) = *bridge {
-                b.reset();
+        // reset() is called inside assert_no_alloc (via start_processing → process_wrapper).
+        // Dropping Strings (pending_names, applied_slot_names, RemoteInterval, peer_identity_map)
+        // and recreating the Opus encoder/decoder all require allocation — wrap in permit_alloc.
+        permit_alloc(|| {
+            self.cumulative_samples = 0;
+            self.pending_names.clear();
+            for name in &mut self.applied_slot_names {
+                *name = None;
             }
-        }
+            if let Ok(mut bridge) = self.bridge.lock() {
+                if let Some(ref mut b) = *bridge {
+                    b.reset();
+                }
+            }
+        });
     }
 
     fn process(

--- a/crates/wail-plugin-send/src/lib.rs
+++ b/crates/wail-plugin-send/src/lib.rs
@@ -233,15 +233,20 @@ impl Plugin for WailSendPlugin {
     }
 
     fn reset(&mut self) {
-        self.cumulative_samples = 0;
-        self.frame_buffer.clear();
-        self.streaming_interval_index = None;
-        self.streaming_frame_number = 0;
-        if let Ok(mut bridge) = self.bridge.lock() {
-            if let Some(ref mut b) = *bridge {
-                b.reset();
+        // reset() is called inside assert_no_alloc (via start_processing → process_wrapper).
+        // AudioBridge::reset() drops RemoteIntervals/peer_identity_map Strings and
+        // recreates the Opus encoder/decoder — wrap in permit_alloc.
+        permit_alloc(|| {
+            self.cumulative_samples = 0;
+            self.frame_buffer.clear();
+            self.streaming_interval_index = None;
+            self.streaming_frame_number = 0;
+            if let Ok(mut bridge) = self.bridge.lock() {
+                if let Some(ref mut b) = *bridge {
+                    b.reset();
+                }
             }
-        }
+        });
     }
 
     fn process(


### PR DESCRIPTION
## Summary

- Wrap `reset()` bodies in `permit_alloc` in both send/recv plugins — fixes SIGABRT when Bitwig calls `start_processing` after `stop_processing` (nih-plug wraps the callback in `assert_no_alloc`; dropping `String` fields and recreating Opus encoder/decoder triggered abort)
- Silence `TrySendError::Closed` log spam in audio DataChannel handler — only warn on `TrySendError::Full` (actual backpressure); `Closed` just means the receiver was dropped on disconnect
- Send real UUID identity in e2e `Hello` messages so Tauri slot assignment is exercised by the test

## Test plan

- [x] e2e test passes (all 9 phases including reconnect)
- [ ] Load `wail-plugin-recv` in Bitwig, start/stop playback — confirm no crash on `start_processing`
- [ ] Verify no "channel full" spam on disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)