### PR TITLE
feat: compensate for network latency when syncing beat at join time

### DIFF
--- a/.changeset/latency-compensated-force-beat.md
+++ b/.changeset/latency-compensated-force-beat.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Compensate for one-way network latency when snapping beat at join time. The `forceBeatAtTime` call now adds `RTT/2 * BPM/60` beats to account for the transit time of the first `StateSnapshot`, reducing join-time beat offset at higher latencies.

--- a/crates/wail-core/src/link.rs
+++ b/crates/wail-core/src/link.rs
@@ -64,13 +64,20 @@ impl LinkBridge {
     /// Uses `forceBeatAtTime` from the Link SDK — an immediate, non-negotiated
     /// timeline edit. Intended for one-shot join-time sync only; calling it
     /// repeatedly is disruptive to LAN Link peers.
-    pub fn force_beat(&mut self, beat: f64) {
+    ///
+    /// `rtt_us` is the round-trip time to the sender in microseconds. When
+    /// provided, the beat value is advanced by `RTT/2 * BPM/60` to compensate
+    /// for one-way transit time (the remote beat was sampled ~RTT/2 ago).
+    pub fn force_beat(&mut self, beat: f64, rtt_us: Option<i64>) {
         let time = self.link.clock_micros();
         self.link.capture_app_session_state(&mut self.session_state);
-        self.session_state.force_beat_at_time(beat, time, self.quantum);
+        let bpm = self.session_state.tempo();
+        let compensation = rtt_us.unwrap_or(0) as f64 / 2_000_000.0 * bpm / 60.0;
+        let compensated = beat + compensation;
+        self.session_state.force_beat_at_time(compensated, time, self.quantum);
         self.link.commit_app_session_state(&self.session_state);
         self.echo_guard_until = Some(Instant::now() + ECHO_GUARD_DURATION);
-        info!(beat, "Forced beat position for join-time sync");
+        info!(beat, compensated, rtt_us, "Forced beat position for join-time sync");
     }
 
     /// Apply a remote tempo change to the local Link session.
@@ -172,8 +179,8 @@ impl LinkBridge {
                             Some(LinkCommand::SetTempo(bpm)) => {
                                 self.set_tempo(bpm);
                             }
-                            Some(LinkCommand::ForceBeat(beat)) => {
-                                self.force_beat(beat);
+                            Some(LinkCommand::ForceBeat { beat, rtt_us }) => {
+                                self.force_beat(beat, rtt_us);
                             }
                             Some(LinkCommand::GetState(tx)) => {
                                 if tx.send(self.state()).is_err() {
@@ -195,7 +202,8 @@ impl LinkBridge {
 pub enum LinkCommand {
     SetTempo(f64),
     /// Snap the local beat clock to the given position (join-time sync only).
-    ForceBeat(f64),
+    /// `rtt_us` is used to compensate for one-way network transit time.
+    ForceBeat { beat: f64, rtt_us: Option<i64> },
     GetState(tokio::sync::oneshot::Sender<LinkState>),
 }
 

--- a/crates/wail-tauri/src/session.rs
+++ b/crates/wail-tauri/src/session.rs
@@ -806,7 +806,8 @@ async fn session_loop(
                         if !initial_beat_synced {
                             initial_beat_synced = true;
                             ui_info!(&app, "Beat sync — snapped to beat {remote_beat:.2}");
-                            if link_cmd_tx.send(LinkCommand::ForceBeat(remote_beat)).is_err() {
+                            let rtt_us = clock.rtt_us(&from);
+                            if link_cmd_tx.send(LinkCommand::ForceBeat { beat: remote_beat, rtt_us }).is_err() {
                                 ui_warn!(&app, "Link bridge stopped — cannot force beat");
                             }
                             interval.set_config(bars, quantum);


### PR DESCRIPTION
## Summary

When a peer joins and receives the first StateSnapshot, `forceBeatAtTime` now compensates for one-way network transit time by adding `RTT/2 * BPM/60` beats to the remote beat position. This reduces join-time beat offset at higher latencies (e.g., ~0.5 beats at 500ms RTT and 120 BPM).

The fix uses per-peer RTT measurements already tracked by ClockSync via Ping/Pong exchanges, falling back to zero compensation if no RTT data is available yet (safe default).

## Test plan

- [x] All existing tests pass (`cargo test -p wail-core`)
- [ ] Manual e2e test with high-latency peers to verify beat offset is reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)