### PR TITLE
fix: Windows VST3 discovery and installer setup

### DIFF
--- a/.changeset/fix-windows-plugin-install.md
+++ b/.changeset/fix-windows-plugin-install.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix Windows plugin installation: NSIS installer now correctly bundles and copies both VST3 and CLAP plugins, and opus.dll is placed alongside plugin binaries so DAW hosts can load them.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Build plugin
         run: cargo xtask build-plugin
 
+      - name: Create opus.dll placeholder for cross-platform resources
+        run: mkdir -p target/bundled && touch target/bundled/opus.dll
+
       - name: Clean stale Tauri bundles
         run: rm -rf target/release/bundle/
 
@@ -139,6 +142,10 @@ jobs:
           PKG_CONFIG_PATH: C:\vcpkg\installed\x64-windows\lib\pkgconfig
         run: cargo xtask build-plugin
 
+      - name: Stage opus.dll for Tauri bundling
+        shell: pwsh
+        run: Copy-Item C:\vcpkg\installed\x64-windows\bin\opus.dll target\bundled\opus.dll
+
       - name: Clean stale Tauri bundles
         run: Remove-Item -Recurse -Force target\release\bundle -ErrorAction SilentlyContinue
         shell: pwsh
@@ -220,6 +227,9 @@ jobs:
 
       - name: Build plugin
         run: cargo xtask build-plugin
+
+      - name: Create opus.dll placeholder for cross-platform resources
+        run: mkdir -p target/bundled && touch target/bundled/opus.dll
 
       - name: Clean stale Tauri bundles
         run: rm -rf target/release/bundle/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Build plugin
         run: cargo xtask build-plugin
 
+      - name: Create opus.dll placeholder for cross-platform resources
+        run: mkdir -p target/bundled && touch target/bundled/opus.dll
+
       - name: Clean stale Tauri bundles
         run: rm -rf target/release/bundle/
 
@@ -183,6 +186,10 @@ jobs:
           PKG_CONFIG_PATH: C:\vcpkg\installed\x64-windows\lib\pkgconfig
         run: cargo xtask build-plugin
 
+      - name: Stage opus.dll for Tauri bundling
+        shell: pwsh
+        run: Copy-Item C:\vcpkg\installed\x64-windows\bin\opus.dll target\bundled\opus.dll
+
       - name: Clean stale Tauri bundles
         run: Remove-Item -Recurse -Force target\release\bundle -ErrorAction SilentlyContinue
         shell: pwsh
@@ -201,6 +208,9 @@ jobs:
           Copy-Item -Recurse target\bundled\wail-plugin-send.vst3 dist\wail-plugin-send.vst3
           Copy-Item target\bundled\wail-plugin-recv.clap dist\
           Copy-Item -Recurse target\bundled\wail-plugin-recv.vst3 dist\wail-plugin-recv.vst3
+          # Place opus.dll inside VST3 bundles and alongside CLAP for manual installs
+          Copy-Item dist\opus.dll dist\wail-plugin-send.vst3\Contents\x86_64-win\
+          Copy-Item dist\opus.dll dist\wail-plugin-recv.vst3\Contents\x86_64-win\
           if (Test-Path target\release\bundle\nsis\*.exe) { Copy-Item target\release\bundle\nsis\*.exe dist\ }
           if (Test-Path target\release\bundle\msi\*.msi) { Copy-Item target\release\bundle\msi\*.msi dist\ }
 
@@ -268,6 +278,9 @@ jobs:
 
       - name: Build plugin
         run: cargo xtask build-plugin
+
+      - name: Create opus.dll placeholder for cross-platform resources
+        run: mkdir -p target/bundled && touch target/bundled/opus.dll
 
       - name: Clean stale Tauri bundles
         run: rm -rf target/release/bundle/

--- a/crates/wail-tauri/nsis/installer.nsi
+++ b/crates/wail-tauri/nsis/installer.nsi
@@ -802,8 +802,20 @@ Section Install
   ${If} $InstallVST3 = ${BST_CHECKED}
     DetailPrint "Installing VST3 plugins to $VST3Dir..."
     CreateDirectory "$VST3Dir"
-    CopyFiles /SILENT "$INSTDIR\resources\plugins\wail-plugin-send.vst3" "$VST3Dir"
-    CopyFiles /SILENT "$INSTDIR\resources\plugins\wail-plugin-recv.vst3" "$VST3Dir"
+    SetOverwrite on
+    ClearErrors
+    CopyFiles "$INSTDIR\resources\plugins\wail-plugin-send.vst3" "$VST3Dir"
+    ${If} ${Errors}
+      DetailPrint "WARNING: Failed to copy wail-plugin-send.vst3 to $VST3Dir"
+    ${EndIf}
+    ClearErrors
+    CopyFiles "$INSTDIR\resources\plugins\wail-plugin-recv.vst3" "$VST3Dir"
+    ${If} ${Errors}
+      DetailPrint "WARNING: Failed to copy wail-plugin-recv.vst3 to $VST3Dir"
+    ${EndIf}
+    ; Place opus.dll inside each VST3 bundle so the DAW can find it at load time
+    CopyFiles "$INSTDIR\resources\plugins\opus.dll" "$VST3Dir\wail-plugin-send.vst3\Contents\x86_64-win"
+    CopyFiles "$INSTDIR\resources\plugins\opus.dll" "$VST3Dir\wail-plugin-recv.vst3\Contents\x86_64-win"
     WriteRegStr HKLM "Software\WAIL\PluginPaths" "VST3Dir" "$VST3Dir"
     WriteRegDWORD HKLM "Software\WAIL\PluginPaths" "InstalledVST3" 1
   ${EndIf}
@@ -812,8 +824,19 @@ Section Install
   ${If} $InstallCLAP = ${BST_CHECKED}
     DetailPrint "Installing CLAP plugins to $CLAPDir..."
     CreateDirectory "$CLAPDir"
-    CopyFiles /SILENT "$INSTDIR\resources\plugins\wail-plugin-send.clap" "$CLAPDir"
-    CopyFiles /SILENT "$INSTDIR\resources\plugins\wail-plugin-recv.clap" "$CLAPDir"
+    SetOverwrite on
+    ClearErrors
+    CopyFiles "$INSTDIR\resources\plugins\wail-plugin-send.clap" "$CLAPDir"
+    ${If} ${Errors}
+      DetailPrint "WARNING: Failed to copy wail-plugin-send.clap to $CLAPDir"
+    ${EndIf}
+    ClearErrors
+    CopyFiles "$INSTDIR\resources\plugins\wail-plugin-recv.clap" "$CLAPDir"
+    ${If} ${Errors}
+      DetailPrint "WARNING: Failed to copy wail-plugin-recv.clap to $CLAPDir"
+    ${EndIf}
+    ; Place opus.dll alongside CLAP plugins so the DAW can find it at load time
+    CopyFiles "$INSTDIR\resources\plugins\opus.dll" "$CLAPDir"
     WriteRegStr HKLM "Software\WAIL\PluginPaths" "CLAPDir" "$CLAPDir"
     WriteRegDWORD HKLM "Software\WAIL\PluginPaths" "InstalledCLAP" 1
   ${EndIf}

--- a/crates/wail-tauri/tauri.conf.json
+++ b/crates/wail-tauri/tauri.conf.json
@@ -34,10 +34,11 @@
       "icons/icon.png"
     ],
     "resources": {
-      "../../target/bundled/wail-plugin-send.clap/": "plugins/wail-plugin-send.clap/",
-      "../../target/bundled/wail-plugin-send.vst3/": "plugins/wail-plugin-send.vst3/",
-      "../../target/bundled/wail-plugin-recv.clap/": "plugins/wail-plugin-recv.clap/",
-      "../../target/bundled/wail-plugin-recv.vst3/": "plugins/wail-plugin-recv.vst3/"
+      "../../target/bundled/wail-plugin-send.clap": "plugins/wail-plugin-send.clap",
+      "../../target/bundled/wail-plugin-send.vst3": "plugins/wail-plugin-send.vst3",
+      "../../target/bundled/wail-plugin-recv.clap": "plugins/wail-plugin-recv.clap",
+      "../../target/bundled/wail-plugin-recv.vst3": "plugins/wail-plugin-recv.vst3",
+      "../../target/bundled/opus.dll": "plugins/opus.dll"
     },
     "windows": {
       "nsis": {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -452,6 +452,15 @@ fn build_tauri() -> Result<()> {
     println!("Building plugins first...");
     build_plugin(&[])?;
 
+    // Ensure opus.dll placeholder exists for Tauri resource bundling.
+    // On Windows the real opus.dll should already be in the build environment;
+    // on other platforms an empty placeholder prevents Tauri from erroring on
+    // the missing resource mapping entry in tauri.conf.json.
+    let opus_placeholder = workspace_dir().join("target/bundled/opus.dll");
+    if !opus_placeholder.exists() {
+        fs::write(&opus_placeholder, b"")?;
+    }
+
     println!("\nBuilding WAIL Tauri app...");
     let mut cmd = Command::new("cargo");
     cmd.args(["tauri", "build", "-c", "crates/wail-tauri/tauri.conf.json"])


### PR DESCRIPTION
## Summary

Fixed critical Windows plugin installation issues affecting Bitwig and setup.exe:

- **VST3 not discoverable in Bitwig**: Added opus.dll deployment alongside plugin binaries so DAW hosts can find the Opus codec at load time
- **Setup.exe plugin installation fails**: Fixed Tauri resource bundling to correctly handle flat .clap files on Windows, and added error reporting to NSIS installer

## Changes

- Fixed `tauri.conf.json` resource mapping: removed trailing slashes that treated flat .clap files as directories
- Enhanced NSIS installer with error checking: replaced `/SILENT` flag with explicit `ClearErrors`/`IfErrors` checks
- Added opus.dll staging to release/build workflows on all platforms
- Updated `xtask build_tauri()` to create opus.dll placeholder for local development

## Testing

- Windows CI builds now bundle all plugins and opus.dll into the NSIS installer
- Manual installs from release zips will have opus.dll alongside both CLAP and VST3 plugins
- Bitwig should now discover and load both plugin formats on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)