### PR TITLE
fix: add libx11-xcb-dev to Linux CI system dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,7 +200,8 @@ jobs:
             patchelf \
             libopus-dev \
             cmake \
-            g++
+            g++ \
+            libx11-xcb-dev
 
       - name: Install cargo-binstall
         run: which cargo-binstall || curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash


### PR DESCRIPTION
## Summary
- Adds `libx11-xcb-dev` to the `apt-get install` list in the `build-linux` CI job
- Fixes the Linux build failure: `The system library x11-xcb required by crate x11 was not found`

## Test plan
- [ ] Verify `build-linux` job passes (specifically the "Build plugin" step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)