### PR TITLE
fix: preserve completed sessions when room empties

### DIFF
--- a/signaling-server/main.go
+++ b/signaling-server/main.go
@@ -604,7 +604,8 @@ func (h *hub) leaveUnlocked(c *conn) {
 		// If room is empty, clean up
 		if peerCountAfter == 0 {
 			delete(h.rooms, room)
-			delete(h.completedSessions, room)
+			// Keep completedSessions — they're capped at maxCompletedSessions
+			// per room and are the only way the dashboard shows historical data.
 			h.db.Exec("DELETE FROM rooms WHERE room = ?", room)
 		}
 	}


### PR DESCRIPTION
## Summary
- When the last peer left a room, `leaveUnlocked` deleted all `completedSessions` for that room (`delete(h.completedSessions, room)`)
- Since both peers typically disconnect within seconds, the metrics dashboard almost never had time to display the completed session data before it was wiped — the `/metrics` endpoint always returned empty arrays
- Removed the `delete(h.completedSessions, room)` call; the per-room cap of 50 sessions already prevents unbounded growth

## Test plan
- [ ] Deploy to fly.io and run a 2-peer session
- [ ] After both peers disconnect, verify `/metrics` still returns the completed session
- [ ] Verify the dashboard at `/metrics/dashboard` shows the completed session history

🤖 Claude Code was involved and is sorry