### PR TITLE
feat: skip force_beat for same-LAN peers

### DIFF
--- a/crates/wail-e2e/src/main.rs
+++ b/crates/wail-e2e/src/main.rs
@@ -232,7 +232,7 @@ async fn wait_for_peer(mesh: &mut PeerMesh) -> Result<String> {
                 info!(peer = %rid, name = ?display_name, "Peer joined");
                 return Ok(rid);
             }
-            Ok(Ok(Some(MeshEvent::PeerListReceived(_)))) => {
+            Ok(Ok(Some(MeshEvent::PeerListReceived { .. }))) => {
                 // After join, check if any peers were already in the room
                 if let Some(rid) = mesh.connected_peers().into_iter().next() {
                     return Ok(rid);

--- a/crates/wail-net/src/lib.rs
+++ b/crates/wail-net/src/lib.rs
@@ -27,6 +27,8 @@ pub struct PeerMesh {
     initial_peer_names: HashMap<String, Option<String>>,
     /// Cumulative count of audio frames dropped due to outgoing channel backpressure.
     audio_send_drops: Arc<AtomicU64>,
+    /// True if another peer from the same public IP (LAN) is already in the room.
+    lan_peer_present: bool,
 }
 
 impl PeerMesh {
@@ -45,7 +47,7 @@ impl PeerMesh {
         mpsc::UnboundedReceiver<(String, SyncMessage)>,
         mpsc::Receiver<(String, Vec<u8>)>,
     )> {
-        let (signaling, channels, initial_peer_names) = SignalingClient::connect_with_options(
+        let (signaling, channels, initial_peer_names, lan_peer_present) = SignalingClient::connect_with_options(
             server_url, room, peer_id, password, stream_count, display_name,
         ).await?;
 
@@ -57,6 +59,7 @@ impl PeerMesh {
             stream_count,
             initial_peer_names,
             audio_send_drops: Arc::new(AtomicU64::new(0)),
+            lan_peer_present,
         };
 
         Ok((mesh, channels.sync_rx, channels.audio_rx))
@@ -111,7 +114,7 @@ impl PeerMesh {
                         self.peers.insert(remote_id);
                     }
                 }
-                Ok(Some(MeshEvent::PeerListReceived(peer_count)))
+                Ok(Some(MeshEvent::PeerListReceived { count: peer_count, lan_peer_present: self.lan_peer_present }))
             }
 
             SignalMessage::PeerJoined { peer_id: remote_id, display_name } => {
@@ -226,7 +229,7 @@ impl PeerMesh {
         // Suppress the automatic `leave` on the old WebSocket
         self.signaling.suppress_leave_on_close();
 
-        let (new_signaling, channels, initial_peer_names) = SignalingClient::connect_with_options(
+        let (new_signaling, channels, initial_peer_names, _lan_peer_present) = SignalingClient::connect_with_options(
             server_url, room, &self.peer_id, password, self.stream_count, display_name,
         ).await?;
 
@@ -259,7 +262,7 @@ impl PeerMesh {
 /// Events from the peer mesh.
 #[derive(Debug)]
 pub enum MeshEvent {
-    PeerListReceived(usize),
+    PeerListReceived { count: usize, lan_peer_present: bool },
     PeerJoined {
         peer_id: String,
         display_name: Option<String>,

--- a/crates/wail-net/src/signaling.rs
+++ b/crates/wail-net/src/signaling.rs
@@ -107,6 +107,8 @@ enum ServerMsg {
         peers: Vec<String>,
         #[serde(default)]
         peer_display_names: HashMap<String, Option<String>>,
+        #[serde(default)]
+        lan_peer_present: bool,
     },
     #[serde(rename = "join_error")]
     JoinError {
@@ -171,7 +173,7 @@ impl SignalingClient {
         room: &str,
         peer_id: &str,
         password: Option<&str>,
-    ) -> Result<(Self, SignalingChannels, HashMap<String, Option<String>>)> {
+    ) -> Result<(Self, SignalingChannels, HashMap<String, Option<String>>, bool)> {
         Self::connect_with_options(server_url, room, peer_id, password, 1, None).await
     }
 
@@ -186,7 +188,7 @@ impl SignalingClient {
         password: Option<&str>,
         stream_count: u16,
         display_name: Option<&str>,
-    ) -> Result<(Self, SignalingChannels, HashMap<String, Option<String>>)> {
+    ) -> Result<(Self, SignalingChannels, HashMap<String, Option<String>>, bool)> {
         let ws_url = format!("{}/ws", server_url.trim_end_matches('/'));
 
         let (ws_stream, _) = tokio_tungstenite::connect_async(&ws_url).await?;
@@ -226,11 +228,12 @@ impl SignalingClient {
             }
         };
 
-        let (peers, initial_peer_names) = match join_response {
+        let (peers, initial_peer_names, lan_peer_present) = match join_response {
             ServerMsg::JoinOk {
                 peers,
                 peer_display_names,
-            } => (peers, peer_display_names),
+                lan_peer_present,
+            } => (peers, peer_display_names, lan_peer_present),
             ServerMsg::JoinError {
                 code,
                 min_version,
@@ -467,6 +470,7 @@ impl SignalingClient {
             },
             channels,
             initial_peer_names,
+            lan_peer_present,
         ))
     }
 }

--- a/crates/wail-tauri/src/session.rs
+++ b/crates/wail-tauri/src/session.rs
@@ -357,6 +357,7 @@ async fn session_loop(
     let mut last_broadcast_bpm: f64 = bpm;
     let mut initial_beat_synced = false;
     let mut is_joiner = false;
+    let mut skip_force_beat = false;
 
     // One-shot logging flags for audio transmission milestones
     let mut logged_first_frame_sent = false;
@@ -790,12 +791,17 @@ async fn session_loop(
                         remove_peer_fully(&mut peers, &mut ipc_pool, &pid).await;
                         let _ = app.emit("peer:left", PeerLeftEvent { peer_id: pid });
                     }
-                    Ok(Some(wail_net::MeshEvent::PeerListReceived(n))) => {
+                    Ok(Some(wail_net::MeshEvent::PeerListReceived { count: n, lan_peer_present })) => {
                         // Seed liveness for initial peers so the watchdog can
                         // detect peers that connect but never send any messages.
                         peers.seed_last_seen();
                         is_joiner = n > 0;
-                        ui_info!(&app, "Joined room with {n} peer(s)");
+                        skip_force_beat = lan_peer_present;
+                        if lan_peer_present {
+                            ui_info!(&app, "Joined room with {n} peer(s) — LAN peer detected, will rely on Link sync");
+                        } else {
+                            ui_info!(&app, "Joined room with {n} peer(s)");
+                        }
                     }
                     Ok(Some(wail_net::MeshEvent::PeerLogBroadcast { from, level, message, .. })) => {
                         if ws_log_handle.is_enabled() {
@@ -981,12 +987,16 @@ async fn session_loop(
                     SyncMessage::StateSnapshot { bpm: remote_bpm, beat: remote_beat, .. } => {
                         if !initial_beat_synced {
                             initial_beat_synced = true;
-                            if is_joiner {
+                            if is_joiner && !skip_force_beat {
                                 ui_info!(&app, "Beat sync — snapped to beat {remote_beat:.2}");
                                 let rtt_us = clock.rtt_us(&from);
                                 if link_cmd_tx.send(LinkCommand::ForceBeat { beat: remote_beat, rtt_us }).is_err() {
                                     ui_warn!(&app, "Link bridge stopped — cannot force beat");
                                 }
+                                let new_idx = compute_interval_index(remote_beat, interval_bars, interval_quantum);
+                                last_interval_index = Some(new_idx);
+                            } else if is_joiner && skip_force_beat {
+                                ui_info!(&app, "Beat sync — LAN peer already in room, relying on Link sync");
                                 let new_idx = compute_interval_index(remote_beat, interval_bars, interval_quantum);
                                 last_interval_index = Some(new_idx);
                             } else {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -212,11 +212,17 @@ App→Recv Plugin: AudioInterval (tag 0x01) with peer_id identifying the remote 
 ```
 1. Peer connects to WebSocket signaling server, sends join (with room password, stream_count, client_version)
    - Server rejects outdated clients with join_error code "version_outdated"
-2. Server replies with join_ok containing list of existing peers
+2. Server replies with join_ok containing list of existing peers and lan_peer_present flag
 3. All sync and audio data flows through the server (no direct P2P connections)
    - Sync: JSON text frames relayed via "sync" / "sync_to" message types
    - Audio: binary WebSocket frames relayed with sender header prepended by server
 ```
+
+### LAN Peer Detection
+
+The signaling server records each client's public IP (from `Fly-Client-IP`, `X-Forwarded-For`, or `RemoteAddr`). When a peer joins a room, the server checks whether any existing peer shares the same public IP — indicating they are on the same LAN. The `join_ok` response includes a `lan_peer_present` boolean.
+
+When `lan_peer_present` is true, the joining peer skips the `ForceBeat` command that normally snaps its beat position to the room owner's. This is because Ableton Link already handles beat/phase synchronization natively over LAN multicast — applying `ForceBeat` on top would conflict with Link's own sync and cause a double-correction.
 
 ## Interval Boundaries
 

--- a/signaling-server/main.go
+++ b/signaling-server/main.go
@@ -7,9 +7,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -80,10 +82,11 @@ type wsMessage struct {
 
 // conn wraps a single WebSocket connection that has joined a room.
 type conn struct {
-	ws     *websocket.Conn
-	room   string
-	peerID string
-	send   chan wsMessage
+	ws       *websocket.Conn
+	room     string
+	peerID   string
+	send     chan wsMessage
+	publicIP string // client's public IP for LAN detection
 }
 
 // ---------------------------------------------------------------------------
@@ -480,11 +483,28 @@ func (h *hub) join(c *conn, msg clientMsg) {
 		}
 	}
 
+	// Check if any existing peer shares the joiner's public IP (same LAN)
+	lanPeerPresent := false
+	if roomConns, ok := h.rooms[room]; ok {
+		for id, rc := range roomConns {
+			if id != peerID && rc.publicIP == c.publicIP {
+				lanPeerPresent = true
+				ipPrefix := c.publicIP
+				if len(ipPrefix) > 8 {
+					ipPrefix = ipPrefix[:8]
+				}
+				log.Printf("peer %s shares LAN with existing peer %s (IP prefix: %s…)", peerID, id, ipPrefix)
+				break
+			}
+		}
+	}
+
 	// Send join_ok
 	c.sendJSON(map[string]any{
 		"type":               "join_ok",
 		"peers":              peers,
 		"peer_display_names": peerDisplayNames,
+		"lan_peer_present":   lanPeerPresent,
 	})
 }
 
@@ -806,6 +826,22 @@ var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool { return true },
 }
 
+// clientIP extracts the client's public IP from the request, checking
+// proxy headers (fly.io, standard) before falling back to RemoteAddr.
+func clientIP(r *http.Request) string {
+	if ip := r.Header.Get("Fly-Client-IP"); ip != "" {
+		return ip
+	}
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		return strings.TrimSpace(strings.Split(xff, ",")[0])
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
 func handleWS(h *hub, w http.ResponseWriter, r *http.Request) {
 	ws, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
@@ -814,8 +850,9 @@ func handleWS(h *hub, w http.ResponseWriter, r *http.Request) {
 	}
 
 	c := &conn{
-		ws:   ws,
-		send: make(chan wsMessage, 256),
+		ws:       ws,
+		send:     make(chan wsMessage, 256),
+		publicIP: clientIP(r),
 	}
 
 	go c.writePump()


### PR DESCRIPTION
## Summary

- Server extracts each peer's public IP at WebSocket upgrade time (`Fly-Client-IP` → `X-Forwarded-For` → `RemoteAddr`) and stores it on the connection
- When a peer joins a room, the server checks if any existing peer shares the same public IP and includes `lan_peer_present: true` in the `join_ok` response
- Client propagates this flag through `PeerMesh` → `MeshEvent::PeerListReceived` → session, which skips `force_beat` for joiners that already have a LAN peer in the room
- Peers on the same LAN are already beat-synced via Ableton Link multicast, so `force_beat` was unnecessarily disrupting their timeline

## Test plan

- [x] `cargo check` passes for all changed crates
- [x] All wail-core, wail-audio, wail-net integration tests pass
- [x] Go signaling server compiles
- [ ] Manual: two peers from same machine join room → second peer logs "LAN peer already in room, relying on Link sync" and does NOT call force_beat
- [ ] Manual: two peers from different networks join room → second peer still gets force_beat as before

🤖 Claude Code was involved and is sorry