### PR TITLE
perf: use sccache for faster incremental builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
+[build]
+rustc-wrapper = "sccache"
+
 [alias]
 xtask = "run --package xtask --"
 


### PR DESCRIPTION
Enable sccache compiler cache to share compilation artifacts across git worktrees and branches, eliminating redundant recompilation when working with multiple worktrees in parallel.

Requires running `cargo install sccache` once locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)