### PR TITLE
Suppress third-party crate logs from peer broadcast

### DIFF
--- a/.changeset/suppress-tao-peer-broadcast.md
+++ b/.changeset/suppress-tao-peer-broadcast.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Filter out third-party crate log warnings (tao, webrtc) from peer log broadcast so remote peers only see WAIL-specific messages.

--- a/crates/wail-tauri/src/session.rs
+++ b/crates/wail-tauri/src/session.rs
@@ -304,7 +304,11 @@ async fn session_loop(
 
             // --- Outgoing peer log broadcast ---
             Ok(entry) = log_rx.recv(), if ws_log_handle.is_enabled() && signaling_reconnect.is_none() => {
-                mesh.send_log(&entry.level, &entry.target, &entry.message, entry.timestamp_us);
+                // Only broadcast wail-crate logs to peers; third-party warnings
+                // (tao, webrtc, tokio) are local concerns.
+                if entry.target.starts_with("wail") {
+                    mesh.send_log(&entry.level, &entry.target, &entry.message, entry.timestamp_us);
+                }
             }
 
             // --- Accept plugin IPC connection ---


### PR DESCRIPTION
## Summary

Filter out third-party crate warnings (tao, webrtc, tokio) from peer log broadcasts. These are local concerns and clutter remote peers' log panels.

Only wail-crate logs are now broadcast to peers. Third-party warnings remain visible in the local UI for debugging.

## Changes

- `crates/wail-tauri/src/session.rs`: Add target filter before sending logs to peers
- `.changeset/suppress-tao-peer-broadcast.md`: Changeset for patch release

🤖 Generated with Claude Code