### PR TITLE
fix: return KeepAlive from plugin process() to prevent DAW sleep

### DIFF
--- a/.changeset/plugin-keep-alive.md
+++ b/.changeset/plugin-keep-alive.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix plugins going inactive in Bitwig by returning `ProcessStatus::KeepAlive` instead of `ProcessStatus::Normal`. Both send and recv plugins must stay active at all times to maintain IPC communication with wail-app, even when outputting silence.

--- a/crates/wail-plugin-recv/src/lib.rs
+++ b/crates/wail-plugin-recv/src/lib.rs
@@ -445,7 +445,7 @@ impl Plugin for WailRecvPlugin {
             }
         }
 
-        ProcessStatus::Normal
+        ProcessStatus::KeepAlive
     }
 }
 

--- a/crates/wail-plugin-send/src/lib.rs
+++ b/crates/wail-plugin-send/src/lib.rs
@@ -401,7 +401,7 @@ impl Plugin for WailSendPlugin {
             }
         }
 
-        ProcessStatus::Normal
+        ProcessStatus::KeepAlive
     }
 }
 


### PR DESCRIPTION
## Summary
- Both send and recv plugins returned `ProcessStatus::Normal`, which lets DAWs like Bitwig deactivate them when outputting silence
- Changed to `ProcessStatus::KeepAlive` so the DAW keeps calling `process()` and IPC communication stays active

## Test plan
- [x] `cargo xtask test` passes
- [ ] Load recv plugin in Bitwig — verify it stays active with no incoming audio
- [ ] Load send plugin in Bitwig — verify it stays active with no input signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)