### PR TITLE
fix: create opus.dll placeholder on non-Windows builds

### DIFF
--- a/crates/wail-tauri/build.rs
+++ b/crates/wail-tauri/build.rs
@@ -14,6 +14,17 @@ fn main() {
         }
     }
 
+    // On non-Windows, opus.dll doesn't exist but is declared in tauri.conf.json
+    // (needed for Windows bundles). Create an empty placeholder so tauri_build
+    // doesn't fail during `cargo tauri dev`.
+    #[cfg(not(target_os = "windows"))]
+    {
+        let opus_dll = bundled.join("opus.dll");
+        if !opus_dll.exists() {
+            std::fs::write(&opus_dll, []).ok();
+        }
+    }
+
     // Clean stale tauri_build resource output. CI caches the target/ directory
     // which includes OUT_DIR; if the resource mapping in tauri.conf.json changed,
     // stale file/directory entries cause conflicts (EEXIST, EISDIR).


### PR DESCRIPTION
Fix tauri_build panic during `cargo tauri dev` on macOS/Linux. The `opus.dll` resource is unconditionally declared in `tauri.conf.json` (required for Windows bundles), but the file doesn't exist on non-Windows platforms. Add platform-conditional placeholder creation in `build.rs`, matching the existing pattern used for CLAP/VST3 plugin bundles. This allows local development without requiring a CI-specific workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)