### PR TITLE
fix: suppress noisy third-party logs from UI

### DIFF
--- a/.changeset/suppress-third-party-ui-logs.md
+++ b/.changeset/suppress-third-party-ui-logs.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Suppress noisy third-party crate logs (e.g. webrtc-rs ICE messages) from the UI log panel. Only WARN+ events from non-wail crates are forwarded to the frontend.

--- a/crates/wail-tauri/src/wslog.rs
+++ b/crates/wail-tauri/src/wslog.rs
@@ -104,6 +104,13 @@ where
         }
 
         let metadata = event.metadata();
+
+        // Only forward wail crate events to the UI; for third-party crates
+        // (webrtc-rs, tokio, etc.) require WARN+ to avoid flooding with
+        // internal messages like "pingAllCandidates called with no candidate pairs".
+        if !metadata.target().starts_with("wail") && *metadata.level() > tracing::Level::WARN {
+            return;
+        }
         let level = metadata.level().as_str().to_lowercase();
         let target = metadata.target().to_string();
 


### PR DESCRIPTION
Suppress INFO-level logs from third-party crates (webrtc-rs, tokio) in the UI log panel. Only messages at WARN+ from non-wail crates are forwarded to the frontend. This prevents internal messages like "pingAllCandidates called with no candidate pairs" from appearing ~5 times per second during ICE negotiation, while still surfacing genuine warnings and errors from external libraries.

Fixes excessive log noise during peer connection establishment.