### PR TITLE
Add peer chat to session view

### DIFF
--- a/.changeset/peer-chat.md
+++ b/.changeset/peer-chat.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add peer chat for WAIL session view. Musicians can now send text messages to other peers during jam sessions via a collapsible chat panel. Messages are sent over the existing WebRTC sync DataChannel and appear immediately on all connected peers with sender names and timestamps.

--- a/crates/wail-core/src/protocol.rs
+++ b/crates/wail-core/src/protocol.rs
@@ -81,6 +81,10 @@ pub enum SyncMessage {
         intervals_received: u64,
         plugin_connected: bool,
     },
+    ChatMessage {
+        sender_name: String,
+        text: String,
+    },
 }
 
 /// Messages exchanged over the WebSocket signaling channel.
@@ -201,6 +205,23 @@ mod tests {
                 assert_eq!(intervals_sent, 5);
                 assert_eq!(intervals_received, 3);
                 assert!(plugin_connected);
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn chat_message_roundtrip() {
+        let msg = SyncMessage::ChatMessage {
+            sender_name: "Ringo".into(),
+            text: "Let's change key".into(),
+        };
+        let json = serde_json::to_string(&msg).expect("serialize");
+        let decoded: SyncMessage = serde_json::from_str(&json).expect("deserialize");
+        match decoded {
+            SyncMessage::ChatMessage { sender_name, text } => {
+                assert_eq!(sender_name, "Ringo");
+                assert_eq!(text, "Let's change key");
             }
             other => panic!("unexpected variant: {other:?}"),
         }

--- a/crates/wail-tauri/src/commands.rs
+++ b/crates/wail-tauri/src/commands.rs
@@ -130,6 +130,15 @@ pub fn change_bpm(state: State<'_, SessionState>, bpm: f64) -> Result<(), String
 }
 
 #[tauri::command]
+pub fn send_chat(state: State<'_, SessionState>, text: String) -> Result<(), String> {
+    let session = state.lock().map_err(|e| e.to_string())?;
+    if let Some(ref handle) = *session {
+        let _ = handle.cmd_tx.send(SessionCommand::SendChat(text));
+    }
+    Ok(())
+}
+
+#[tauri::command]
 pub fn set_telemetry(handle: State<'_, TelemetryHandle>, enabled: bool) -> Result<(), String> {
     handle.set_enabled(enabled);
     info!(enabled, "Telemetry toggled");

--- a/crates/wail-tauri/src/events.rs
+++ b/crates/wail-tauri/src/events.rs
@@ -140,3 +140,10 @@ pub struct LogEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub peer_name: Option<String>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatMessageEvent {
+    pub sender_name: String,
+    pub is_own: bool,
+    pub text: String,
+}

--- a/crates/wail-tauri/src/lib.rs
+++ b/crates/wail-tauri/src/lib.rs
@@ -154,6 +154,7 @@ pub fn run(test_args: Option<TestModeArgs>) {
             commands::join_room,
             commands::disconnect,
             commands::change_bpm,
+            commands::send_chat,
             commands::set_telemetry,
             commands::set_log_sharing,
             commands::list_public_rooms,

--- a/crates/wail-tauri/src/session.rs
+++ b/crates/wail-tauri/src/session.rs
@@ -50,6 +50,7 @@ pub struct SessionHandle {
 
 pub enum SessionCommand {
     ChangeBpm(f64),
+    SendChat(String),
     Disconnect,
 }
 
@@ -294,6 +295,18 @@ async fn session_loop(
                         if link_cmd_tx.send(LinkCommand::SetTempo(new_bpm)).is_err() {
                             ui_warn!(&app, "Link bridge stopped");
                         }
+                    }
+                    SessionCommand::SendChat(text) => {
+                        let msg = SyncMessage::ChatMessage {
+                            sender_name: display_name.clone(),
+                            text: text.clone(),
+                        };
+                        mesh.broadcast(&msg).await;
+                        let _ = app.emit("chat:message", ChatMessageEvent {
+                            sender_name: display_name.clone(),
+                            is_own: true,
+                            text,
+                        });
                     }
                     SessionCommand::Disconnect => {
                         ui_info!(&app, "Disconnecting...");
@@ -851,6 +864,14 @@ async fn session_loop(
                             peer_audio_status.insert(from.clone(), cur);
                             ui_info!(&app, "[REMOTE {name}] dc_open={audio_dc_open}, sent={intervals_sent}, recv={intervals_received}, plugin={plugin_connected}");
                         }
+                    }
+
+                    SyncMessage::ChatMessage { sender_name, text } => {
+                        let _ = app.emit("chat:message", ChatMessageEvent {
+                            sender_name,
+                            is_own: false,
+                            text,
+                        });
                     }
                 }
             }

--- a/crates/wail-tauri/ui/index.html
+++ b/crates/wail-tauri/ui/index.html
@@ -207,6 +207,15 @@
           </div>
         </div>
       </section>
+
+      <details id="chat-toggle" open>
+        <summary>Chat</summary>
+        <div id="chat-messages" class="chat-messages"></div>
+        <div class="chat-input-row">
+          <input type="text" id="chat-input" placeholder="Message..." maxlength="1000" autocomplete="off">
+          <button type="button" id="chat-send-btn" class="small-btn">Send</button>
+        </div>
+      </details>
     </div>
 
     <!-- Network tab -->

--- a/crates/wail-tauri/ui/main.js
+++ b/crates/wail-tauri/ui/main.js
@@ -22,6 +22,9 @@ const settingsDisplayNameInput = document.getElementById('settings-display-name'
 const settingsTelemetryCheckbox = document.getElementById('settings-telemetry');
 const settingsLogSharingCheckbox = document.getElementById('settings-log-sharing');
 const settingsRememberCheckbox = document.getElementById('settings-remember');
+const chatInput = document.getElementById('chat-input');
+const chatSendBtn = document.getElementById('chat-send-btn');
+const chatMessages = document.getElementById('chat-messages');
 
 // Version label
 window.__TAURI__.app.getVersion().then(v => {
@@ -528,6 +531,7 @@ function showSession(room) {
   sessionScreen.style.display = '';
   sessionError.style.display = 'none';
   clearLog();
+  clearChatMessages();
   document.getElementById('session-room').textContent = room;
   document.getElementById('peer-list').innerHTML = '<span class="empty">No peers connected</span>';
   document.getElementById('session-audio').textContent = '0 / 0';
@@ -634,6 +638,15 @@ toggleTestToneBtn.addEventListener('click', async () => {
   updateTestToneUI();
 });
 
+// --- Chat ---
+chatSendBtn.addEventListener('click', sendChatMessage);
+chatInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    sendChatMessage();
+  }
+});
+
 // --- Event Listeners ---
 async function setupListeners() {
   cleanup();
@@ -717,6 +730,11 @@ async function setupListeners() {
     addLogEntry(p.level, p.message, p.peer_name || p.peer_id || null);
   }));
 
+  unlisten.push(await listen('chat:message', (event) => {
+    const p = event.payload;
+    addChatMessage(p.sender_name, p.is_own, p.text);
+  }));
+
   unlisten.push(await listen('peers:network', (event) => {
     const peers = event.payload.peers;
     const tbody = document.getElementById('network-table-body');
@@ -782,6 +800,53 @@ function clearLog() {
   const badge = document.getElementById('log-count');
   badge.textContent = '0';
   badge.className = 'log-badge';
+}
+
+// --- Chat panel ---
+const MAX_CHAT_ENTRIES = 200;
+
+function sendChatMessage() {
+  const text = chatInput.value.trim();
+  if (!text) return;
+  chatInput.value = '';
+  invoke('send_chat', { text }).catch(err => console.error('Send chat error:', err));
+}
+
+function addChatMessage(senderName, isOwn, text) {
+  const time = new Date().toLocaleTimeString();
+  const entry = document.createElement('div');
+  entry.className = 'chat-entry' + (isOwn ? ' chat-own' : '');
+
+  const sender = document.createElement('span');
+  sender.className = 'chat-sender';
+  sender.textContent = isOwn ? 'You' : senderName;
+
+  const timeSpan = document.createElement('span');
+  timeSpan.className = 'chat-time';
+  timeSpan.textContent = time;
+
+  const messageText = document.createElement('span');
+  messageText.className = 'chat-text';
+  messageText.textContent = text;
+
+  entry.appendChild(sender);
+  entry.appendChild(timeSpan);
+  entry.appendChild(messageText);
+
+  chatMessages.appendChild(entry);
+
+  // Cap at MAX_CHAT_ENTRIES
+  while (chatMessages.children.length > MAX_CHAT_ENTRIES) {
+    chatMessages.removeChild(chatMessages.firstChild);
+  }
+
+  // Auto-scroll to bottom
+  chatMessages.scrollTop = chatMessages.scrollHeight;
+}
+
+function clearChatMessages() {
+  chatMessages.innerHTML = '';
+  chatInput.value = '';
 }
 
 function escapeHtml(text) {

--- a/crates/wail-tauri/ui/style.css
+++ b/crates/wail-tauri/ui/style.css
@@ -859,6 +859,107 @@ summary:hover {
 }
 
 /* ================================================================
+   CHAT PANEL
+   ================================================================ */
+
+#chat-toggle {
+  margin-top: 12px;
+}
+
+#chat-toggle summary {
+  cursor: pointer;
+  color: var(--fg-dim);
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  list-style: none;
+}
+
+#chat-toggle summary::-webkit-details-marker {
+  display: none;
+}
+
+#chat-toggle summary::before {
+  content: '›';
+  display: inline-block;
+  margin-right: 6px;
+  font-size: 14px;
+  transition: transform var(--transition);
+}
+
+#chat-toggle[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.chat-messages {
+  max-height: 160px;
+  overflow-y: auto;
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+#chat-toggle[open] {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+#chat-toggle[open] .chat-messages {
+  height: 160px;
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+.chat-entry {
+  padding: 4px 10px;
+  font-size: 12px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 8px;
+  border-left: 2px solid rgba(255, 255, 255, 0.04);
+  margin-bottom: 1px;
+  word-break: break-word;
+  border-radius: 0 4px 4px 0;
+}
+
+.chat-entry.chat-own {
+  border-left-color: var(--accent);
+  background: var(--accent-dim);
+}
+
+.chat-sender {
+  font-weight: 500;
+  color: var(--fg);
+  white-space: nowrap;
+}
+
+.chat-time {
+  color: var(--fg-muted);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.chat-text {
+  color: var(--fg);
+  grid-column: 2;
+}
+
+.chat-input-row {
+  display: flex;
+  gap: 8px;
+}
+
+.chat-input-row input {
+  flex: 1;
+  min-width: 0;
+}
+
+.chat-input-row .small-btn {
+  flex-shrink: 0;
+}
+
+/* ================================================================
    MODAL (settings, plugin error)
    ================================================================ */
 


### PR DESCRIPTION
## Summary

Adds a text chat feature for WAIL sessions, allowing musicians to communicate during jam sessions. Messages are sent over the existing WebRTC sync DataChannel with no new infrastructure needed. The chat panel is collapsible, displays sender names and timestamps, and automatically clears on session reconnect.

## Implementation

- `ChatMessage` variant added to `SyncMessage` protocol with sender_name and text fields
- New `ChatMessageEvent` struct for frontend with `is_own` flag for styling own messages
- Session command handler broadcasts chat messages to all peers and echoes locally
- Collapsible chat UI panel with auto-scrolling message history (max 200 entries)
- Enter key and Send button send messages; chat input accepts up to 1000 characters
- Accent highlighting for own messages; proper cleanup on disconnect/rejoin

## Testing

All existing tests pass including new `chat_message_roundtrip` test for protocol serialization. Build verified with `cargo build -p wail-tauri`.

Co-Authored-By: Claude Code: working remotely today