### PR TITLE
ci: rename Link beta `interface` param for MinGW GCC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,17 +134,35 @@ jobs:
 
       - name: Patch Link beta header for MinGW GCC
         shell: bash
-        # The Ableton Link 4.0 beta vendored by abletonlink-go has a name
-        # collision in link_audio/Channels.hpp: the SendHandler constructor
-        # parameter `endpoint` shadows the member function `endpoint()`. By the
-        # standard the parameter wins inside the initializer (Linux GCC 11 gets
-        # this right), but the MinGW GCC on the Windows runners mis-resolves it
-        # to the member function and fails with "unresolved overloaded function
-        # type". Rename the parameter to disambiguate. See #329.
+        # The Ableton Link 4.0 beta vendored by abletonlink-go has two name
+        # collisions in link_audio/Channels.hpp that only bite the MinGW GCC on
+        # the Windows runners — Linux GCC 11 compiles the same headers cleanly:
+        #
+        #   1. The SendHandler constructor parameter `endpoint` shadows the
+        #      member function `endpoint()`. By the standard the parameter wins
+        #      inside the initializer, but MinGW GCC mis-resolves it to the
+        #      member function ("unresolved overloaded function type"). Rename
+        #      only the parameter and its use — never the `endpoint()` member.
+        #
+        #   2. The SendHandler parameter / local variable named `interface`
+        #      collides with the Windows `interface` macro (objbase.h defines
+        #      `#define interface struct`), pulled in transitively via asio's
+        #      winsock headers. The preprocessor rewrites the identifier and the
+        #      build fails with "expected identifier before ')' token". Rename
+        #      every lowercase `interface` identifier to `iface`; the
+        #      word-boundary match leaves the `Interface` template type and the
+        #      `mpInterface` member untouched.
+        #
+        # See #329.
         run: |
           f="$RUNNER_TEMP/abletonlink-go/vendor/link/include/ableton/link_audio/Channels.hpp"
-          sed -i 's/SendHandler(discovery::UdpEndpoint endpoint,/SendHandler(discovery::UdpEndpoint ep,/; s/: mEndpoint(endpoint)/: mEndpoint(ep)/' "$f"
-          grep -n "SendHandler(discovery::UdpEndpoint ep," "$f" || { echo "patch did not apply"; exit 1; }
+          sed -i \
+            -e 's/SendHandler(discovery::UdpEndpoint endpoint,/SendHandler(discovery::UdpEndpoint ep,/' \
+            -e 's/: mEndpoint(endpoint)/: mEndpoint(ep)/' \
+            -e 's/\binterface\b/iface/g' \
+            "$f"
+          grep -q "SendHandler(discovery::UdpEndpoint ep, std::shared_ptr<Interface> iface)" "$f" \
+            || { echo "Channels.hpp endpoint/interface patch did not apply"; exit 1; }
 
       - name: Build wail desktop app
         shell: bash


### PR DESCRIPTION
## What

The `windows-2022` **Release** build (`build-windows` → "Build wail desktop app") is failing with:

```
Channels.hpp:52:80: error: expected identifier before ')' token
   52 |     SendHandler(discovery::UdpEndpoint ep, std::shared_ptr<Interface> interface)
```

The earlier #336 patch (renaming the `endpoint` parameter that shadows `endpoint()`) applied successfully — it just uncovered a **second** name collision in the same Ableton Link 4.0 beta header.

## Root cause

`link_audio/Channels.hpp`'s `SendHandler` names a constructor parameter / local variable `interface`. On Windows that's a preprocessor macro — `objbase.h` does `#define interface struct`, pulled in transitively through asio's winsock headers. So `std::shared_ptr<Interface> interface` becomes `... struct` and MinGW GCC chokes. Linux GCC 11 never sees the macro, which is why only the Windows runner breaks.

All five compiler errors (lines 52, 53, 54, 60, 64) trace to the four lowercase `interface` identifiers — GCC compiled the rest of the `LinkAudio.hpp` include tree cleanly, so this is the complete fix, not another whack-a-mole step.

## The fix

Extend the existing "Patch Link beta header for MinGW GCC" step to also rename every lowercase `interface` identifier to `iface`. The `\binterface\b` word-boundary match deliberately leaves the `Interface` template type and the `mpInterface` member untouched (verified against the real upstream header). The verification grep now asserts the full patched signature.

Only `release.yml` is affected — `build.yml`'s Windows job builds with `-tags linkstub` and never compiles `LinkAudio.hpp`.

🤖 Claude Code typed it; the macro is the real villain