### PR TITLE
fix: eliminate silence artifacts at interval boundaries

### DIFF
--- a/crates/wail-audio/src/codec.rs
+++ b/crates/wail-audio/src/codec.rs
@@ -107,25 +107,48 @@ impl AudioEncoder {
         Ok(output)
     }
 
-    /// Encode a single 20ms frame of interleaved f32 audio into raw Opus bytes.
+    /// Encode a frame of interleaved f32 audio into raw Opus bytes.
     ///
-    /// Input: interleaved f32 samples for one frame (frame_size * channels samples).
-    /// Zero-pads if the input is shorter than one full frame.
-    /// Returns raw Opus packet bytes (no length prefix).
+    /// For full 20ms input, encodes a 20ms Opus packet. For shorter input,
+    /// picks the smallest valid Opus frame size (2.5/5/10/20 ms) that fits
+    /// and zero-pads to that size. Smaller sizes avoid emitting silence when
+    /// a partial "final" frame is flushed at an interval boundary — a full
+    /// 20ms pad on a 1 ms remainder would decode as ~19 ms of silence
+    /// appended to the interval.
+    ///
+    /// Returns raw Opus packet bytes (no length prefix). The decoder
+    /// autodetects the packet's frame size, so `decode_frame` returns
+    /// exactly the encoded number of samples per channel.
     pub fn encode_frame(&mut self, samples: &[f32]) -> Result<Vec<u8>> {
         let ch = self.channels as usize;
-        let frame_samples = self.frame_size * ch;
+        let full_per_ch = self.frame_size;
+        let input_per_ch = samples.len() / ch;
+
+        // Choose smallest Opus frame size that fits. At any supported sample
+        // rate, valid sizes are frame_size * {1/8, 1/4, 1/2, 1} (= 2.5/5/10/20 ms).
+        let target_per_ch = if input_per_ch >= full_per_ch {
+            full_per_ch
+        } else if input_per_ch > full_per_ch / 2 {
+            full_per_ch
+        } else if input_per_ch > full_per_ch / 4 {
+            full_per_ch / 2
+        } else if input_per_ch > full_per_ch / 8 {
+            full_per_ch / 4
+        } else {
+            full_per_ch / 8
+        };
+        let target_total = target_per_ch * ch;
 
         let padded;
-        let frame = if samples.len() < frame_samples {
+        let frame = if samples.len() < target_total {
             padded = {
                 let mut p = samples.to_vec();
-                p.resize(frame_samples, 0.0);
+                p.resize(target_total, 0.0);
                 p
             };
-            &padded
+            &padded[..]
         } else {
-            &samples[..frame_samples]
+            &samples[..target_total]
         };
 
         let mut opus_buf = vec![0u8; 4000];
@@ -358,6 +381,54 @@ mod tests {
         let samples = vec![0.5f32; 100];
         let opus_bytes = encoder.encode_frame(&samples).unwrap();
         assert!(!opus_bytes.is_empty());
+    }
+
+    // A 1 ms remainder used to be zero-padded to a full 20 ms Opus packet, so
+    // every interval's final frame decoded as ~19 ms of trailing silence.
+    // encode_frame now picks the smallest supported packet size, capping the
+    // silence tail at ≤ 1.5 ms for a 1 ms input.
+    #[test]
+    fn encode_frame_partial_input_uses_smaller_packet_size() {
+        let sample_rate = 48000;
+        let channels = 2;
+        let mut encoder = AudioEncoder::new(sample_rate, channels, 128).unwrap();
+        let mut decoder = AudioDecoder::new(sample_rate, channels).unwrap();
+
+        // 1 ms of stereo at 48 kHz = 48 samples per channel.
+        let samples_per_ch = (sample_rate as f64 * 0.001) as usize;
+        let total = samples_per_ch * channels as usize;
+        let samples: Vec<f32> = (0..total)
+            .map(|i| {
+                let t = (i / channels as usize) as f32 / sample_rate as f32;
+                (t * 440.0 * 2.0 * std::f32::consts::PI).sin() * 0.5
+            })
+            .collect();
+
+        let opus_bytes = encoder.encode_frame(&samples).unwrap();
+        let decoded = decoder.decode_frame(&opus_bytes).unwrap();
+
+        // 2.5 ms frame at 48 kHz stereo = 120 samples per channel × 2.
+        let expected_max = 120 * channels as usize;
+        assert_eq!(
+            decoded.len(),
+            expected_max,
+            "1 ms input should produce a 2.5 ms Opus packet, not 20 ms",
+        );
+    }
+
+    #[test]
+    fn encode_frame_full_input_still_emits_20ms_packet() {
+        let sample_rate = 48000;
+        let channels = 2;
+        let mut encoder = AudioEncoder::new(sample_rate, channels, 128).unwrap();
+        let mut decoder = AudioDecoder::new(sample_rate, channels).unwrap();
+
+        let frame_samples = encoder.frame_size() * channels as usize;
+        let samples = vec![0.0f32; frame_samples];
+
+        let opus_bytes = encoder.encode_frame(&samples).unwrap();
+        let decoded = decoder.decode_frame(&opus_bytes).unwrap();
+        assert_eq!(decoded.len(), frame_samples);
     }
 
     #[test]

--- a/crates/wail-audio/src/ring.rs
+++ b/crates/wail-audio/src/ring.rs
@@ -400,13 +400,34 @@ impl IntervalRing {
 
         // Accumulate into existing entry for the same (peer_id, stream_id, interval_index)
         // to support incremental per-frame decode without creating hundreds of entries.
+        //
+        // Backfill: the recv plugin drains its IPC channel and calls feed_remote
+        // for every frame BEFORE advancing current_interval via
+        // process_rt_with_interval. So the first batch of frames for interval N
+        // arrives while current_interval is still N-1 (premix=false). Later
+        // batches arrive with premix=true and extend the same entry, but the
+        // head samples never reach next_playback_slot unless we backfill them
+        // at the premix=false→true transition. Without this, the new interval's
+        // playback starts with a zero-filled head region (audible dip at the
+        // start of every interval; see realtime_paced_no_dropout_e2e).
         if let Some(existing) = self.pending_remote.iter_mut().find(|r| {
             r.peer_id == peer_id && r.stream_id == stream_id && r.index == interval_index
         }) {
             let offset = existing.samples.len();
             existing.samples.extend_from_slice(&samples);
+            let needs_backfill = premix && !existing.premixed;
             if premix {
                 existing.premixed = true;
+            }
+            let backfill = if needs_backfill {
+                Some(existing.samples[..offset].to_vec())
+            } else {
+                None
+            };
+            if let Some(head) = backfill {
+                self.premix_into_next_playback(&head, 0);
+            }
+            if premix {
                 self.premix_into_next_playback(&samples, offset);
             }
             return;
@@ -2428,6 +2449,79 @@ mod tests {
         ring.feed_remote("peer-a".into(), 0, 2, vec![0.4f32; 100]);
 
         assert_eq!(ring.pending_remote_count(), 4);
+    }
+
+    // Recv plugin drains all pending IPC frames via feed_remote *before* it
+    // advances current_interval with process_rt_with_interval. The first batch
+    // of frames for a new interval therefore always arrives with premix=false,
+    // and the second-or-later batch arrives with premix=true. Without a
+    // backfill at the premix transition, the head of the new interval's
+    // playback is zero-filled — the dip that `realtime_paced_no_dropout_e2e`
+    // caught as 25 % RMS on callback 1.
+    #[test]
+    fn feed_remote_backfills_accumulated_samples_on_premix_transition() {
+        let mut ring = make_ring();
+        let buf = 1024;
+        let mut output = vec![0.0f32; buf];
+
+        // Establish current_interval=0 (receiver is still on interval 0).
+        ring.process_with_interval(&[], &mut output, Some(0));
+
+        // First batch for interval 1 arrives while ring is still on interval 0.
+        // premix=false → only goes to pending_remote. Use a region well past
+        // XFADE_SAMPLES so the head audio is unambiguously full-volume.
+        let head_len = 2048;
+        let head = vec![0.7f32; head_len];
+        ring.feed_remote("peer-a".into(), 0, 1, head.clone());
+
+        // Receiver advances to interval 1. current_interval is now 1, so the
+        // next feed_remote call will see premix=true.
+        ring.process_with_interval(&[], &mut output, Some(1));
+
+        // Second batch for interval 1 arrives with premix=true. The backfill
+        // path must also mix the previously-accumulated `head` into the head
+        // region of next_playback_slot.
+        let tail_len = 1024;
+        let tail = vec![0.3f32; tail_len];
+        ring.feed_remote("peer-a".into(), 0, 1, tail.clone());
+
+        // Cross the boundary into interval 2. Interval 1's data swaps into
+        // playback_slot.
+        output.fill(0.0);
+        ring.process_with_interval(&[], &mut output, Some(2));
+
+        let mut played = Vec::new();
+        played.extend_from_slice(&output);
+        for _ in 0..16 {
+            output.fill(0.0);
+            ring.process_with_interval(&[], &mut output, Some(2));
+            if output.iter().all(|&s| s == 0.0) {
+                break;
+            }
+            played.extend_from_slice(&output);
+        }
+
+        // Post-crossfade head region: must be audible at ~0.7 amplitude.
+        // Without backfill, samples [XFADE_LEN..head_len] would be zero.
+        let post_fade_head = &played[XFADE_LEN..head_len];
+        let non_zero = post_fade_head.iter().filter(|&&s| s.abs() > 0.5).count();
+        assert!(
+            non_zero > post_fade_head.len() / 2,
+            "Head region silent — backfill missing. realtime_paced_no_dropout_e2e dip. \
+             Post-fade non-zero count: {}/{}",
+            non_zero,
+            post_fade_head.len(),
+        );
+
+        // Tail region: must be audible at ~0.3 amplitude.
+        let tail_slice = &played[head_len..head_len + tail_len];
+        let tail_non_zero = tail_slice.iter().filter(|&&s| s.abs() > 0.2).count();
+        assert!(
+            tail_non_zero > tail_slice.len() / 2,
+            "Tail region missing — premix of new samples broke: {}/{}",
+            tail_non_zero,
+            tail_slice.len(),
+        );
     }
 
     #[test]

--- a/crates/wail-plugin-recv/src/lib.rs
+++ b/crates/wail-plugin-recv/src/lib.rs
@@ -631,7 +631,13 @@ fn ipc_thread_recv(
                                                         }
                                                     }
                                                 });
-                                                match dec.decode_frame(&frame.opus_data) {
+                                                if frame.opus_data.is_empty() {
+                                                    // Empty final-marker frame: sender uses it to
+                                                    // signal interval completion for stats, no PCM
+                                                    // to decode. Running PLC here would synthesise
+                                                    // 20 ms of silence at the interval tail.
+                                                } else {
+                                                    match dec.decode_frame(&frame.opus_data) {
                                                     Ok(samples) => {
                                                         if let Err(e) = incoming_tx.try_send((
                                                             peer_id.clone(),
@@ -677,6 +683,7 @@ fn ipc_thread_recv(
                                                                 "IPC recv: failed to send PLC frame to audio thread (channel full)"
                                                             );
                                                         }
+                                                    }
                                                     }
                                                 }
                                             }


### PR DESCRIPTION
## Summary

A user recording showed ~19 ms of audible silence at every WAIL interval boundary (6 periodic gaps at ~8 s intervals, 4 bars @ 120 BPM). While investigating, a second boundary artifact surfaced: a 25 % RMS dip in the first callback of every new interval, caught by the realtime_paced_no_dropout_e2e assertion. Both live at interval boundaries but have distinct causes — this PR fixes all three.

### 1. Tail silence at end of every interval
- **Encoder picks smallest-fit Opus packet size.** AudioEncoder::encode_frame was zero-padding partial final frames to 20 ms, decoded as ~19 ms of trailing silence. It now selects 2.5 / 5 / 10 / 20 ms — whichever matches. A 1 ms remainder now caps silence at ≤ 1.5 ms instead of 19 ms.
- **Recv plugin skips empty final-marker frames.** The sender emits an empty is_final: true frame at each boundary so stats (frames_expected, total_frames) can finalise cleanly. Decoding empty opus data triggers PLC → 20 ms of silence. Now guarded with if !frame.opus_data.is_empty(); the wire frame still flows through session.go and FrameAssembler unchanged.
- Considered and rejected: dropping the empty final-marker frame on the send side. Would break wail-app/session.go and FrameAssembler, both of which finalise interval stats on is_final: true.

### 2. Amplitude dip at start of every interval
- **Ring buffer backfills at the premix/current_interval race.** The recv plugin drains its IPC channel (and calls feed_remote per frame) before it advances current_interval via process_rt_with_interval. So the first batch of frames for a new interval always lands in pending_remote with premixed=false. The second batch arrives with premix=true and accumulates into the existing entry, but the head samples never reached next_playback_slot — leaving a zero-filled head region audible as a 25 % RMS dip on callback 1.
- Fix: on the premixed=false → true transition, backfill the already-accumulated head samples into next_playback_slot at offset 0. One vec-clone per (peer, stream, interval) state change; bounded, not per-frame.

## Test plan

- [x] cargo xtask test -- -p wail-audio — 150 tests pass (3 new regression tests)
- [x] cargo xtask test — full workspace green
- [x] /e2e — all three scenarios (late_join_bidirectional_e2e, peer_disconnect_silence_e2e, realtime_paced_no_dropout_e2e) pass; realtime_paced was the previously-failing boundary amplitude guard, now fixed
- [ ] Repeat the recording experiment with the test-tone client and re-run the silence-scan. Acceptance: no silent gaps > 2 ms at interval boundaries.

Co-authored by a very tired language model.
