### PR TITLE
ci: make Windows release build link (MinGW rtmidi + Winsock/iphlpapi/winmm)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,10 +187,13 @@ jobs:
           # opus + rtmidi for the CGo link come from the MinGW (x64-mingw-static)
           # prefix so their ABI matches the GCC that compiles the CGo objects.
           PKG_CONFIG_PATH: C:\vcpkg\installed\x64-mingw-static\lib\pkgconfig
-          # asio (LinkAudio) needs Winsock 2 and rtmidi's WinMM MIDI backend needs
-          # winmm, but abletonlink-go's cgo LDFLAGS declare neither. Statically
-          # link the GCC/C++ runtime so wail.exe doesn't depend on MinGW DLLs.
-          CGO_LDFLAGS: -lws2_32 -lwinmm -static-libgcc -static-libstdc++
+          # System libs abletonlink-go's cgo LDFLAGS omit: ws2_32 (asio sockets),
+          # winmm (rtmidi WinMM MIDI backend), iphlpapi (GetAdaptersAddresses in
+          # Link's Windows ScanIpIfAddrs). We deliberately do NOT pass
+          # -static-libstdc++: abletonlink-go already links -lstdc++ (the dynamic
+          # import lib), so forcing the static libstdc++.a too yields duplicate
+          # symbol definitions. Keep libstdc++ dynamic and ship the runtime DLLs.
+          CGO_LDFLAGS: -lws2_32 -lwinmm -liphlpapi
         working-directory: wail-app
         run: |
           REPLACE_PATH="${RUNNER_TEMP//\\//}/abletonlink-go"
@@ -208,8 +211,13 @@ jobs:
           cp /c/vcpkg/installed/x64-windows/bin/opus.dll dist/lib/opus.dll
           cp dist/lib/opus.dll dist/lib/wail-plugin-send.vst3/Contents/x86_64-win/
           cp dist/lib/opus.dll dist/lib/wail-plugin-recv.vst3/Contents/x86_64-win/
-          # No rtmidi.dll: rtmidi is linked statically into wail.exe from the
-          # x64-mingw-static prefix, and the GCC/C++ runtime is static too.
+          # rtmidi + opus are linked statically into wail.exe (x64-mingw-static),
+          # so no rtmidi.dll. But the exe is built with MinGW GCC against a
+          # dynamic libstdc++, so it needs the GCC/C++ runtime DLLs at launch.
+          # Ship them from the same toolchain that built the exe (C:\mingw64).
+          cp /c/mingw64/bin/libstdc++-6.dll dist/bin/
+          cp /c/mingw64/bin/libgcc_s_seh-1.dll dist/bin/
+          cp /c/mingw64/bin/libwinpthread-1.dll dist/bin/
           cat > dist/README.txt <<'EOF'
           WAIL — WAN Audio Interchange for Link
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,15 +82,32 @@ jobs:
           path: C:\vcpkg\installed
           # Bump the suffix whenever the package list below changes, otherwise a
           # stale cache is restored and the new packages are never installed.
-          key: vcpkg-opus-rtmidi-pkgconf-x64-windows-v2
+          key: vcpkg-opus-rtmidi-mingw-static-pkgconf-x64-windows-v3
 
       - name: Install opus + rtmidi + pkgconf via vcpkg
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        shell: bash
         # pkgconf is a drop-in pkg-config that the Go/CGo build needs to locate
         # opus and rtmidi. We get it from vcpkg rather than choco because the
         # choco community feed is flaky (504s) and silently leaves the build to
         # fall back to Strawberry Perl's broken pkg-config.bat stub on PATH.
-        run: vcpkg install opus:x64-windows rtmidi:x64-windows pkgconf:x64-windows
+        #
+        # Triplet choice matters for the CGo desktop-app link:
+        #   - opus is a C library; its C-ABI symbols link cleanly into the
+        #     MinGW-GCC CGo binary even when built by MSVC. The x64-windows
+        #     opus.dll is what the plugins (audiopus) and the staged bundles use.
+        #   - rtmidi is C++; the MSVC build's mangled symbols and C++ runtime are
+        #     ABI-incompatible with MinGW GCC and cannot be linked into the CGo
+        #     binary. So we also build opus + rtmidi for the x64-mingw-static
+        #     triplet (same GCC ABI as the CGo objects) and link the desktop app
+        #     against those, statically. See #329.
+        run: |
+          gcc --version  # the x64-mingw-static triplet builds with this GCC
+          vcpkg install \
+            pkgconf:x64-windows \
+            opus:x64-windows \
+            opus:x64-mingw-static \
+            rtmidi:x64-mingw-static
 
       - name: Configure pkg-config
         shell: pwsh
@@ -167,7 +184,13 @@ jobs:
       - name: Build wail desktop app
         shell: bash
         env:
-          PKG_CONFIG_PATH: C:\vcpkg\installed\x64-windows\lib\pkgconfig
+          # opus + rtmidi for the CGo link come from the MinGW (x64-mingw-static)
+          # prefix so their ABI matches the GCC that compiles the CGo objects.
+          PKG_CONFIG_PATH: C:\vcpkg\installed\x64-mingw-static\lib\pkgconfig
+          # asio (LinkAudio) needs Winsock 2 and rtmidi's WinMM MIDI backend needs
+          # winmm, but abletonlink-go's cgo LDFLAGS declare neither. Statically
+          # link the GCC/C++ runtime so wail.exe doesn't depend on MinGW DLLs.
+          CGO_LDFLAGS: -lws2_32 -lwinmm -static-libgcc -static-libstdc++
         working-directory: wail-app
         run: |
           REPLACE_PATH="${RUNNER_TEMP//\\//}/abletonlink-go"
@@ -185,9 +208,8 @@ jobs:
           cp /c/vcpkg/installed/x64-windows/bin/opus.dll dist/lib/opus.dll
           cp dist/lib/opus.dll dist/lib/wail-plugin-send.vst3/Contents/x86_64-win/
           cp dist/lib/opus.dll dist/lib/wail-plugin-recv.vst3/Contents/x86_64-win/
-          # rtmidi.dll is required at runtime by abletonlink-go's CGo bindings.
-          # Drop it next to wail.exe so Windows finds it on the default DLL search path.
-          cp /c/vcpkg/installed/x64-windows/bin/rtmidi.dll dist/bin/rtmidi.dll
+          # No rtmidi.dll: rtmidi is linked statically into wail.exe from the
+          # x64-mingw-static prefix, and the GCC/C++ runtime is static too.
           cat > dist/README.txt <<'EOF'
           WAIL — WAN Audio Interchange for Link
 


### PR DESCRIPTION
## Summary

Gets the **Windows release build green** for the first time since the Ableton Link 4.0 beta bump. Verified end-to-end via `workflow_dispatch` against `v2.4.6` — all jobs pass and the zip contains `wail.exe` + plugins + runtime DLLs.

Builds on #338 (which fixed the *compile*); this fixes the *link*.

## What was failing & why

Once `Channels.hpp` compiled (#338), the CGo desktop-app link surfaced a stack of issues, all rooted in the Link 4.0 beta now pulling in asio sockets + rtmidi while the build links with **MinGW GCC**:

1. **MSVC↔MinGW ABI mismatch.** `abletonlink-go` links rtmidi via `pkg-config`, and vcpkg's `rtmidi:x64-windows` is **MSVC**-built C++ — its mangled symbols/runtime can't link into a MinGW binary. → Build opus + rtmidi for the **`x64-mingw-static`** triplet and point the desktop-app `pkg-config` there. (Opus stays `x64-windows` for the plugin `opus.dll`; opus is pure C and links cleanly either way.)
2. **Missing system libs.** `abletonlink-go`'s cgo `LDFLAGS` declare none of: `ws2_32` (asio sockets), `winmm` (rtmidi WinMM backend), `iphlpapi` (`GetAdaptersAddresses` in Link's Windows `ScanIpIfAddrs`). → `CGO_LDFLAGS=-lws2_32 -lwinmm -liphlpapi`.
3. **Duplicate libstdc++.** abletonlink-go already links `-lstdc++` (dynamic), so forcing `-static-libstdc++` produced `multiple definition` errors. → Keep libstdc++ dynamic and **ship the three MinGW runtime DLLs** (`libstdc++-6`, `libgcc_s_seh-1`, `libwinpthread-1`) next to `wail.exe`. rtmidi + opus are linked statically, so no `rtmidi.dll`.

## Verified artifact (`wail-windows-x64-2.4.6.zip`, 23 MB)
```
bin/wail.exe + libstdc++-6.dll + libgcc_s_seh-1.dll + libwinpthread-1.dll
lib/opus.dll + wail-plugin-{send,recv}.{clap,vst3}
```

> Note: CI can't launch the exe, so a smoke-test on a clean Windows box is still worth doing — but the standard MinGW runtime trio is bundled.

Reluctantly assisted by Claude Code