### PR TITLE
ci: fix knope versioned_files for the plain VERSION file

### DIFF
--- a/knope.toml
+++ b/knope.toml
@@ -1,5 +1,7 @@
 [package]
-versioned_files = ["VERSION"]
+# VERSION is a plain-text semver file (not a format knope recognizes by name),
+# so we point knope at it with a regex whose `version` capture group it bumps.
+versioned_files = [{ path = "VERSION", regex = "(?<version>\\d+\\.\\d+\\.\\d+)" }]
 changelog = "CHANGELOG.md"
 
 [github]

--- a/wail-app/version.go
+++ b/wail-app/version.go
@@ -1,5 +1,5 @@
 package main
 
-// appVersion is injected at build time via -ldflags from Cargo.toml workspace
-// version. Unreleased/local builds show the default.
+// appVersion is injected at build time via -ldflags from the release git tag
+// (see .github/workflows/release.yml). Unreleased/local builds show the default.
 var appVersion = "0.0.0-dev"


### PR DESCRIPTION
The **Prepare Release** workflow failed on `main` after the Link Audio migration landed ([run 29394940326](https://github.com/MostDistant/WAIL/actions/runs/29394940326)):

```
Error: Problem with versioned file
  ╰─▶ Unknown file: VERSION
```

The migration switched versioning from `Cargo.toml` to a plain-text `VERSION` file, but knope identifies versioned files **by name** and has no built-in support for a bare `VERSION` file — so `knope prepare-release` errored and no release PR was created.

## Fix

Point knope at the file with a regex whose `version` capture group it reads and bumps (the documented way to version an unsupported file type):

```toml
versioned_files = [{ path = "VERSION", regex = "(?<version>\\d+\\.\\d+\\.\\d+)" }]
```

Verified: the TOML parses and the regex extracts `2.4.7` from the current `VERSION`.

Also corrects a stale comment in `version.go` — `appVersion` is injected from the release **git tag** (`release.yml` `-ldflags`), not the removed `Cargo.toml`.

Once this lands, the next push to `main` re-runs Prepare Release and should produce the proper **v3.0.0** release PR (the migration is a `feat!`).

---
Claude Code, having sent the last release bot into an existential "Unknown file" spiral, offers this apology in regex form.