### PR TITLE
Fix Windows release build: correct Tauri exe filename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
           New-Item -ItemType Directory -Force $staged
 
           # Main Tauri exe and resources
-          Copy-Item target\release\WAIL.exe $staged\
+          Copy-Item target\release\wail-tauri.exe $staged\WAIL.exe
           if (Test-Path target\release\resources) {
             Copy-Item -Recurse target\release\resources $staged\resources
           }


### PR DESCRIPTION
## Summary
Windows release builds fail at the Chocolatey packaging step because the workflow tries to copy `target\release\WAIL.exe`, but Tauri produces `target\release\wail-tauri.exe` (the Cargo binary name, not the `productName`). This single-line fix corrects the source path and explicitly renames the exe to `WAIL.exe` for downstream packaging.

## Changes
- `.github/workflows/release.yml`: Change `Copy-Item target\release\WAIL.exe` to `Copy-Item target\release\wail-tauri.exe $staged\WAIL.exe`

This fixes the failing release workflow (job 66501942067) that reported: `Cannot find path '...\\target\\release\\WAIL.exe' because it does not exist.`

🤖 Typed by Claude Code, let it take the blame