### PR TITLE
fix: restore chat and logs tabs after session disconnect

### DIFF
--- a/crates/wail-tauri/ui/main.js
+++ b/crates/wail-tauri/ui/main.js
@@ -527,11 +527,7 @@ function showJoin() {
   joinError.style.display = 'none';
   joinBtn.disabled = false;
   joinBtn.textContent = 'Join Room';
-  // Reset session tabs to Session on leave
-  sessionTabSessionBtn.classList.add('active');
-  sessionTabNetworkBtn.classList.remove('active');
-  sessionTabSessionContent.style.display = '';
-  sessionTabNetworkContent.style.display = 'none';
+  switchSessionTab(sessionTabSessionBtn);
   cleanup();
 }
 


### PR DESCRIPTION
The showJoin() function had an incomplete tab reset that only handled Session and Network tabs, leaving Chat and Logs in stale state. This caused those tabs' content to remain visible after disconnect/reconnect cycles. Replace manual reset with switchSessionTab() to properly reset all 4 tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)