### PR TITLE
fix: restore nolibopusfile tag and add rtmidi dep

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,9 @@ jobs:
         run: cargo build --workspace
 
       - name: Build Go app (linkstub)
-        run: go build -tags linkstub -o /dev/null .
+        # nolibopusfile suppresses unused stream.go in gopkg.in/hraban/opus.v2,
+        # which would otherwise require libopusfile to be installed.
+        run: go build -tags "linkstub,nolibopusfile" -o /dev/null .
         working-directory: wail-app
 
   build-windows:
@@ -89,7 +91,7 @@ jobs:
       - name: Build Go app (linkstub)
         env:
           PKG_CONFIG_PATH: C:\vcpkg\installed\x64-windows\lib\pkgconfig
-        run: go build -tags linkstub -o NUL .
+        run: go build -tags "linkstub,nolibopusfile" -o NUL .
         working-directory: wail-app
 
       - name: Collect artifacts
@@ -149,7 +151,7 @@ jobs:
         run: cargo xtask bundle-plugin
 
       - name: Build Go app (linkstub)
-        run: go build -tags linkstub -o /dev/null .
+        run: go build -tags "linkstub,nolibopusfile" -o /dev/null .
         working-directory: wail-app
 
       - name: Collect artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,11 +75,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: C:\vcpkg\installed
-          key: vcpkg-opus-x64-windows-v1
+          key: vcpkg-opus-rtmidi-x64-windows-v1
 
-      - name: Install opus via vcpkg
+      - name: Install opus + rtmidi via vcpkg
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'
-        run: vcpkg install opus:x64-windows
+        run: vcpkg install opus:x64-windows rtmidi:x64-windows
 
       - name: Install pkg-config
         run: choco install pkgconfiglite -y
@@ -113,7 +113,7 @@ jobs:
         run: |
           REPLACE_PATH="${RUNNER_TEMP//\\//}/abletonlink-go"
           sed -i "s|^replace github.com/DatanoiseTV/abletonlink-go.*|replace github.com/DatanoiseTV/abletonlink-go => $REPLACE_PATH|" go.mod
-          go build -ldflags "-X main.appVersion=${{ steps.version.outputs.value }}" -o "$GITHUB_WORKSPACE/dist/bin/wail.exe" .
+          go build -tags nolibopusfile -ldflags "-X main.appVersion=${{ steps.version.outputs.value }}" -o "$GITHUB_WORKSPACE/dist/bin/wail.exe" .
 
       - name: Stage release artifacts
         shell: bash
@@ -126,15 +126,19 @@ jobs:
           cp /c/vcpkg/installed/x64-windows/bin/opus.dll dist/lib/opus.dll
           cp dist/lib/opus.dll dist/lib/wail-plugin-send.vst3/Contents/x86_64-win/
           cp dist/lib/opus.dll dist/lib/wail-plugin-recv.vst3/Contents/x86_64-win/
+          # rtmidi.dll is required at runtime by abletonlink-go's CGo bindings.
+          # Drop it next to wail.exe so Windows finds it on the default DLL search path.
+          cp /c/vcpkg/installed/x64-windows/bin/rtmidi.dll dist/bin/rtmidi.dll
           cat > dist/README.txt <<'EOF'
           WAIL — WAN Audio Interchange for Link
 
           Run:
             bin\wail.exe
 
-          On first launch the CLAP/VST3 plugins in lib/ are copied to your
-          system CLAP/VST3 directories (%COMMONPROGRAMFILES%\CLAP and
-          %COMMONPROGRAMFILES%\VST3) so your DAW can find them.
+          On first launch the CLAP/VST3 plugins in lib/ are copied to
+          %LOCALAPPDATA%\Programs\Common\CLAP and
+          %LOCALAPPDATA%\Programs\Common\VST3 so your DAW can find them.
+          (No admin rights required.)
 
           Note: this binary is unsigned. If Windows SmartScreen blocks
           launch, click "More info" then "Run anyway".
@@ -174,6 +178,7 @@ jobs:
           sudo apt-get install -y \
             libssl-dev \
             libopus-dev \
+            librtmidi-dev \
             libgl-dev \
             libx11-xcb-dev \
             libxcb1-dev \
@@ -202,7 +207,7 @@ jobs:
       - name: Build wail desktop app
         run: |
           sed -i "s|^replace github.com/DatanoiseTV/abletonlink-go.*|replace github.com/DatanoiseTV/abletonlink-go => $RUNNER_TEMP/abletonlink-go|" go.mod
-          go build -ldflags "-X main.appVersion=${{ steps.version.outputs.value }}" -o "$GITHUB_WORKSPACE/dist/bin/wail" .
+          go build -tags nolibopusfile -ldflags "-X main.appVersion=${{ steps.version.outputs.value }}" -o "$GITHUB_WORKSPACE/dist/bin/wail" .
         working-directory: wail-app
 
       - name: Stage release artifacts
@@ -216,7 +221,7 @@ jobs:
           WAIL — WAN Audio Interchange for Link
 
           Runtime dependencies (Debian/Ubuntu):
-            sudo apt install libwebkit2gtk-4.1-0 libopus0
+            sudo apt install libwebkit2gtk-4.1-0 libopus0 librtmidi6
 
           Run:
             ./bin/wail

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Then rescan plugins in your DAW.
 **Linux** — Download `wail-linux-x64-<version>.tar.gz` from the Releases page. Install the runtime dependencies, extract, and run:
 
 ```sh
-sudo apt install libwebkit2gtk-4.1-0 libopus0   # Debian/Ubuntu runtime deps
+sudo apt install libwebkit2gtk-4.1-0 libopus0 librtmidi6   # Debian/Ubuntu runtime deps
 tar -xzf wail-linux-x64-*.tar.gz
 ./wail-*/bin/wail
 ```


### PR DESCRIPTION
## Summary

Follow-up fix for #325. Two CI failures landed on \`main\` because:

1. **\`nolibopusfile\` was not actually dead.** The tag is consumed by \`gopkg.in/hraban/opus.v2/stream.go\` via legacy \`// +build\` syntax, which a \`//go:build\` grep misses. Removing it forced every build to link \`libopusfile\`, which we don't have installed. wail-app only uses \`opus.NewEncoder\`, so suppressing the unused streaming code is the right call — restored the tag in all 5 sites.
2. **\`librtmidi\` is a hard dep.** abletonlink-go's \`rtmidi.go\` has no build tag, so the \`#cgo pkg-config: rtmidi\` directive applies whenever real Link is built. Added \`librtmidi-dev\` to Linux apt, \`rtmidi:x64-windows\` via vcpkg, and ship \`rtmidi.dll\` next to \`wail.exe\`. Linux runtime users now also need \`librtmidi6\`.

Also corrected the bundled Windows \`README.txt\` — the install path note was still pointing at \`%COMMONPROGRAMFILES%\` instead of the user-writable \`%LOCALAPPDATA%\Programs\Common\\\` we actually use.

## Test plan

- [ ] \`workflow_dispatch\` a release tag and confirm \`build-linux\` / \`build-windows\` complete and produce real binaries.
- [ ] Linux: confirm the tarball runs after \`apt install libwebkit2gtk-4.1-0 libopus0 librtmidi6\`.
- [ ] Windows: confirm \`bin\wail.exe\` launches with \`rtmidi.dll\` next to it (no missing-DLL prompt).

Powered by artificial mediocrity