### PR TITLE
chore: remove WebRTC/TURN leftovers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4324,7 +4324,6 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "md5",
  "serde_json",
 ]
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -81,17 +81,7 @@ bin/dev                  # build plugins + run Go/Wails app in dev mode
 cargo test                    # all tests (~114 unit + integration)
 cargo test -p wail-core       # core library tests
 cargo test -p wail-audio      # audio codec, ring buffer, wire format
-cargo test -p wail-net        # networking + WebRTC integration tests
-```
-
-Some integration tests are marked `#[ignore]` because they require external resources:
-
-```sh
-# Requires internet access — hits the live Metered API and asserts valid TURN credentials are returned
-cargo test -p wail-net -- --ignored fetch_metered_ice_servers_live
-
-# Requires coturn installed (brew install coturn) — full WebRTC path through a local TURN relay
-cargo test -p wail-net -- --ignored two_peers_exchange_audio_via_turn
+cargo test -p wail-net        # networking integration tests
 ```
 
 # TODO

--- a/crates/wail-audio/Cargo.toml
+++ b/crates/wail-audio/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wail-audio"
 version.workspace = true
 edition.workspace = true
-description = "Audio interval encoding/decoding for WAIL (Opus over WebRTC DataChannels)"
+description = "Audio interval encoding/decoding for WAIL (Opus over the WAIL relay)"
 
 [dependencies]
 audiopus = "0.3.0-rc.0"

--- a/crates/wail-audio/src/ring.rs
+++ b/crates/wail-audio/src/ring.rs
@@ -2208,9 +2208,9 @@ mod tests {
         assert_eq!(output[32], 0.0);
     }
 
-    // --- Tests: reconnect with same peer_id (WebRTC-level reconnect, no new peer_id) ---
+    // --- Tests: reconnect with same peer_id (transport-level reconnect, no new peer_id) ---
 
-    /// When the WebRTC connection drops and reconnects without a new peer_id
+    /// When the transport connection drops and reconnects without a new peer_id
     /// (session retries the same connection), no PeerLeft IPC is sent.
     /// The session sends PeerJoined again with the same peer_id and identity.
     /// The ring must keep the peer on the same slot — the slot was never freed.
@@ -2232,7 +2232,7 @@ mod tests {
             .unwrap()
             .0;
 
-        // WebRTC reconnect: PeerJoined IPC re-sent with same peer_id/identity,
+        // Transport reconnect: PeerJoined IPC re-sent with same peer_id/identity,
         // but NO PeerLeft was sent (slot is still active)
         ring.notify_peer_joined("peer-a", "identity-alice");
 

--- a/crates/wail-audio/src/wire.rs
+++ b/crates/wail-audio/src/wire.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-/// Binary wire format for audio intervals over WebRTC DataChannels.
+/// Binary wire format for audio intervals over the WAIL relay.
 ///
 /// Format (all integers are little-endian):
 /// ```text
@@ -26,7 +26,7 @@ const FRAME_FLAG_STEREO: u8 = 0x01;
 const FRAME_FLAG_FINAL: u8 = 0x02;
 
 
-/// Binary wire format for streaming audio frames over WebRTC DataChannels.
+/// Binary wire format for streaming audio frames over the WAIL relay.
 ///
 /// Each frame carries a single 20ms Opus packet. The final frame of an
 /// interval includes metadata so the receiver can reconstruct an AudioInterval.

--- a/crates/wail-core/src/protocol.rs
+++ b/crates/wail-core/src/protocol.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-/// Messages exchanged between peers over WebRTC DataChannels.
+/// Messages exchanged between peers over the WAIL relay.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum SyncMessage {
@@ -36,7 +36,7 @@ pub enum SyncMessage {
         bars: u32,
         quantum: f64,
     },
-    /// Greeting on DataChannel open
+    /// Greeting on connect
     Hello {
         peer_id: String,
         /// Human-readable name (e.g. "Ringo"). Old peers omit this field.

--- a/wail-app/events.go
+++ b/wail-app/events.go
@@ -79,17 +79,15 @@ type StatusUpdate struct {
 }
 
 type PeerNetworkInfo struct {
-	PeerID         string   `json:"peer_id"`
-	DisplayName    *string  `json:"display_name,omitempty"`
-	Slot           *uint32  `json:"slot,omitempty"`
-	ICEState       string   `json:"ice_state"`
-	DCSyncState    string   `json:"dc_sync_state"`
-	DCAudioState   string   `json:"dc_audio_state"`
-	RTTMs          *float64 `json:"rtt_ms,omitempty"`
-	AudioRecv      uint64   `json:"audio_recv"`
-	FramesReceived uint64   `json:"frames_received"`
-	PacketsLost    uint64   `json:"packets_lost"`
-	LossEvents     uint64   `json:"loss_events"`
+	PeerID          string   `json:"peer_id"`
+	DisplayName     *string  `json:"display_name,omitempty"`
+	Slot            *uint32  `json:"slot,omitempty"`
+	ConnectionState string   `json:"connection_state"`
+	RTTMs           *float64 `json:"rtt_ms,omitempty"`
+	AudioRecv       uint64   `json:"audio_recv"`
+	FramesReceived  uint64   `json:"frames_received"`
+	PacketsLost     uint64   `json:"packets_lost"`
+	LossEvents      uint64   `json:"loss_events"`
 }
 
 type PeersNetwork struct {

--- a/wail-app/frontend/index.html
+++ b/wail-app/frontend/index.html
@@ -198,16 +198,14 @@
           <tr>
             <th>Peer</th>
             <th>Slot</th>
-            <th>ICE</th>
-            <th>Sync DC</th>
-            <th>Audio DC</th>
+            <th>Connection</th>
             <th>RTT</th>
             <th>Recv</th>
             <th>Lost</th>
           </tr>
         </thead>
         <tbody id="network-table-body">
-          <tr><td colspan="8" class="empty">No peers connected</td></tr>
+          <tr><td colspan="6" class="empty">No peers connected</td></tr>
         </tbody>
       </table>
     </div>

--- a/wail-app/frontend/main.js
+++ b/wail-app/frontend/main.js
@@ -801,9 +801,7 @@ function renderNetwork(peers) {
     return `<tr>
       <td>${name}</td>
       <td>${slot}</td>
-      <td class="net-state net-${escapeHtml(p.ice_state)}">${escapeHtml(p.ice_state)}</td>
-      <td class="net-state net-${escapeHtml(p.dc_sync_state)}">${escapeHtml(p.dc_sync_state)}</td>
-      <td class="net-state net-${escapeHtml(p.dc_audio_state)}">${escapeHtml(p.dc_audio_state)}</td>
+      <td class="net-state net-${escapeHtml(p.connection_state)}">${escapeHtml(p.connection_state)}</td>
       <td>${rtt}</td>
       <td>${fr}</td>
       <td class="${lostClass}">${lost}</td>

--- a/wail-app/session.go
+++ b/wail-app/session.go
@@ -727,7 +727,7 @@ func sessionLoop(
 			}
 
 			connected := mesh.ConnectedPeers()
-			dcOpen := mesh.AnyPeersConnected()
+			anyPeersConnected := mesh.AnyPeersConnected()
 
 			// Build peer infos
 			peerInfos := make([]PeerInfo, 0, len(connected))
@@ -740,7 +740,7 @@ func sessionLoop(
 					recvPrev = ps.AudioRecvPrev
 				})
 				isRecv := recvNow > recvPrev
-				isSend := dcOpen && mesh.IsPeerConnected(p)
+				isSend := anyPeersConnected && mesh.IsPeerConnected(p)
 				status := peers.DeriveStatus(p)
 				var rttMs *float64
 				if rtt := clock.RTTUs(p); rtt != nil {
@@ -774,7 +774,7 @@ func sessionLoop(
 							streamName = &n
 						}
 					})
-					isSend = dcOpen && mesh.IsPeerConnected(pid)
+					isSend = anyPeersConnected && mesh.IsPeerConnected(pid)
 				}
 				status := "connecting"
 				if found {
@@ -818,14 +818,14 @@ func sessionLoop(
 				LocalSends: localSends, IntervalBars: intervalBars,
 				AudioSent: audioIntervalsSent, AudioRecv: audioIntervalsReceived,
 				AudioBytesSent: audioBytesSent, AudioBytesRecv: audioBytesRecv,
-				AudioDCOpen: dcOpen, PluginConnected: !ipcPool.IsEmpty() || config.TestMode,
+				AudioDCOpen: anyPeersConnected, PluginConnected: !ipcPool.IsEmpty() || config.TestMode,
 				Recording: recorder != nil,
 				RecordingSizeBytes: func() uint64 { if recorder != nil { return recorder.BytesWritten() }; return 0 }(),
 			})
 
 			// Broadcast audio status
 			audioStatusSeq++
-			mesh.Broadcast(NewAudioStatus(dcOpen, audioIntervalsSent, audioIntervalsReceived, !ipcPool.IsEmpty() || config.TestMode, audioStatusSeq))
+			mesh.Broadcast(NewAudioStatus(anyPeersConnected, audioIntervalsSent, audioIntervalsReceived, !ipcPool.IsEmpty() || config.TestMode, audioStatusSeq))
 
 			// Send metrics + build network event
 			perPeer := make(map[string]PeerFrameReport)
@@ -858,14 +858,14 @@ func sessionLoop(
 				status := peers.DeriveStatus(p)
 				networkInfos = append(networkInfos, PeerNetworkInfo{
 					PeerID: p, DisplayName: dn, Slot: slot,
-					ICEState: status, DCSyncState: status, DCAudioState: status,
+					ConnectionState: status,
 					RTTMs: rttMs, AudioRecv: audioRecv,
 					FramesReceived: fr, PacketsLost: lost, LossEvents: lossEvents,
 				})
 			}
 			emitter.Emit("peers:network", PeersNetwork{Peers: networkInfos})
 			_ = ipcDropCount.Load()
-			mesh.SendMetricsReport(dcOpen, !ipcPool.IsEmpty() || config.TestMode, perPeer, ipcDropCount.Load(), boundaryDriftUs)
+			mesh.SendMetricsReport(anyPeersConnected, !ipcPool.IsEmpty() || config.TestMode, perPeer, ipcDropCount.Load(), boundaryDriftUs)
 		}
 	}
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,5 +6,4 @@ publish = false
 
 [dependencies]
 anyhow = "1"
-md5 = "0.7"
 serde_json = "1"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -19,7 +19,6 @@ TASKS:
   install-plugin  Build (optional) and install to system plugin directories
   package-plugin  Create a macOS .pkg installer (macOS only)
   test            Build plugins if missing, then run cargo test
-  run-turn        Start a local coturn TURN server
   test-client     Run the test tone client
 
 OPTIONS (install):
@@ -38,12 +37,6 @@ OPTIONS (install-plugin):
 OPTIONS (package-plugin):
   --no-build      Skip the build step; package existing bundles
 
-OPTIONS (run-turn):
-  --port <PORT>   Listening port          (default: 3478)
-  --user <U:P>    Username:password       (default: wail:wailpass)
-  --min-port <N>  Relay port range start  (default: 49152)
-  --max-port <N>  Relay port range end    (default: 49252)
-
 OPTIONS (test-client):
   All arguments are forwarded to wail-test-client.
   See `cargo xtask test-client -- --help` for available options.
@@ -61,7 +54,6 @@ EXAMPLES:
   cargo xtask package-plugin --no-build
   cargo xtask test
   cargo xtask test -- -p wail-net --ignored
-  cargo xtask run-turn
 ";
 
 // ---------------------------------------------------------------------------
@@ -95,10 +87,6 @@ fn main() -> Result<()> {
         Some("test") => {
             args.remove(0);
             run_test(&args)
-        }
-        Some("run-turn") => {
-            args.remove(0);
-            run_turn(&args)
         }
         Some("test-client") => {
             args.remove(0);
@@ -498,78 +486,6 @@ fn run_test(args: &[String]) -> Result<()> {
     Ok(())
 }
 
-fn run_turn(args: &[String]) -> Result<()> {
-    // Parse optional flags
-    let get_flag = |flag: &str, default: &str| -> String {
-        args.windows(2)
-            .find(|w| w[0] == flag)
-            .map(|w| w[1].clone())
-            .unwrap_or_else(|| default.to_string())
-    };
-
-    let port = get_flag("--port", "3478");
-    let user = get_flag("--user", "wail:wailpass");
-    let min_port = get_flag("--min-port", "49152");
-    let max_port = get_flag("--max-port", "49252");
-    let realm = "wail";
-
-    // Detect local IP
-    let local_ip = detect_local_ip().unwrap_or_else(|| "0.0.0.0".to_string());
-
-    // Detect public IP
-    println!("Detecting public IP...");
-    let public_ip = detect_public_ip().unwrap_or_else(|| {
-        eprintln!("Warning: Could not detect public IP. Using local IP.");
-        local_ip.clone()
-    });
-
-    let username = user.split(':').next().unwrap_or("wail");
-    let password = user.split(':').nth(1).unwrap_or("wailpass");
-
-    println!("Local IP:  {local_ip}");
-    println!("Public IP: {public_ip}");
-    println!("TURN port: {port}");
-    println!("Relay ports: {min_port}-{max_port}");
-    println!("Credentials: {username}:{password}");
-    println!();
-    println!("Configure your WAIL client with:");
-    println!("  TURN Server:   turn:{public_ip}:{port}");
-    println!("  TURN Username: {username}");
-    println!("  TURN Password: {password}");
-    println!();
-    println!("Make sure to forward ports {port} (TCP+UDP) and {min_port}-{max_port} (UDP) on your router.");
-    println!();
-
-    // Compute lt-cred-mech key: MD5(username:realm:password)
-    let key = {
-        use std::io::Write;
-        let mut ctx = md5::Context::new();
-        write!(ctx, "{username}:{realm}:{password}").unwrap();
-        format!("0x{:x}", ctx.compute())
-    };
-
-    // Find turnserver binary
-    let turnserver = which_turnserver()?;
-
-    let mut cmd = Command::new(turnserver);
-    cmd.arg("-n") // no config file
-        .arg("--log-file=stdout")
-        .arg("--verbose")
-        .arg(format!("--listening-port={port}"))
-        .arg(format!("--listening-ip={local_ip}"))
-        .arg(format!("--external-ip={public_ip}/{local_ip}"))
-        .arg(format!("--realm={realm}"))
-        .arg(format!("--user={username}:{key}"))
-        .arg("--lt-cred-mech")
-        .arg("--no-tls")
-        .arg("--no-dtls")
-        .arg(format!("--min-port={min_port}"))
-        .arg(format!("--max-port={max_port}"));
-
-    println!("Starting coturn TURN server...\n");
-    run_cmd(cmd)
-}
-
 fn run_test_client(args: &[String]) -> Result<()> {
     println!("Building and running wail-test-client...");
     let mut cmd = Command::new(env!("CARGO"));
@@ -577,89 +493,6 @@ fn run_test_client(args: &[String]) -> Result<()> {
     cmd.args(args);
     cmd.current_dir(workspace_dir());
     run_cmd(cmd)
-}
-
-fn which_turnserver() -> Result<String> {
-    // Check common locations
-    for path in &[
-        "/opt/homebrew/opt/coturn/bin/turnserver",
-        "/opt/homebrew/bin/turnserver",
-        "/usr/local/bin/turnserver",
-        "/usr/bin/turnserver",
-    ] {
-        if Path::new(path).exists() {
-            return Ok(path.to_string());
-        }
-    }
-    // Try PATH
-    let output = Command::new("which")
-        .arg("turnserver")
-        .output()
-        .context("Could not locate turnserver")?;
-    if output.status.success() {
-        return Ok(String::from_utf8_lossy(&output.stdout).trim().to_string());
-    }
-    #[cfg(target_os = "macos")]
-    bail!("coturn not found. Install with: brew install coturn");
-    #[cfg(target_os = "linux")]
-    bail!("coturn not found. Install with: sudo apt install coturn");
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    bail!("coturn not found. See https://github.com/coturn/coturn for installation instructions.")
-}
-
-fn detect_local_ip() -> Option<String> {
-    #[cfg(target_os = "macos")]
-    {
-        // Try en0 first (Wi-Fi on macOS), then en1
-        for iface in &["en0", "en1"] {
-            let output = Command::new("ipconfig")
-                .args(["getifaddr", iface])
-                .output()
-                .ok()?;
-            if output.status.success() {
-                let ip = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                if !ip.is_empty() {
-                    return Some(ip);
-                }
-            }
-        }
-        None
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        // hostname -I returns space-separated non-loopback IPs
-        let output = Command::new("hostname").arg("-I").output().ok()?;
-        if output.status.success() {
-            let ips = String::from_utf8_lossy(&output.stdout);
-            if let Some(ip) = ips.split_whitespace().next() {
-                if !ip.is_empty() {
-                    return Some(ip.to_string());
-                }
-            }
-        }
-        None
-    }
-
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    {
-        None
-    }
-}
-
-fn detect_public_ip() -> Option<String> {
-    // Try IPv4 first
-    let output = Command::new("curl")
-        .args(["-s", "-4", "--max-time", "5", "https://api.ipify.org"])
-        .output()
-        .ok()?;
-    if output.status.success() {
-        let ip = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if !ip.is_empty() && !ip.contains(':') {
-            return Some(ip);
-        }
-    }
-    None
 }
 
 fn install_all(args: &[String]) -> Result<()> {


### PR DESCRIPTION
## What

WebRTC was replaced by the WebSocket relay a while back, but residue remained that no longer describes anything real. This removes it. Pure cleanup — no behavioral change to the sync/audio paths.

### Changed
- **xtask**: dropped the `run-turn` coturn task, its `detect_local_ip`/`detect_public_ip`/`which_turnserver` helpers, and the now-unused `md5` dependency. TURN/ICE NAT traversal doesn't exist in the relay architecture.
- **Comments & labels**: "over WebRTC DataChannels" → "over the WAIL relay" (`wail-audio/src/wire.rs`, `wail-audio` crate description, `wail-core/src/protocol.rs`); "Greeting on DataChannel open" → "on connect"; WebRTC-reconnect test comments → transport-level.
- **`session.go`**: renamed local `dcOpen` → `anyPeersConnected` (the WebRTC "data channel open" name never fit; it just means "any peers connected"). Wire/protocol field names left untouched.
- **Dashboard**: the network table had three columns — `ice_state`, `dc_sync_state`, `dc_audio_state` — all populated with the *same* status string. Collapsed into one honest `Connection` column (`events.go`, `session.go`, `index.html`, `main.js`).
- **`DEVELOPMENT.md`**: removed instructions to run two `#[ignore]` tests that were deleted with the WebRTC migration (`fetch_metered_ice_servers_live`, `two_peers_exchange_audio_via_turn`).

### Deliberately deferred (entangled with upcoming work)
- The **protocol fields** `audio_dc_open` (peer↔peer) and `dc_open` (client→server) — the server defaults `dc_open` to false when absent and gates its session-phase transition on it, so removal needs a server-first rollout. Folds into the plugin-retirement migration.
- **`wail-net`** tooling names (`is_peer_audio_dc_open`, etc.) and **`docs/test-strategies.md`**'s WebRTC/ICE test-strategy sections — the latter is a whole-document rewrite better done against the new architecture.

## Testing
- `go build` / `go vet` / `go test ./...` (wail-app, linkstub) — pass
- `cargo test -p wail-core -p wail-audio -p xtask` — 64 pass, xtask compiles without `md5`/`run_turn`
- `cargo build --workspace --exclude wail-plugin-test` — full compile (plugin crates included; `wail-plugin-test` skipped by its pre-existing bundle-gated build.rs)

🧹 Tidied by Claude Code, which has since gone to lie down