### PR TITLE
feat: make logs and chat top-level tabs

### DIFF
--- a/crates/wail-tauri/ui/index.html
+++ b/crates/wail-tauri/ui/index.html
@@ -151,6 +151,8 @@
 
     <div class="tab-bar">
       <button type="button" class="tab active" id="session-tab-session">Session</button>
+      <button type="button" class="tab" id="session-tab-chat">Chat</button>
+      <button type="button" class="tab" id="session-tab-logs">Logs <span id="log-count" class="log-badge">0</span></button>
       <button type="button" class="tab" id="session-tab-network">Network</button>
     </div>
 
@@ -208,14 +210,15 @@
         </div>
       </section>
 
-      <details id="chat-toggle" open>
-        <summary>Chat</summary>
-        <div id="chat-messages" class="chat-messages"></div>
-        <div class="chat-input-row">
-          <input type="text" id="chat-input" placeholder="Message..." maxlength="1000" autocomplete="off">
-          <button type="button" id="chat-send-btn" class="small-btn">Send</button>
-        </div>
-      </details>
+    </div>
+
+    <!-- Chat tab -->
+    <div id="session-tab-chat-content" style="display:none">
+      <div id="chat-messages" class="chat-messages"></div>
+      <div class="chat-input-row">
+        <input type="text" id="chat-input" placeholder="Message..." maxlength="1000" autocomplete="off">
+        <button type="button" id="chat-send-btn" class="small-btn">Send</button>
+      </div>
     </div>
 
     <!-- Network tab -->
@@ -238,14 +241,14 @@
       </table>
     </div>
 
+    <!-- Logs tab -->
+    <div id="session-tab-logs-content" style="display:none">
+      <div id="log-list" class="log-list"></div>
+    </div>
+
     <button type="button" id="disconnect-btn">Disconnect</button>
 
     <div id="session-error" class="error" style="display:none"></div>
-
-    <details id="log-toggle">
-      <summary>Logs <span id="log-count" class="log-badge">0</span></summary>
-      <div id="log-list" class="log-list"></div>
-    </details>
   </div>
 
   <!-- Plugin Install Error Modal -->

--- a/crates/wail-tauri/ui/main.js
+++ b/crates/wail-tauri/ui/main.js
@@ -493,23 +493,32 @@ settingsForm.addEventListener('submit', (e) => {
 
 // --- Session screen tab switching ---
 const sessionTabSessionBtn = document.getElementById('session-tab-session');
+const sessionTabChatBtn = document.getElementById('session-tab-chat');
+const sessionTabLogsBtn = document.getElementById('session-tab-logs');
 const sessionTabNetworkBtn = document.getElementById('session-tab-network');
 const sessionTabSessionContent = document.getElementById('session-tab-session-content');
+const sessionTabChatContent = document.getElementById('session-tab-chat-content');
+const sessionTabLogsContent = document.getElementById('session-tab-logs-content');
 const sessionTabNetworkContent = document.getElementById('session-tab-network-content');
 
-sessionTabSessionBtn.addEventListener('click', () => {
-  sessionTabSessionBtn.classList.add('active');
-  sessionTabNetworkBtn.classList.remove('active');
-  sessionTabSessionContent.style.display = '';
-  sessionTabNetworkContent.style.display = 'none';
-});
+const SESSION_TABS = [
+  { btn: sessionTabSessionBtn, content: sessionTabSessionContent },
+  { btn: sessionTabChatBtn,    content: sessionTabChatContent },
+  { btn: sessionTabLogsBtn,    content: sessionTabLogsContent },
+  { btn: sessionTabNetworkBtn, content: sessionTabNetworkContent },
+];
 
-sessionTabNetworkBtn.addEventListener('click', () => {
-  sessionTabNetworkBtn.classList.add('active');
-  sessionTabSessionBtn.classList.remove('active');
-  sessionTabSessionContent.style.display = 'none';
-  sessionTabNetworkContent.style.display = '';
-});
+function switchSessionTab(activeBtn) {
+  SESSION_TABS.forEach(({ btn, content }) => {
+    btn.classList.toggle('active', btn === activeBtn);
+    content.style.display = btn === activeBtn ? '' : 'none';
+  });
+}
+
+sessionTabSessionBtn.addEventListener('click', () => switchSessionTab(sessionTabSessionBtn));
+sessionTabChatBtn.addEventListener('click', () => switchSessionTab(sessionTabChatBtn));
+sessionTabLogsBtn.addEventListener('click', () => switchSessionTab(sessionTabLogsBtn));
+sessionTabNetworkBtn.addEventListener('click', () => switchSessionTab(sessionTabNetworkBtn));
 
 function showJoin() {
   firstLaunchScreen.style.display = 'none';

--- a/crates/wail-tauri/ui/style.css
+++ b/crates/wail-tauri/ui/style.css
@@ -757,36 +757,6 @@ summary:hover {
    LOG PANEL
    ================================================================ */
 
-#log-toggle {
-  margin-top: 12px;
-}
-
-#log-toggle summary {
-  cursor: pointer;
-  color: var(--fg-dim);
-  font-size: 11px;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  list-style: none;
-}
-
-#log-toggle summary::-webkit-details-marker {
-  display: none;
-}
-
-#log-toggle summary::before {
-  content: '›';
-  display: inline-block;
-  margin-right: 6px;
-  font-size: 14px;
-  transition: transform var(--transition);
-}
-
-#log-toggle[open] > summary::before {
-  transform: rotate(90deg);
-}
-
 .log-badge {
   background: rgba(255, 255, 255, 0.06);
   border-radius: 10px;
@@ -806,22 +776,17 @@ summary:hover {
   color: var(--state-error);
 }
 
-.log-list {
-  max-height: 200px;
-  overflow-y: auto;
-  margin-top: 8px;
-}
-
-#log-toggle[open] {
+#session-tab-logs-content {
   display: flex;
   flex-direction: column;
+  flex: 1;
   min-height: 0;
 }
 
-#log-toggle[open] .log-list {
-  height: 200px;
-  max-height: 200px;
+.log-list {
+  flex: 1;
   overflow-y: auto;
+  padding-top: 4px;
 }
 
 .log-entry {
@@ -868,53 +833,17 @@ summary:hover {
    CHAT PANEL
    ================================================================ */
 
-#chat-toggle {
-  margin-top: 12px;
-}
-
-#chat-toggle summary {
-  cursor: pointer;
-  color: var(--fg-dim);
-  font-size: 11px;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  list-style: none;
-}
-
-#chat-toggle summary::-webkit-details-marker {
-  display: none;
-}
-
-#chat-toggle summary::before {
-  content: '›';
-  display: inline-block;
-  margin-right: 6px;
-  font-size: 14px;
-  transition: transform var(--transition);
-}
-
-#chat-toggle[open] > summary::before {
-  transform: rotate(90deg);
-}
-
-.chat-messages {
-  max-height: 160px;
-  overflow-y: auto;
-  margin-top: 8px;
-  margin-bottom: 8px;
-}
-
-#chat-toggle[open] {
+#session-tab-chat-content {
   display: flex;
   flex-direction: column;
+  flex: 1;
   min-height: 0;
 }
 
-#chat-toggle[open] .chat-messages {
-  height: 160px;
-  max-height: 160px;
+.chat-messages {
+  flex: 1;
   overflow-y: auto;
+  margin-bottom: 8px;
 }
 
 .chat-entry {


### PR DESCRIPTION
## Summary
Move chat and logs from collapsible details sections into their own first-class tabs alongside Session and Network. This improves discoverability and gives more screen real estate to each section.

## Changes
- Add Chat and Logs as new tabs in the session view tab bar
- Remove `<details>` wrappers for chat and logs collapsible sections
- Refactor tab switching to use a unified `switchSessionTab()` function that works for all four tabs
- Update CSS to remove details-specific styling and properly flex the tab content areas

## Test plan
- Launch app with `cargo tauri dev`
- Session screen shows 4 tabs (Session, Chat, Logs, Network)
- Chat tab displays messages and input field; sending works
- Logs tab displays entries with count badge on the tab button; badge updates with warn/error colors
- Session tab shows peers and status (no longer contains chat/logs)
- Network tab unchanged

🤖 Generated with Claude Code