### PR TITLE
Build & ship real Windows + Linux binaries in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         run: cargo build --workspace
 
       - name: Build Go app (linkstub)
-        run: go build -tags "linkstub,nolibopusfile" -o /dev/null .
+        run: go build -tags linkstub -o /dev/null .
         working-directory: wail-app
 
   build-windows:
@@ -89,7 +89,7 @@ jobs:
       - name: Build Go app (linkstub)
         env:
           PKG_CONFIG_PATH: C:\vcpkg\installed\x64-windows\lib\pkgconfig
-        run: go build -tags "linkstub,nolibopusfile" -o NUL .
+        run: go build -tags linkstub -o NUL .
         working-directory: wail-app
 
       - name: Collect artifacts
@@ -149,7 +149,7 @@ jobs:
         run: cargo xtask bundle-plugin
 
       - name: Build Go app (linkstub)
-        run: go build -tags "linkstub,nolibopusfile" -o /dev/null .
+        run: go build -tags linkstub -o /dev/null .
         working-directory: wail-app
 
       - name: Collect artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,20 +149,49 @@ jobs:
             cmake \
             g++
 
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "value=${TAG#v}" >> "$GITHUB_OUTPUT"
+
       - name: Build plugin
         run: cargo xtask bundle-plugin
 
-      - name: Build Go app (linkstub)
-        run: go build -tags linkstub -o /dev/null .
+      - name: Clone abletonlink-go
+        run: git clone --recursive https://github.com/DatanoiseTV/abletonlink-go.git "$RUNNER_TEMP/abletonlink-go"
+
+      - name: Build wail desktop app
+        run: |
+          sed -i "s|^replace github.com/DatanoiseTV/abletonlink-go.*|replace github.com/DatanoiseTV/abletonlink-go => $RUNNER_TEMP/abletonlink-go|" go.mod
+          go build -ldflags "-X main.appVersion=${{ steps.version.outputs.value }}" -o "$GITHUB_WORKSPACE/dist/bin/wail" .
         working-directory: wail-app
 
-      - name: Collect artifacts
+      - name: Stage release artifacts
         run: |
-          mkdir -p dist
-          cp target/bundled/wail-plugin-send.clap dist/
-          cp -r target/bundled/wail-plugin-send.vst3 dist/
-          cp target/bundled/wail-plugin-recv.clap dist/
-          cp -r target/bundled/wail-plugin-recv.vst3 dist/
+          mkdir -p dist/lib
+          cp target/bundled/wail-plugin-send.clap dist/lib/
+          cp -r target/bundled/wail-plugin-send.vst3 dist/lib/
+          cp target/bundled/wail-plugin-recv.clap dist/lib/
+          cp -r target/bundled/wail-plugin-recv.vst3 dist/lib/
+          cat > dist/README.txt <<'EOF'
+          WAIL — WAN Audio Interchange for Link
+
+          Runtime dependencies (Debian/Ubuntu):
+            sudo apt install libwebkit2gtk-4.1-0 libopus0
+
+          Run:
+            ./bin/wail
+
+          On first launch the CLAP/VST3 plugins in lib/ are copied to
+          ~/.clap/ and ~/.vst3/ so your DAW can find them.
+
+          Documentation: https://github.com/MostDistant/WAIL
+          EOF
 
       - uses: actions/upload-artifact@v7
         with:
@@ -194,11 +223,17 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
-      - name: Zip platform artifacts
+      - name: Package platform artifacts
         run: |
           VERSION="${{ steps.tag.outputs.version }}"
-          cd wail-release-windows && zip -r ../wail-windows-x64-${VERSION}.zip . && cd ..
-          cd wail-release-linux && zip -r ../wail-linux-x64-${VERSION}.zip . && cd ..
+          # Windows: zip, with a top-level wail-<version>/ directory inside.
+          mv wail-release-windows "wail-${VERSION}"
+          zip -r "wail-windows-x64-${VERSION}.zip" "wail-${VERSION}"
+          mv "wail-${VERSION}" wail-release-windows
+          # Linux: tarball, same top-level directory layout.
+          mv wail-release-linux "wail-${VERSION}"
+          tar -czf "wail-linux-x64-${VERSION}.tar.gz" "wail-${VERSION}"
+          mv "wail-${VERSION}" wail-release-linux
 
       - name: Find individual installers
         id: files
@@ -210,7 +245,7 @@ jobs:
           tag_name: ${{ steps.tag.outputs.tag }}
           files: |
             wail-windows-x64-${{ steps.tag.outputs.version }}.zip
-            wail-linux-x64-${{ steps.tag.outputs.version }}.zip
+            wail-linux-x64-${{ steps.tag.outputs.version }}.tar.gz
             ${{ steps.files.outputs.src_tarball }}
 
       # Update the Homebrew tap formula with the new version and SHA256.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Build Go app (linkstub)
         env:
           PKG_CONFIG_PATH: C:\vcpkg\installed\x64-windows\lib\pkgconfig
-        run: go build -tags "linkstub,nolibopusfile" -o NUL .
+        run: go build -tags linkstub -o NUL .
         working-directory: wail-app
 
       - name: Collect artifacts
@@ -153,7 +153,7 @@ jobs:
         run: cargo xtask bundle-plugin
 
       - name: Build Go app (linkstub)
-        run: go build -tags "linkstub,nolibopusfile" -o /dev/null .
+        run: go build -tags linkstub -o /dev/null .
         working-directory: wail-app
 
       - name: Collect artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,28 +85,62 @@ jobs:
         run: choco install pkgconfiglite -y
         continue-on-error: true
 
+      - name: Determine version
+        id: version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "value=${TAG#v}" >> "$GITHUB_OUTPUT"
+
       - name: Build plugin
         env:
           PKG_CONFIG_PATH: C:\vcpkg\installed\x64-windows\lib\pkgconfig
         run: cargo xtask bundle-plugin
 
-      - name: Build Go app (linkstub)
+      - name: Clone abletonlink-go
+        shell: bash
+        run: git clone --recursive https://github.com/DatanoiseTV/abletonlink-go.git "$RUNNER_TEMP/abletonlink-go"
+
+      - name: Build wail desktop app
+        shell: bash
         env:
           PKG_CONFIG_PATH: C:\vcpkg\installed\x64-windows\lib\pkgconfig
-        run: go build -tags linkstub -o NUL .
         working-directory: wail-app
-
-      - name: Collect artifacts
-        shell: pwsh
         run: |
-          New-Item -ItemType Directory -Force dist
-          Copy-Item C:\vcpkg\installed\x64-windows\bin\opus.dll dist\
-          Copy-Item target\bundled\wail-plugin-send.clap dist\
-          Copy-Item -Recurse target\bundled\wail-plugin-send.vst3 dist\wail-plugin-send.vst3
-          Copy-Item target\bundled\wail-plugin-recv.clap dist\
-          Copy-Item -Recurse target\bundled\wail-plugin-recv.vst3 dist\wail-plugin-recv.vst3
-          Copy-Item dist\opus.dll dist\wail-plugin-send.vst3\Contents\x86_64-win\
-          Copy-Item dist\opus.dll dist\wail-plugin-recv.vst3\Contents\x86_64-win\
+          REPLACE_PATH="${RUNNER_TEMP//\\//}/abletonlink-go"
+          sed -i "s|^replace github.com/DatanoiseTV/abletonlink-go.*|replace github.com/DatanoiseTV/abletonlink-go => $REPLACE_PATH|" go.mod
+          go build -ldflags "-X main.appVersion=${{ steps.version.outputs.value }}" -o "$GITHUB_WORKSPACE/dist/bin/wail.exe" .
+
+      - name: Stage release artifacts
+        shell: bash
+        run: |
+          mkdir -p dist/lib
+          cp target/bundled/wail-plugin-send.clap dist/lib/
+          cp -r target/bundled/wail-plugin-send.vst3 dist/lib/
+          cp target/bundled/wail-plugin-recv.clap dist/lib/
+          cp -r target/bundled/wail-plugin-recv.vst3 dist/lib/
+          cp /c/vcpkg/installed/x64-windows/bin/opus.dll dist/lib/opus.dll
+          cp dist/lib/opus.dll dist/lib/wail-plugin-send.vst3/Contents/x86_64-win/
+          cp dist/lib/opus.dll dist/lib/wail-plugin-recv.vst3/Contents/x86_64-win/
+          cat > dist/README.txt <<'EOF'
+          WAIL — WAN Audio Interchange for Link
+
+          Run:
+            bin\wail.exe
+
+          On first launch the CLAP/VST3 plugins in lib/ are copied to your
+          system CLAP/VST3 directories (%COMMONPROGRAMFILES%\CLAP and
+          %COMMONPROGRAMFILES%\VST3) so your DAW can find them.
+
+          Note: this binary is unsigned. If Windows SmartScreen blocks
+          launch, click "More info" then "Run anyway".
+
+          Documentation: https://github.com/MostDistant/WAIL
+          EOF
 
       - uses: actions/upload-artifact@v7
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,8 @@ cargo xtask test -- -p wail-core          # core library tests only
 cargo xtask test -- -p wail-audio         # audio tests (codec, ring buffer, wire format)
 ```
 
+**Skip tests for docs-only changes.** If a PR only modifies `.md` files (or other non-code docs), do not run `cargo xtask test` — it builds plugins and is slow. Tests are not needed when no code paths change.
+
 ## Code Conventions
 
 - Async with tokio, channels for cross-task communication

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ WAIL synchronizes [Ableton Link](https://www.ableton.com/link/) sessions across 
 
 Download the latest release from the [Releases page](https://github.com/MostDistant/WAIL/releases).
 
-**macOS** — Open the DMG and drag WAIL to Applications. The WAIL Send and Recv plugins are automatically installed to your plugin directories on first launch.
-
 **macOS (Homebrew, from source)** — Build and install directly from source:
 
 ```sh
@@ -23,9 +21,17 @@ wail-install-plugins
 
 Then rescan plugins in your DAW.
 
-**Windows** — Install via Chocolatey: `choco install wail --source <release-url>`. Use `--params "'/VST3Dir:path /CLAPDir:path'"` for custom plugin directories (defaults to `%CommonProgramFiles%\VST3` and `%CommonProgramFiles%\CLAP`). Uninstalling via `choco uninstall wail` also removes the plugins.
+**Windows** — Download `wail-windows-x64-<version>.zip` from the Releases page, extract it, and run `bin\wail.exe`. The WAIL Send and Recv plugins are auto-installed on first launch into `%LOCALAPPDATA%\Programs\Common\{CLAP,VST3}\` (no admin rights required); rescan plugins in your DAW. The binary is unsigned, so SmartScreen will warn on first launch — click "More info" → "Run anyway".
 
-**Linux** — Install the `.deb` package (`sudo dpkg -i wail_*.deb`) or download the AppImage and make it executable (`chmod +x WAIL_*.AppImage`). The WAIL Send and Recv plugins are automatically installed to `~/.clap/` and `~/.vst3/` on first launch.
+**Linux** — Download `wail-linux-x64-<version>.tar.gz` from the Releases page. Install the runtime dependencies, extract, and run:
+
+```sh
+sudo apt install libwebkit2gtk-4.1-0 libopus0   # Debian/Ubuntu runtime deps
+tar -xzf wail-linux-x64-*.tar.gz
+./wail-*/bin/wail
+```
+
+The WAIL Send and Recv plugins are auto-installed to `~/.clap/` and `~/.vst3/` on first launch.
 
 ## Getting Started
 

--- a/wail-app/app.go
+++ b/wail-app/app.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -39,13 +38,13 @@ func NewApp(instance int) *App {
 	identity := getOrCreateIdentity(dataDir)
 	streamNames := LoadStreamNames(dataDir)
 
-	// Auto-install plugins (skip on Windows — handled by NSIS installer)
+	// Auto-install plugins from the bundled lib/ dir into the user's CLAP/VST3
+	// directories. Plugins ship inside the release archive, so this gives a
+	// single-download install on every platform.
 	var pluginErrors []string
-	if runtime.GOOS != "windows" {
-		pluginDir := FindPluginDir("")
-		if pluginDir != "" {
-			pluginErrors = InstallPluginsIfMissing(pluginDir)
-		}
+	pluginDir := FindPluginDir("")
+	if pluginDir != "" {
+		pluginErrors = InstallPluginsIfMissing(pluginDir)
 	}
 
 	return &App{

--- a/wail-app/plugin_install.go
+++ b/wail-app/plugin_install.go
@@ -36,11 +36,13 @@ func SystemPluginDir(format string) (string, error) {
 		}
 		return filepath.Join(home, ".vst3"), nil
 	case "windows":
-		commonFiles := os.Getenv("COMMONPROGRAMFILES")
-		if commonFiles == "" {
-			commonFiles = filepath.Join("C:", "Program Files", "Common Files")
+		// Use the per-user "Programs\Common" location so first-launch install
+		// works without Administrator rights. DAWs scan this path by default.
+		localAppData := os.Getenv("LOCALAPPDATA")
+		if localAppData == "" {
+			localAppData = filepath.Join(home, "AppData", "Local")
 		}
-		return filepath.Join(commonFiles, pluginDirName(format)), nil
+		return filepath.Join(localAppData, "Programs", "Common", pluginDirName(format)), nil
 	default:
 		return "", fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
@@ -89,6 +91,7 @@ func hasPlugins(dir string) bool {
 // Returns a list of errors (empty if all succeeded).
 func InstallPluginsIfMissing(pluginDir string) []string {
 	var errors []string
+	installedClap := false
 	for _, p := range pluginBundles {
 		src := filepath.Join(pluginDir, p.name)
 		if _, err := os.Stat(src); err != nil {
@@ -109,10 +112,34 @@ func InstallPluginsIfMissing(pluginDir string) []string {
 		}
 		if err := copyPath(src, dest); err != nil {
 			errors = append(errors, fmt.Sprintf("%s: copy: %v", p.name, err))
-		} else {
-			log.Printf("[plugin-install] Installed %s to %s", p.name, destDir)
+			continue
+		}
+		log.Printf("[plugin-install] Installed %s to %s", p.name, destDir)
+		if p.format == "clap" {
+			installedClap = true
 		}
 	}
+
+	// On Windows the CLAP plugin is a single .dll that depends on opus.dll.
+	// VST3 bundles already carry opus.dll in their Contents folder, but CLAP
+	// has no bundle layout — drop opus.dll alongside the .clap files so the
+	// DAW's LoadLibraryEx finds it via the altered search path.
+	if runtime.GOOS == "windows" && installedClap {
+		opusSrc := filepath.Join(pluginDir, "opus.dll")
+		if _, err := os.Stat(opusSrc); err == nil {
+			if clapDir, err := SystemPluginDir("clap"); err == nil {
+				opusDest := filepath.Join(clapDir, "opus.dll")
+				if _, err := os.Stat(opusDest); err != nil {
+					if err := copyFile(opusSrc, opusDest); err != nil {
+						errors = append(errors, fmt.Sprintf("opus.dll: copy: %v", err))
+					} else {
+						log.Printf("[plugin-install] Installed opus.dll to %s", clapDir)
+					}
+				}
+			}
+		}
+	}
+
 	return errors
 }
 


### PR DESCRIPTION
## Summary

The release pipeline previously built plugin bundles on Windows/Linux but compiled the Go desktop app with `-tags linkstub` and discarded the binary (`-o NUL` / `-o /dev/null`). The README pointed users at fictional Chocolatey, `.deb`, and AppImage artifacts. macOS Homebrew-from-source was the only working install path.

This PR makes the Windows and Linux installs real:

- `release.yml` now clones `abletonlink-go` and builds a real `wail.exe` / `wail` with Ableton Link linked in, packaged with the CLAP/VST3 plugins (and `opus.dll` on Windows).
- Plugins ship inside the release archive; the existing `InstallPluginsIfMissing()` first-launch hook copies them into the user's CLAP/VST3 dirs. Windows now uses `%LOCALAPPDATA%\Programs\Common\{CLAP,VST3}` so install works without admin rights.
- Linux ships as `wail-linux-x64-<v>.tar.gz`; Windows ships as `wail-windows-x64-<v>.zip` (existing). Both archives use the FHS layout `bin/wail{,.exe}` + `lib/<plugins>` that `FindPluginDir()` already searches.
- README install section rewritten to describe the real assets — fictional `choco install`, `dpkg -i`, AppImage, and DMG instructions removed. macOS Homebrew section preserved.
- Dead `nolibopusfile` build tag removed from CI workflows (it was never referenced by any `//go:build` directive).
- `CLAUDE.md` notes that docs-only PRs can skip `cargo xtask test`.

No code signing for Windows in this PR — accept SmartScreen warning, revisit later.

## Risks

- Windows real-Link build is the highest-risk piece — `abletonlink-go`'s default (`!static`) build path is header-only via CGo CXXFLAGS, which sidesteps the MSVC/MinGW conflict that would have arisen with a CMake-based static lib build. If a CI run reveals a toolchain mismatch, fallback is to drop Windows back to `linkstub` until resolved (Linux real binary is still a strict improvement).
- Linux tarball does not bundle `libwebkit2gtk-4.1-0` / `libopus0` — both documented as runtime deps in the README. AppImage is a follow-up.
- Windows `LOCALAPPDATA\Programs\Common` is the per-user CLAP/VST3 path most DAWs scan; if a user's DAW only scans `%COMMONPROGRAMFILES%`, they can copy manually or rescan after a system-level install.

## Test plan

- [ ] Tag a release (or `workflow_dispatch`) and confirm `wail-windows-x64-<v>.zip`, `wail-linux-x64-<v>.tar.gz`, and the source tarball all appear on the GitHub release.
- [ ] Linux: `tar -xzf wail-linux-x64-*.tar.gz && ./wail-*/bin/wail --headless --room test --bpm 120` — confirm room join + plugins land in `~/.clap/` and `~/.vst3/`.
- [ ] Windows: extract zip, double-click `bin\wail.exe`, accept SmartScreen, confirm UI loads and plugins appear under `%LOCALAPPDATA%\Programs\Common\{CLAP,VST3}\`.
- [ ] macOS Homebrew: `brew reinstall MostDistant/wail/wail` — verify nothing regressed.

Reluctantly assisted by Claude Code