### PR TITLE
Align connected badges in peer list

### DIFF
--- a/crates/wail-tauri/ui/style.css
+++ b/crates/wail-tauri/ui/style.css
@@ -604,6 +604,7 @@ summary:hover {
 .peer-name {
   font-weight: 600;
   font-size: 12px;
+  flex: 1;
 }
 
 .peer-slot {


### PR DESCRIPTION
## Summary
Added `flex: 1` to `.peer-name` in the peer list CSS to ensure status badges align vertically in the same column regardless of peer name length.

Previously, with `justify-content: space-between`, badges would shift horizontally based on the width of each peer's name. Now the name element expands to fill available space, keeping badges consistently positioned on the right.

💁 Claude Code: present but not responsible