### PR TITLE
Fix Opus decoder state leak across interval boundaries

### DIFF
--- a/.changeset/fix-decoder-state-leak.md
+++ b/.changeset/fix-decoder-state-leak.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix Opus decoder state leak across interval boundaries in recv plugin.

--- a/crates/wail-plugin-recv/src/lib.rs
+++ b/crates/wail-plugin-recv/src/lib.rs
@@ -466,7 +466,7 @@ fn ipc_thread_recv(
         );
     }
 
-    let mut decoders: HashMap<(String, u16), AudioDecoder> = HashMap::new();
+    let mut decoders: HashMap<(String, u16, i64), AudioDecoder> = HashMap::new();
 
     loop {
         if shutdown.load(Ordering::Relaxed) {
@@ -521,7 +521,7 @@ fn ipc_thread_recv(
                                                 // the final frame arrives. This ensures decoded
                                                 // PCM reaches the audio thread continuously,
                                                 // avoiding dropout at interval boundaries.
-                                                let dec_key = (peer_id.clone(), frame.stream_id);
+                                                let dec_key = (peer_id.clone(), frame.stream_id, frame.interval_index);
                                                 let dec = decoders.entry(dec_key).or_insert_with(|| {
                                                     match AudioDecoder::new(opus_rate, channels) {
                                                         Ok(d) => d,


### PR DESCRIPTION
## Summary
Fixes a critical bug where Opus decoders were reused across interval boundaries, allowing Packet Loss Concealment state from one interval to leak into the next. This violated NINJAM semantics where each interval must be logically independent.

## Changes
The decoder HashMap now keys on `(peer_id, stream_id, interval_index)` instead of just `(peer_id, stream_id)`, ensuring each interval gets its own independent decoder instance. This prevents PLC state carryover that could cause brief audio artifacts when frames are lost near boundaries.

## Test Status
All existing tests pass. The fix is minimal and surgical—only changing the decoder key and HashMap type annotation.

Claude Code: doing the typing you didn't want to do