### PR TITLE
ci: fix Windows plugin build broken by CMake 4.x on runner image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,13 @@ jobs:
       - name: Build plugin
         env:
           PKG_CONFIG_PATH: C:\vcpkg\installed\x64-windows\lib\pkgconfig
+          # audiopus_sys builds a vendored Opus from source via CMake on Windows
+          # (pkg-config is compiled out for the MSVC target). The bundled Opus
+          # declares cmake_minimum_required(<3.5), which CMake 4.x (now on the
+          # windows-latest runner image) refuses. This env var tells CMake to
+          # treat the floor as 3.5 so the legacy project still configures.
+          # Tracked follow-up (link the prebuilt vcpkg Opus instead): #329
+          CMAKE_POLICY_VERSION_MINIMUM: "3.5"
         run: cargo xtask bundle-plugin
 
       - name: Build Go app (linkstub)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,13 @@ jobs:
       - name: Build plugin
         env:
           PKG_CONFIG_PATH: C:\vcpkg\installed\x64-windows\lib\pkgconfig
+          # audiopus_sys builds a vendored Opus from source via CMake on Windows
+          # (pkg-config is compiled out for the MSVC target). The bundled Opus
+          # declares cmake_minimum_required(<3.5), which CMake 4.x (now on the
+          # windows-latest runner image) refuses. This env var tells CMake to
+          # treat the floor as 3.5 so the legacy project still configures.
+          # Tracked follow-up (link the prebuilt vcpkg Opus instead): #329
+          CMAKE_POLICY_VERSION_MINIMUM: "3.5"
         run: cargo xtask bundle-plugin
 
       - name: Clone abletonlink-go


### PR DESCRIPTION
## What happened

The [v2.4.1 release run](https://github.com/MostDistant/WAIL/actions/runs/26854963551/job/79195604209) failed in the **`build-windows`** job at the **Build plugin** step. Linux and the Homebrew tarball were fine.

Root cause is an **environment regression, not a code change**: GitHub bumped the `windows-latest` runner image to one shipping **CMake 4.x** (the log shows generator `Visual Studio 18 2026`). `audiopus_sys 0.2.2` compiles a vendored Opus from source via CMake on the MSVC target, and that bundled Opus declares an ancient `cmake_minimum_required(<3.5)` — which CMake 4.0 refuses:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
  ...
  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Linux survived only because `ubuntu-22.04` still has CMake 3.22 (< 4.0).

## Fix

Set `CMAKE_POLICY_VERSION_MINIMUM=3.5` on the Windows **Build plugin** step — the canonical bridge for CMake-4-vs-legacy-C-library breakage. CMake reads this as an environment variable and treats the policy floor as 3.5, so the old project configures again. Applied to **both** `release.yml` (release artifacts) and `build.yml` (CI) since both run the same step and would break identically.

## This is a bridge, not the root-cause fix

We shouldn't be compiling Opus from source on Windows at all — the job already `vcpkg install`s a prebuilt Opus. Pointing `audiopus_sys` at that copy removes CMake from the Windows path entirely, but it carries its own trade-offs (static/dynamic linkage, plugin self-containedness, vcpkg triplet/cache changes) and can only be validated on a Windows CI runner. Tracked in **#329**.

## Testing

CI-config-only change — no Rust/Go code paths touched, so the local test suite adds no signal (and per `CLAUDE.md`, tests are skipped when no code paths change). YAML validated to parse. Real confirmation is the next Windows CI/release run.

> Note: to ship corrected v2.4.1 Windows binaries, the release workflow will need to be re-run against a tag that includes this commit.

🛟 Claude Code threw the inflatable ring; the swimming was all you
