### PR TITLE
feat: show own stereo pair sends in session view

### DIFF
--- a/.changeset/show-local-sends.md
+++ b/.changeset/show-local-sends.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Session view now shows your own stereo pair sends (WAIL Send plugin connections), so you can see whether your audio is connected and actively sending.

--- a/crates/wail-tauri/src/events.rs
+++ b/crates/wail-tauri/src/events.rs
@@ -50,6 +50,15 @@ pub struct PeerInfo {
     pub is_receiving: bool,
 }
 
+/// Local send plugin info: one entry per connected WAIL Send plugin instance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LocalSendInfo {
+    /// Stream index (0–14) matching the Send plugin's stream_index parameter.
+    pub stream_index: u16,
+    /// True if audio frames were received from this stream since the last status tick.
+    pub is_sending: bool,
+}
+
 /// Slot-centric view: one entry per occupied DAW aux output slot.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SlotInfo {
@@ -83,6 +92,7 @@ pub struct StatusUpdate {
     pub link_peers: u64,
     pub peers: Vec<PeerInfo>,
     pub slots: Vec<SlotInfo>,
+    pub local_sends: Vec<LocalSendInfo>,
     pub interval_bars: u32,
     pub audio_sent: u64,
     pub audio_recv: u64,

--- a/crates/wail-tauri/src/session.rs
+++ b/crates/wail-tauri/src/session.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
@@ -201,10 +202,10 @@ async fn session_loop(
 
     // One-shot logging flags for audio transmission milestones
     let mut logged_first_frame_sent = false;
-    let mut logged_first_frame_recv: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut logged_first_frame_recv: HashSet<String> = HashSet::new();
 
     // Track last-logged AudioStatus per peer to avoid flooding the UI
-    let mut peer_audio_status: std::collections::HashMap<String, (bool, bool)> = std::collections::HashMap::new();
+    let mut peer_audio_status: HashMap<String, (bool, bool)> = HashMap::new();
 
     // Test mode: track interval boundary timing
     let mut last_boundary_time: Option<Instant> = None;
@@ -216,6 +217,9 @@ async fn session_loop(
     let mut audio_bytes_sent: u64 = 0;
     let mut audio_intervals_sent: u64 = 0;
     let mut audio_bytes_recv: u64 = 0;
+    // Local send plugin tracking
+    let mut local_send_streams: HashMap<usize, u16> = HashMap::new(); // conn_id → stream_index
+    let mut local_send_active: HashSet<u16> = HashSet::new(); // streams that sent audio this tick
     // Per-interval delta counters (reset at each boundary)
     let mut interval_frames_sent: u64 = 0;
     let mut interval_frames_recv: u64 = 0;
@@ -373,6 +377,7 @@ async fn session_loop(
                             ipc_pool.push(conn_id, write_half);
                         } else {
                             // Send plugin — we don't need its write half (it only sends audio TO us)
+                            local_send_streams.insert(conn_id, stream_index);
                             drop(write_half);
                         }
                         let _ = app.emit("plugin:connected", ());
@@ -435,6 +440,11 @@ async fn session_loop(
                     if interval.current_index().is_none() {
                         debug!("audio dropped — interval not started yet");
                         continue;
+                    }
+                    // Track which stream is actively sending (WAIF: stream_id at bytes [5..7])
+                    if wire_data.len() >= 7 && &wire_data[0..4] == b"WAIF" {
+                        let stream_id = u16::from_le_bytes([wire_data[5], wire_data[6]]);
+                        local_send_active.insert(stream_id);
                     }
                     let failed_peers = mesh.broadcast_audio(&wire_data).await;
                     audio_bytes_sent += wire_data.len() as u64;
@@ -923,6 +933,7 @@ async fn session_loop(
             // --- IPC disconnect notification ---
             Some(conn_id) = ipc_disconnect_rx.recv() => {
                 ipc_pool.remove(conn_id);
+                local_send_streams.remove(&conn_id);
                 ui_info!(&app, "IPC connection {conn_id} removed");
             }
 
@@ -1200,6 +1211,17 @@ async fn session_loop(
                         .collect();
                     let _ = app.emit("peers:network", PeersNetwork { peers: network_infos });
 
+                    // Build local send plugin view and reset per-tick active set
+                    let mut local_sends: Vec<LocalSendInfo> = local_send_streams
+                        .values()
+                        .map(|&stream_index| LocalSendInfo {
+                            stream_index,
+                            is_sending: local_send_active.contains(&stream_index),
+                        })
+                        .collect();
+                    local_sends.sort_by_key(|ls| ls.stream_index);
+                    local_send_active.clear();
+
                     // Update snapshots for next tick
                     peers.flush_audio_recv_prev();
                     let _ = app.emit("status:update", StatusUpdate {
@@ -1209,6 +1231,7 @@ async fn session_loop(
                         link_peers: state.num_peers,
                         peers: peer_infos,
                         slots: slot_infos,
+                        local_sends,
                         interval_bars: interval.bars(),
                         audio_sent: audio_intervals_sent,
                         audio_recv: audio_intervals_received,

--- a/crates/wail-tauri/ui/main.js
+++ b/crates/wail-tauri/ui/main.js
@@ -681,13 +681,24 @@ async function setupListeners() {
       document.getElementById('recording-size').textContent = `${mb} MB`;
     }
 
-    // Update slot list (slot-centric view)
+    // Update slot list (local sends first, then remote slots)
     const slotList = document.getElementById('peer-list');
+    const localSends = s.local_sends || [];
     const slots = (s.slots || []).slice().sort((a, b) => a.slot - b.slot);
-    if (slots.length === 0) {
+    if (localSends.length === 0 && slots.length === 0) {
       slotList.innerHTML = '<span class="empty">No peers connected</span>';
     } else {
-      slotList.innerHTML = slots.map(sl => {
+      const localHtml = localSends.map(ls => {
+        const label = localSends.length > 1 ? `My Send (stream ${ls.stream_index})` : 'My Send';
+        const sendClass = ls.is_sending ? 'peer-status status-connected' : 'peer-status';
+        const sendLabel = ls.is_sending ? 'sending' : 'idle';
+        return `<div class="peer-item peer-item--local">
+          <span class="peer-slot">Send</span><span class="peer-name">${label}</span>
+          <span class="${sendClass}">${sendLabel}</span>
+          <span class="peer-rtt"></span>
+        </div>`;
+      }).join('');
+      const remoteHtml = slots.map(sl => {
         const name = sl.display_name
           ? `${escapeHtml(sl.display_name)} (${escapeHtml(sl.short_id)})`
           : escapeHtml(sl.short_id);
@@ -700,6 +711,7 @@ async function setupListeners() {
           <span class="peer-rtt">${rtt}</span>
         </div>`;
       }).join('');
+      slotList.innerHTML = localHtml + remoteHtml;
     }
   }));
 

--- a/crates/wail-tauri/ui/style.css
+++ b/crates/wail-tauri/ui/style.css
@@ -601,6 +601,11 @@ summary:hover {
   background: var(--bg-hover);
 }
 
+.peer-item--local {
+  border-left: 2px solid #88aaff;
+  opacity: 0.9;
+}
+
 .peer-name {
   font-weight: 600;
   font-size: 12px;


### PR DESCRIPTION
## Summary

Display WAIL Send plugin connections as local stereo pair sends in the session view. Users can now see whether their send plugins are connected and actively sending audio.

- Track connected send plugins (stream_index) and activity per tick
- Extract stream_id from WAIF frame headers to identify active streams
- Render local sends above remote slots with "sending" or "idle" status
- Visual distinction: blue left border for local send items

Reluctantly assisted by Claude Code