### PR TITLE
fix: remove --delete-branch from merge queue workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -101,7 +101,7 @@ jobs:
             exit 1
           fi
           sleep 5
-          gh pr merge "$PR" --merge --delete-branch
+          gh pr merge "$PR" --merge
 
       # GITHUB_TOKEN merges don't trigger other workflows, so we run the
       # release steps inline instead of relying on release-on-merge.yml.


### PR DESCRIPTION
The `prepare-release` CI job fails because the `--delete-branch` flag is incompatible with GitHub's merge queue (enabled on main). This removes the flag; the release branch is already cleaned up separately via the GitHub API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)