### PR TITLE
fix: update GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
       actions: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
     if: "!startsWith(github.event.head_commit.message, 'chore: prepare release')"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -36,7 +36,7 @@ jobs:
     runs-on: windows-latest
     if: "!startsWith(github.event.head_commit.message, 'chore: prepare release')"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -46,7 +46,7 @@ jobs:
 
       - name: Cache vcpkg
         id: vcpkg-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: C:\vcpkg\installed
           key: vcpkg-opus-x64-windows-v1
@@ -59,7 +59,7 @@ jobs:
         run: choco install pkgconfiglite -y
 
       - name: Cache CLI tools
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~\.cargo\bin\cargo-tauri.exe
@@ -110,7 +110,7 @@ jobs:
           Copy-Item dist\opus.dll dist\wail-plugin-send.vst3\Contents\x86_64-win\
           Copy-Item dist\opus.dll dist\wail-plugin-recv.vst3\Contents\x86_64-win\
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wail-windows-x64
           path: dist\
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: "!startsWith(github.event.head_commit.message, 'chore: prepare release')"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -143,7 +143,7 @@ jobs:
             libx11-xcb-dev
 
       - name: Cache CLI tools
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/cargo-tauri
           key: linux-cli-tools-v1
@@ -179,7 +179,7 @@ jobs:
           cp target/release/bundle/appimage/*.AppImage dist/ || true
           cp target/release/bundle/deb/*.deb dist/ || true
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wail-linux-x64
           path: dist/

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
       actions: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
   build-homebrew-tarball:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag || github.ref }}
           submodules: recursive
@@ -42,7 +42,7 @@ jobs:
           tar -czf "wail-${VERSION}-src.tar.gz" -C /tmp "${STAGING}"
           sha256sum "wail-${VERSION}-src.tar.gz" | awk '{print $1}' > "wail-${VERSION}-src.tar.gz.sha256"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wail-homebrew-src
           path: |
@@ -52,7 +52,7 @@ jobs:
   build-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag || github.ref }}
           submodules: recursive
@@ -63,7 +63,7 @@ jobs:
 
       - name: Cache vcpkg
         id: vcpkg-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: C:\vcpkg\installed
           key: vcpkg-opus-x64-windows-v1
@@ -76,7 +76,7 @@ jobs:
         run: choco install pkgconfiglite -y
 
       - name: Cache CLI tools
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~\.cargo\bin\cargo-tauri.exe
@@ -127,7 +127,7 @@ jobs:
           Copy-Item dist\opus.dll dist\wail-plugin-send.vst3\Contents\x86_64-win\
           Copy-Item dist\opus.dll dist\wail-plugin-recv.vst3\Contents\x86_64-win\
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wail-release-windows
           path: dist\
@@ -135,7 +135,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag || github.ref }}
           submodules: recursive
@@ -160,7 +160,7 @@ jobs:
             libx11-xcb-dev
 
       - name: Cache CLI tools
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/cargo-tauri
           key: linux-cli-tools-v1
@@ -196,7 +196,7 @@ jobs:
           cp target/release/bundle/appimage/*.AppImage dist/ || true
           cp target/release/bundle/deb/*.deb dist/ || true
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wail-release-linux
           path: dist/
@@ -207,9 +207,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag || github.ref }}
           path: source


### PR DESCRIPTION
## Summary
- Update `actions/checkout` v4 → v6
- Update `actions/upload-artifact` v4 → v7
- Update `actions/download-artifact` v4 → v8
- Update `actions/cache` v4 → v5

Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 2, 2026. These new major versions are the Node.js 24-compatible releases — no API breaking changes, just the runtime upgrade.

## Test plan
- [ ] Build workflow passes without Node.js 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)