### PR TITLE
ci: provision pkg-config via vcpkg pkgconf on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,15 +76,29 @@ jobs:
         uses: actions/cache@v5
         with:
           path: C:\vcpkg\installed
-          key: vcpkg-opus-x64-windows-v1
+          # Bump the suffix whenever the package list below changes, otherwise a
+          # stale cache is restored and the new packages are never installed.
+          key: vcpkg-opus-pkgconf-x64-windows-v2
 
-      - name: Install opus via vcpkg
+      - name: Install opus + pkgconf via vcpkg
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'
-        run: vcpkg install opus:x64-windows
+        # pkgconf is a drop-in pkg-config that the Go/CGo build needs to locate
+        # opus. We get it from vcpkg rather than choco because the choco
+        # community feed is flaky (504s) and silently leaves the build to fall
+        # back to Strawberry Perl's broken pkg-config.bat stub on PATH.
+        run: vcpkg install opus:x64-windows pkgconf:x64-windows
 
-      - name: Install pkg-config
-        run: choco install pkgconfiglite -y
-        continue-on-error: true
+      - name: Configure pkg-config
+        shell: pwsh
+        # Point CGo straight at the vcpkg pkgconf binary by absolute path via
+        # PKG_CONFIG, so PATH lookup (and Strawberry Perl's pkg-config.bat stub)
+        # is bypassed entirely for every later step in this job.
+        run: |
+          $pkgconf = Get-ChildItem C:\vcpkg\installed\x64-windows -Recurse -Filter pkgconf.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $pkgconf) { throw "pkgconf.exe not found under vcpkg (did the install step run?)" }
+          "PKG_CONFIG=$($pkgconf.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          Write-Host "Using PKG_CONFIG=$($pkgconf.FullName)"
+          & $pkgconf.FullName --version
 
       - name: Build plugin
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,15 +80,29 @@ jobs:
         uses: actions/cache@v5
         with:
           path: C:\vcpkg\installed
-          key: vcpkg-opus-rtmidi-x64-windows-v1
+          # Bump the suffix whenever the package list below changes, otherwise a
+          # stale cache is restored and the new packages are never installed.
+          key: vcpkg-opus-rtmidi-pkgconf-x64-windows-v2
 
-      - name: Install opus + rtmidi via vcpkg
+      - name: Install opus + rtmidi + pkgconf via vcpkg
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'
-        run: vcpkg install opus:x64-windows rtmidi:x64-windows
+        # pkgconf is a drop-in pkg-config that the Go/CGo build needs to locate
+        # opus and rtmidi. We get it from vcpkg rather than choco because the
+        # choco community feed is flaky (504s) and silently leaves the build to
+        # fall back to Strawberry Perl's broken pkg-config.bat stub on PATH.
+        run: vcpkg install opus:x64-windows rtmidi:x64-windows pkgconf:x64-windows
 
-      - name: Install pkg-config
-        run: choco install pkgconfiglite -y
-        continue-on-error: true
+      - name: Configure pkg-config
+        shell: pwsh
+        # Point CGo straight at the vcpkg pkgconf binary by absolute path via
+        # PKG_CONFIG, so PATH lookup (and Strawberry Perl's pkg-config.bat stub)
+        # is bypassed entirely for every later step in this job.
+        run: |
+          $pkgconf = Get-ChildItem C:\vcpkg\installed\x64-windows -Recurse -Filter pkgconf.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $pkgconf) { throw "pkgconf.exe not found under vcpkg (did the install step run?)" }
+          "PKG_CONFIG=$($pkgconf.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          Write-Host "Using PKG_CONFIG=$($pkgconf.FullName)"
+          & $pkgconf.FullName --version
 
       - name: Determine version
         id: version


### PR DESCRIPTION
## Context

Third in the chain to get Windows release binaries building (after #330 CMake, #332 windows-2022 pin). The windows-2022 pin worked — the v2.4.3 run's `build-windows` got **past the Ableton Link C++ compile** that broke v2.4.2 (older MinGW GCC handles the beta headers, same as Linux GCC 11). It then failed at a new, more tractable spot in **Build wail desktop app**:

```
# github.com/DatanoiseTV/abletonlink-go
# [pkg-config --cflags  -- rtmidi]
Can't find C:\Strawberry\perl\bin\pkg-config.bat on PATH, '.' not in PATH.
```

## Root cause

Two compounding issues:

1. The `choco install pkgconfiglite` step hit a **transient 504** from Chocolatey's community feed (`Unable to find package 'pkgconfiglite' ... 504 Gateway Timeout`), and `continue-on-error: true` let the build continue without a real pkg-config.
2. With none installed, CGo fell back to **Strawberry Perl's broken `pkg-config.bat` stub** — Strawberry is preinstalled and on PATH on windows-2022 (it wasn't shadowing on the newer image, which is why this only surfaced after the pin).

## Fix

Stop depending on the flaky choco feed and on PATH resolution:

- Install **`pkgconf`** (a drop-in pkg-config) via **vcpkg** alongside opus/rtmidi — no external-feed dependency at build time, and it's cached with the rest of the vcpkg install.
- A new **Configure pkg-config** step sets `PKG_CONFIG` to pkgconf's **absolute path** via `GITHUB_ENV`, so CGo invokes it directly and never consults PATH (or the Strawberry stub) again.
- **Bump the vcpkg cache key** so the new package is actually installed instead of restored from a stale cache.

Applied to both `release.yml` and `build.yml`.

## Caveats

- First run after the cache-key bump rebuilds opus/rtmidi/pkgconf from vcpkg source (slower, one-time).
- Still CI-only validation — no local repro on macOS. Confirmation is the next release run getting `build-windows` through "Stage release artifacts" + upload.

Tracked alongside the other Windows-toolchain follow-ups in **#329**.

## Testing

CI-config-only; no code paths touched (per `CLAUDE.md`, local suite skipped when no code changes). YAML validated.

🧰 Claude Code passed the wrench; you turned it
