### PR TITLE
chore: bump vendored Ableton Link to final 4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ signaling-server/
 └── main.go           WebSocket signaling server (Go + SQLite, deployed to fly.io)
 
 vendor/
-└── link/             Ableton Link 4.0.0 beta SDK (git submodule)
+└── link/             Ableton Link 4.0 SDK (git submodule)
 ```
 
 ## Build


### PR DESCRIPTION
## What

Bumps the `vendor/link` submodule from **4.0.0b1** (`082691b`) to the final **Link-4.0** tag (`e9a2e41`).

Beta 1 predates fixes shipped in the final release, notably:
- **source-only peers never receiving audio** — a hard blocker for any future Link Audio *capture* role (WAIL subscribing to local channels is exactly a source-heavy peer)
- a peer-name buffer overrun crash
- message-size exceptions

This is the prerequisite called out in `docs/adr/0001` for the Link Audio direction.

## Why it's safe

Nothing in the normal build compiles our `vendor/link`:
- The **Go app** and the **Homebrew formula** both build Link via the separately-cloned `abletonlink-go` fork (`homebrew/wail.rb:45-50`).
- The **Rust crates** use `rusty_link`'s own vendored Link.
- Our `vendor/link` is only bundled into the release source tarball (`release.yml:40`) as the reference SDK.

The MinGW `Channels.hpp` patch in `release.yml` targets **abletonlink-go's** vendored copy (`$RUNNER_TEMP/abletonlink-go/vendor/link/...`), *not* this submodule — so it is unaffected by this bump.

## Testing
Pointer-only change; no local build compiles this submodule. Verified the SDK's `Link-4.0` tag resolves to `e9a2e41` and the C++17 requirement (`AbletonLinkConfig.cmake`) is documented. No CI build path compiles `vendor/link`.

## Follow-up (not in this PR)
`abletonlink-go` (the fork the Go app actually links) has its own Link pin; keeping it current is tracked separately.

🎚️ Submodule wrangled by Claude Code, now humming to itself in the corner