### PR TITLE
fix: remove unused reset_added_at method

### DIFF
--- a/crates/wail-tauri/src/peers.rs
+++ b/crates/wail-tauri/src/peers.rs
@@ -209,15 +209,6 @@ impl PeerRegistry {
             .map(|(id, _)| id.clone())
     }
 
-    /// Reset the added_at clock for a peer, e.g. after a successful reconnect
-    /// attempt so the Hello-completion watchdog gets a fresh window.
-    pub fn reset_added_at(&mut self, peer_id: &str) {
-        if let Some(peer) = self.peers.get_mut(peer_id) {
-            peer.added_at = Instant::now();
-            peer.hello_retry_sent = false;
-        }
-    }
-
     /// Return peer IDs that are active (have received messages) but whose Hello
     /// handshake has not completed (identity still unknown).
     ///
@@ -523,21 +514,6 @@ mod tests {
         );
         assert!(soft.is_empty(), "identified peer must be excluded");
         assert!(hard.is_empty(), "identified peer must be excluded");
-    }
-
-    #[test]
-    fn reset_added_at_refreshes_clock() {
-        let mut reg = PeerRegistry::new();
-        reg.add("peer1".to_string(), None);
-        let peer = reg.get_mut("peer1").unwrap();
-        peer.added_at = Instant::now() - Duration::from_secs(20);
-
-        reg.reset_added_at("peer1");
-
-        assert!(
-            reg.get("peer1").unwrap().added_at.elapsed() < Duration::from_secs(1),
-            "added_at should be reset to now"
-        );
     }
 
 }


### PR DESCRIPTION
## Summary
- Removes the unused `PeerRegistry::reset_added_at` method and its test, eliminating a `dead_code` compiler warning on every build.

## Test plan
- [x] `cargo build --workspace --exclude wail-plugin-test` produces zero warnings
- [x] `cargo xtask test` — all tests pass (pre-existing `recv_plugin_e2e` failure is unrelated plugin bundle issue on main)

🤖 Claude Code was here, tidied up, left quietly