### PR TITLE
ci: patch Ableton Link beta header for MinGW GCC name collision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,20 @@ jobs:
         shell: bash
         run: git clone --recursive https://github.com/DatanoiseTV/abletonlink-go.git "$RUNNER_TEMP/abletonlink-go"
 
+      - name: Patch Link beta header for MinGW GCC
+        shell: bash
+        # The Ableton Link 4.0 beta vendored by abletonlink-go has a name
+        # collision in link_audio/Channels.hpp: the SendHandler constructor
+        # parameter `endpoint` shadows the member function `endpoint()`. By the
+        # standard the parameter wins inside the initializer (Linux GCC 11 gets
+        # this right), but the MinGW GCC on the Windows runners mis-resolves it
+        # to the member function and fails with "unresolved overloaded function
+        # type". Rename the parameter to disambiguate. See #329.
+        run: |
+          f="$RUNNER_TEMP/abletonlink-go/vendor/link/include/ableton/link_audio/Channels.hpp"
+          sed -i 's/SendHandler(discovery::UdpEndpoint endpoint,/SendHandler(discovery::UdpEndpoint ep,/; s/: mEndpoint(endpoint)/: mEndpoint(ep)/' "$f"
+          grep -n "SendHandler(discovery::UdpEndpoint ep," "$f" || { echo "patch did not apply"; exit 1; }
+
       - name: Build wail desktop app
         shell: bash
         env:


### PR DESCRIPTION
## The real blocker, finally isolated

The v2.4.2/3/4 `build-windows` failures were three layers (CMake → pkg-config → this) masking each other. With #330 (CMake) and #334 (pkg-config) fixed, the Go/CGo build finally reached — and failed at — the actual problem: compiling `abletonlink-go`'s vendored **Ableton Link 4.0 beta**.

`link_audio/Channels.hpp` has a name collision — the `SendHandler` constructor parameter `endpoint` shadows a member function `endpoint()`:

```cpp
SendHandler(discovery::UdpEndpoint endpoint, ...)   // param "endpoint"
  : mEndpoint(endpoint)                              // ← fails here
...
discovery::UdpEndpoint endpoint() const { ... }      // member fn "endpoint()"
```

Per the standard the parameter wins inside the initializer, and **Linux GCC 11 compiles it fine** — but the **MinGW GCC** on the Windows runners mis-resolves `endpoint` to the member function:

```
Channels.hpp:53: error: no matching function for call to
  'basic_endpoint<udp>::basic_endpoint(<unresolved overloaded function type>)'
```

It reproduced on both windows-latest and windows-2022, confirming it's the toolchain, not the runner image.

## Fix

A CI step (after the abletonlink-go clone, before the Go build) renames the colliding parameter — semantically identical, sidesteps the GCC name-lookup quirk — with a guard that fails the build if the patch no longer applies cleanly.

## Notes

- MinGW GCC isn't an Ableton-supported Link compiler; the durable fix is upstream in `DatanoiseTV/abletonlink-go`. Tracked in **#329**.
- Only `release.yml` needs this; `build.yml` builds with `linkstub` and never compiles the real Link.
- A sibling name-collision deeper in the beta headers could surface next — if so, same treatment.

🩹 Claude Code applied the band-aid; you kissed it better

CI-config-only; no code paths touched. YAML validated.
