### PR TITLE
Fix infinite pre-connect watchdog loop when ICE fails

### DIFF
--- a/.changeset/fix-preconnect-watchdog-loop.md
+++ b/.changeset/fix-preconnect-watchdog-loop.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix infinite "stuck in pre-connect" reconnection loop when ICE fails. Previously, the liveness watchdog called `close_peer` which transitions WebRTC state to `Closed` (not `Failed`), so the failure callback never fired — `last_seen` was never updated and the watchdog fired every 5 seconds indefinitely. Now `close_peer` always signals failure directly, and the watchdog skips peers already being reconnected.

--- a/crates/wail-net/src/lib.rs
+++ b/crates/wail-net/src/lib.rs
@@ -488,13 +488,20 @@ impl PeerMesh {
     }
 
     /// Close a specific peer's WebRTC connection (without removing from the mesh).
-    /// The connection state callback will fire, which can trigger `MeshEvent::PeerFailed`.
+    /// Always signals failure via `failure_tx` so the `PeerFailed` handler runs.
+    ///
+    /// Note: `pc.close()` transitions state to `Closed`, not `Failed`, so the
+    /// `on_peer_connection_state_change` callback does **not** send to `failure_tx`.
+    /// We send directly here to ensure the reconnect logic always fires.
     pub async fn close_peer(&self, peer_id: &str) {
         if let Some(pc) = self.peers.get(peer_id) {
             if let Err(e) = pc.close().await {
                 warn!(peer = %peer_id, error = %e, "Error closing peer connection");
             }
         }
+        // Signal failure directly — close() → Closed (not Failed), so the callback won't.
+        // The reconnect_pending guard in PeerFailed deduplicates concurrent events.
+        let _ = self.failure_tx.send(peer_id.to_string());
     }
 
     /// Remove a peer from the mesh, closing its WebRTC connection.

--- a/crates/wail-tauri/src/session.rs
+++ b/crates/wail-tauri/src/session.rs
@@ -1020,16 +1020,20 @@ async fn session_loop(
                     mesh.remove_peer(&dead_id).await;
                     let _ = app.emit("peer:left", PeerLeftEvent { peer_id: dead_id });
                 }
-                // Safety net: peers whose ICE never connected and are stuck beyond 2× the normal
-                // timeout. The PeerFailed path handles the common case (~30s ICE timeout); this
-                // catches the rare case where WebRTC never fires a Failed state at all.
+                // Safety net: peers whose ICE never connected and are stuck beyond the timeout.
+                // close_peer sends to failure_tx directly (pc.close() → Closed, not Failed,
+                // so the state-change callback does not fire it). The PeerFailed handler then
+                // schedules a reconnect timer with backoff.
                 const PRE_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
                 let stale_peers = peers.stale_preconnect_peers(PRE_CONNECT_TIMEOUT);
                 for stale_id in stale_peers {
+                    // Skip peers already being reconnected — their timer will update last_seen.
+                    if peers.get(&stale_id).is_some_and(|p| p.reconnect_pending) {
+                        continue;
+                    }
                     let name = peers.get(&stale_id).and_then(|p| p.display_name.as_deref()).unwrap_or(&stale_id).to_string();
                     ui_warn!(&app, "Peer {name} stuck in pre-connect — forcing reconnection after {PRE_CONNECT_TIMEOUT:?}");
                     mesh.close_peer(&stale_id).await;
-                    // close_peer triggers PeerConnectionState::Failed → failure_tx → PeerFailed handler
                 }
             }
 


### PR DESCRIPTION
## Summary

The liveness watchdog called `close_peer()` which transitions WebRTC state to `Closed` (not `Failed`), so the connection failure callback never fired. Without a `PeerFailed` event, `last_seen` was never updated and the watchdog fired every 5 seconds indefinitely when ICE negotiation stalled.

## Changes

- `close_peer()` now signals failure directly to `failure_tx` to ensure `PeerFailed` always runs
- Watchdog skips peers already being reconnected to prevent interference with in-flight timers
- Fixed incorrect comment claiming `close_peer()` triggers `Failed` state

🤖 Generated with [Claude Code](https://claude.com/claude-code)