### PR TITLE
fix: replace --bundles none with --no-bundle for tauri-cli v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Build Tauri app
         env:
           PKG_CONFIG_PATH: C:\vcpkg\installed\x64-windows\lib\pkgconfig
-        run: cargo tauri build --bundles none
+        run: cargo tauri build --no-bundle
 
       - name: Determine version
         id: version


### PR DESCRIPTION
## Summary
- `cargo tauri build --bundles none` fails on newer tauri-cli v2 releases because `none` is no longer a valid bundle value (only `msi`/`nsis` are accepted)
- Replace with `--no-bundle`, the proper Tauri v2 flag for building the binary without creating any installer bundles

## Test plan
- [ ] Verify `build-windows` CI job passes — specifically the "Build Tauri app" step
- [ ] Confirm `target\release\WAIL.exe` is produced and subsequent Chocolatey packaging steps succeed

Grudgingly patched by Claude Code