### PR TITLE
ci: pin Windows builds to windows-2022 for Link-compatible toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,10 @@ jobs:
         working-directory: wail-app
 
   build-windows:
-    runs-on: windows-latest
+    # Pinned to windows-2022 to match the release workflow's toolchain (older
+    # MinGW GCC + CMake). windows-latest rolled over to the 2025/2026 image
+    # whose newer toolchain breaks the plugin/CGo builds. See #329.
+    runs-on: windows-2022
     if: "!startsWith(github.event.head_commit.message, 'chore: prepare release')"
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -86,11 +89,12 @@ jobs:
       - name: Build plugin
         env:
           PKG_CONFIG_PATH: C:\vcpkg\installed\x64-windows\lib\pkgconfig
-          # audiopus_sys builds a vendored Opus from source via CMake on Windows
-          # (pkg-config is compiled out for the MSVC target). The bundled Opus
-          # declares cmake_minimum_required(<3.5), which CMake 4.x (now on the
-          # windows-latest runner image) refuses. This env var tells CMake to
-          # treat the floor as 3.5 so the legacy project still configures.
+          # Belt-and-suspenders for CMake 4.x: audiopus_sys builds a vendored
+          # Opus from source via CMake on Windows (pkg-config is compiled out
+          # for the MSVC target), and that Opus declares
+          # cmake_minimum_required(<3.5), which CMake 4.x refuses. windows-2022
+          # currently ships CMake 3.x so this is a no-op there, but it keeps the
+          # build green if the image's CMake is ever bumped.
           # Tracked follow-up (link the prebuilt vcpkg Opus instead): #329
           CMAKE_POLICY_VERSION_MINIMUM: "3.5"
         run: cargo xtask bundle-plugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,12 @@ jobs:
             wail-*-src.tar.gz.sha256
 
   build-windows:
-    runs-on: windows-latest
+    # Pinned to windows-2022 (older MinGW GCC + CMake) rather than
+    # windows-latest, which rolled over to the 2025/2026 image. That newer
+    # image's MinGW GCC rejects the Ableton Link 4.0 beta headers compiled by
+    # the Go/CGo desktop-app build (the same headers compile cleanly on the
+    # Linux runner's GCC 11). See #329.
+    runs-on: windows-2022
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
@@ -99,11 +104,12 @@ jobs:
       - name: Build plugin
         env:
           PKG_CONFIG_PATH: C:\vcpkg\installed\x64-windows\lib\pkgconfig
-          # audiopus_sys builds a vendored Opus from source via CMake on Windows
-          # (pkg-config is compiled out for the MSVC target). The bundled Opus
-          # declares cmake_minimum_required(<3.5), which CMake 4.x (now on the
-          # windows-latest runner image) refuses. This env var tells CMake to
-          # treat the floor as 3.5 so the legacy project still configures.
+          # Belt-and-suspenders for CMake 4.x: audiopus_sys builds a vendored
+          # Opus from source via CMake on Windows (pkg-config is compiled out
+          # for the MSVC target), and that Opus declares
+          # cmake_minimum_required(<3.5), which CMake 4.x refuses. windows-2022
+          # currently ships CMake 3.x so this is a no-op there, but it keeps the
+          # build green if the image's CMake is ever bumped.
           # Tracked follow-up (link the prebuilt vcpkg Opus instead): #329
           CMAKE_POLICY_VERSION_MINIMUM: "3.5"
         run: cargo xtask bundle-plugin


### PR DESCRIPTION
## Context

Follow-up to #330. That PR fixed the first Windows release blocker (CMake 4.x vs the vendored Opus). With it, the v2.4.2 run got further — **Build plugin, build-linux, and build-homebrew-tarball all went green** — but `build-windows` then failed one step later, at **Build wail desktop app** (the Go/CGo build):

```
ableton/link_audio/Channels.hpp:53: error: no matching function for call to
  'basic_endpoint<udp>::basic_endpoint(<unresolved overloaded function type>)'
   53 |       : mEndpoint(endpoint)
```

## Root cause

Same family as the CMake break: GitHub rolled `windows-latest` over to the **2025/2026 image**, bringing a much newer (stricter) **MinGW GCC**. That compiler rejects the Ableton Link 4.0 **beta** headers (`Ableton/link @ 082691b`, vendored by `abletonlink-go`) that the Go desktop app compiles via CGo.

The decisive clue: the **identical** Link SDK — pinned by submodule, so byte-for-byte the same on every platform — **compiles cleanly on the Linux runner (ubuntu-22.04, GCC 11) in the same run**. The only difference is the host C++ compiler. So this is a toolchain interaction, not a code defect we introduced.

## Fix

Pin the Windows jobs to **`windows-2022`** (older MinGW GCC, close to the GCC 11 that works on Linux) instead of `windows-latest`. Applied to both `release.yml` and `build.yml` so the two Windows builds share one toolchain. The `CMAKE_POLICY_VERSION_MINIMUM=3.5` workaround from #330 is kept as a no-op safety net (windows-2022 ships CMake 3.x).

## Caveats / trade-offs

- `windows-2022` has its own deprecation horizon — this buys time, it isn't forever. The durable fix is bumping/forking `abletonlink-go`'s Link submodule to a commit that compiles with modern GCC (or switching the CGo compiler to Clang). Tracked alongside the Opus follow-up in **#329**.
- This Windows real-app build has **never** gone green (it's new since #325 and was masked by the earlier CMake failure), so `windows-2022`'s toolchain compatibility can only be confirmed by the next release run — there's no local repro.

## Testing

CI-config-only — no code paths touched, so the local suite adds no signal (per `CLAUDE.md`, skipped when no code changes). YAML validated. Real confirmation is the next Windows CI/release run.

🪜 Claude Code held the ladder; you climbed it
