### PR TITLE
Include version number in release artifact filenames

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,8 +228,9 @@ jobs:
 
       - name: Zip platform artifacts
         run: |
-          cd wail-release-windows && zip -r ../wail-windows-x64.zip . && cd ..
-          cd wail-release-linux && zip -r ../wail-linux-x64.zip . && cd ..
+          VERSION="${{ steps.tag.outputs.version }}"
+          cd wail-release-windows && zip -r ../wail-windows-x64-${VERSION}.zip . && cd ..
+          cd wail-release-linux && zip -r ../wail-linux-x64-${VERSION}.zip . && cd ..
 
       - name: Find individual installers
         id: files
@@ -242,8 +243,8 @@ jobs:
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           files: |
-            wail-windows-x64.zip
-            wail-linux-x64.zip
+            wail-windows-x64-${{ steps.tag.outputs.version }}.zip
+            wail-linux-x64-${{ steps.tag.outputs.version }}.zip
             ${{ steps.files.outputs.appimage }}
             ${{ steps.files.outputs.deb }}
             ${{ steps.files.outputs.src_tarball }}


### PR DESCRIPTION
## Summary
- Adds the version number to Windows and Linux release zip filenames (e.g. `wail-windows-x64-1.2.3.zip` instead of `wail-windows-x64.zip`)
- The source tarball, `.AppImage`, and `.deb` already included version numbers — this brings the platform zips in line

## Test plan
- [x] All existing tests pass (`cargo xtask test`)
- [ ] Verify on next release that artifacts are uploaded with versioned filenames

🤖 Claude Code was here and forgot to version the version numbers