### PR TITLE
Fix Chocolatey nuspec schema for v2 compatibility

### DIFF
--- a/packaging/windows/wail.nuspec
+++ b/packaging/windows/wail.nuspec
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.chocolatey.org/2010/07/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>wail</id>
     <version>$version$</version>


### PR DESCRIPTION
## Summary
The `choco pack` step fails on Chocolatey v2.x because `wail.nuspec` uses the old 2010 Chocolatey-specific XML namespace, which was dropped in v2. Updates the namespace to the standard NuGet 2015 schema.

Fixes: `The schema version of 'wail' is incompatible with version 2.6.0.0 of NuGet.`

🤖 Powered by artificial mediocrity