### PR TITLE
feat: reserve stream index 0 for test tone, auto-name, and fix health %

### DIFF
--- a/crates/wail-plugin-send/src/params.rs
+++ b/crates/wail-plugin-send/src/params.rs
@@ -2,7 +2,8 @@ use nih_plug::prelude::*;
 
 #[derive(Params)]
 pub struct WailSendParams {
-    /// Stream index (0–14). Each index sends on a separate stream.
+    /// Stream index (1–14). Each index sends on a separate stream.
+    /// Index 0 is reserved for the built-in test tone generator.
     /// Same index from the same peer is mixed together on the receive side.
     #[id = "stream_index"]
     pub stream_index: IntParam,
@@ -16,7 +17,7 @@ pub struct WailSendParams {
 impl Default for WailSendParams {
     fn default() -> Self {
         Self {
-            stream_index: IntParam::new("Stream Index", 0, IntRange::Linear { min: 0, max: 14 }),
+            stream_index: IntParam::new("Stream Index", 1, IntRange::Linear { min: 1, max: 14 }),
             passthrough: BoolParam::new("Passthrough", false),
         }
     }

--- a/crates/wail-tauri/src/events.rs
+++ b/crates/wail-tauri/src/events.rs
@@ -60,6 +60,9 @@ pub struct LocalSendInfo {
     /// User-chosen name for this stream (e.g. "Bass"), if set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream_name: Option<String>,
+    /// True if this send is the virtual test tone generator (stream index 0).
+    #[serde(default)]
+    pub is_test_tone: bool,
 }
 
 /// Slot-centric view: one entry per occupied DAW aux output slot.

--- a/crates/wail-tauri/src/peers.rs
+++ b/crates/wail-tauri/src/peers.rs
@@ -29,6 +29,9 @@ pub struct PeerState {
     pub total_frames_expected: u64,
     /// Cumulative frames actually received (non-gap) across all assembled intervals.
     pub total_frames_received: u64,
+    /// Per-interval high-water mark for expected frame count, so we can incrementally
+    /// update `total_frames_expected` as non-final frames arrive (not just on the final).
+    pub interval_frames_expected: HashMap<i64, u64>,
     /// Cumulative WAIF frames that arrived for already-passed intervals.
     pub late_frames: u64,
     pub prev_status: String,
@@ -59,6 +62,7 @@ impl PeerState {
             remote_intervals_sent: 0,
             total_frames_expected: 0,
             total_frames_received: 0,
+            interval_frames_expected: HashMap::new(),
             late_frames: 0,
             prev_status: String::new(),
             added_at: Instant::now(),

--- a/crates/wail-tauri/src/session.rs
+++ b/crates/wail-tauri/src/session.rs
@@ -482,6 +482,12 @@ async fn session_loop(
         let conn_id = usize::MAX;
         tokio::spawn(test_tone_task(0, conn_id, ipc_tx, boundary_rx, cancel_rx));
         local_send_streams.insert(conn_id, 0);
+        let tone_name = if display_name.is_empty() {
+            "Test Tone".to_string()
+        } else {
+            format!("{}'s Test Tone", display_name)
+        };
+        local_stream_names.insert(0, tone_name);
         test_tone_boundary_tx = Some(boundary_tx);
         test_tone_cancel_tx = Some(cancel_tx);
         test_tone_stream = Some(0);
@@ -525,6 +531,10 @@ async fn session_loop(
                         if let Some(cancel_tx) = test_tone_cancel_tx.take() {
                             let _ = cancel_tx.send(true);
                         }
+                        // Clean up previous test tone stream name
+                        if let Some(prev_idx) = test_tone_stream {
+                            local_stream_names.remove(&prev_idx);
+                        }
                         test_tone_boundary_tx = None;
                         test_tone_stream = None;
                         test_mode = false;
@@ -541,6 +551,14 @@ async fn session_loop(
                             // Register in local_send_streams so it's tracked like a real plugin
                             local_send_streams.insert(conn_id, stream_index);
 
+                            // Auto-name the test tone stream
+                            let tone_name = if display_name.is_empty() {
+                                "Test Tone".to_string()
+                            } else {
+                                format!("{}'s Test Tone", display_name)
+                            };
+                            local_stream_names.insert(stream_index, tone_name);
+
                             test_tone_boundary_tx = Some(boundary_tx);
                             test_tone_cancel_tx = Some(cancel_tx);
                             test_tone_stream = Some(stream_index);
@@ -549,6 +567,9 @@ async fn session_loop(
                         } else {
                             ui_info!(&app, "[TEST] Test tone stopped");
                         }
+                        // Broadcast updated stream names to peers
+                        let msg = SyncMessage::StreamNames { names: stream_names_to_wire(&local_stream_names) };
+                        mesh.broadcast(&msg).await;
                     }
                     SessionCommand::Disconnect => {
                         ui_info!(&app, "Disconnecting...");
@@ -1197,8 +1218,27 @@ async fn session_loop(
                 if let Some(header) = wail_audio::peek_waif_header(&data) {
                     if let Some(peer) = peers.get_mut(&from) {
                         peer.total_frames_received += 1;
+                        // Use frame_number (0-based) to infer expected count:
+                        // each frame tells us at least frame_number+1 frames exist
+                        // for this interval. The final frame carries the authoritative
+                        // total_frames count. Track per-interval high-water mark to
+                        // avoid double-counting across intervals.
+                        let interval_expected = if header.is_final {
+                            header.total_frames as u64
+                        } else {
+                            header.frame_number as u64 + 1
+                        };
+                        let prev = peer.interval_frames_expected
+                            .entry(header.interval_index)
+                            .or_insert(0);
+                        if interval_expected > *prev {
+                            peer.total_frames_expected += interval_expected - *prev;
+                            *prev = interval_expected;
+                        }
+                        // Clean up: once the final frame arrives the count is
+                        // authoritative, so remove the entry to bound map growth.
                         if header.is_final {
-                            peer.total_frames_expected += header.total_frames as u64;
+                            peer.interval_frames_expected.remove(&header.interval_index);
                         }
                         // Detect late frames: frames for intervals we've already passed
                         if let Some(current_idx) = last_interval_index {
@@ -1591,6 +1631,7 @@ async fn session_loop(
                             stream_index,
                             is_sending: local_send_active.contains(&stream_index),
                             stream_name: local_stream_names.get(&stream_index).cloned(),
+                            is_test_tone: test_tone_stream == Some(stream_index),
                         })
                         .collect();
                     local_sends.sort_by_key(|ls| ls.stream_index);

--- a/crates/wail-tauri/ui/index.html
+++ b/crates/wail-tauri/ui/index.html
@@ -165,11 +165,7 @@
             <label>Test Tone</label>
             <select id="test-tone-select" class="small-select">
               <option value="">None</option>
-              <option value="0">Send 0</option>
-              <option value="1">Send 1</option>
-              <option value="2">Send 2</option>
-              <option value="3">Send 3</option>
-              <option value="4">Send 4</option>
+              <option value="0">Test Tone</option>
             </select>
           </div>
           <div class="status-cell" id="recording-stat" style="display:none">

--- a/crates/wail-tauri/ui/main.js
+++ b/crates/wail-tauri/ui/main.js
@@ -735,7 +735,8 @@ function renderStatus(s) {
 
   // Update slot list (local sends first, then remote slots)
   const slotList = document.getElementById('peer-list');
-  const localSends = s.local_sends || [];
+  // Filter out test tone entries that aren't actively sending
+  const localSends = (s.local_sends || []).filter(ls => !ls.is_test_tone || ls.is_sending);
   const slots = (s.slots || []).slice().sort((a, b) => a.slot - b.slot);
   if (localSends.length === 0 && slots.length === 0) {
     slotList.innerHTML = '<span class="empty">No peers connected</span>';


### PR DESCRIPTION
## Summary
- Reserves stream index 0 for the built-in test tone generator; real WAIL Send plugins now use indices 1-14
- Test tone dropdown simplified to "None" / "Test Tone" instead of Send 0-4
- Auto-names the test tone stream as "{Name}'s Test Tone" (broadcast to remote peers)
- Hides test tone from the peer list when not actively sending
- Fixes health % showing >100% (e.g. 132.8%) — `frames_expected` now tracks per-interval high-water marks from every WAIF frame instead of only accumulating on final frames

## Test plan
- [ ] `cargo build -p wail-tauri -p wail-plugin-send` compiles
- [ ] `cargo xtask test` — all tests pass (except pre-existing recv_plugin_e2e)
- [ ] Launch app → test tone dropdown shows "None" and "Test Tone"
- [ ] Select "Test Tone" → appears in peer list as "{Name}'s Test Tone" with "sending" status
- [ ] Select "None" → test tone disappears from peer list
- [ ] Remote peer sees the test tone stream name
- [ ] Health % stays ≤100% during a session

🧠 Claude Code was here and has opinions about stream indices