### PR TITLE
fix: Homebrew source tarball nested the Link SDK one directory too deep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,16 @@ jobs:
           # Export the repo tree (excludes .git) into a named staging directory
           mkdir -p "/tmp/${STAGING}"
           git archive --format=tar HEAD | tar -x -C "/tmp/${STAGING}"
-          # Overlay the submodule contents (git archive omits them)
-          cp -r vendor/link "/tmp/${STAGING}/vendor/link"
+          # Overlay the submodule contents. git archive emits the gitlink as an
+          # empty vendor/link/ directory, so copy the submodule's *contents* into
+          # it — `cp -r vendor/link dest/vendor/link` would nest them one level
+          # too deep (vendor/link/link/), breaking the cgo include paths.
+          mkdir -p "/tmp/${STAGING}/vendor/link"
+          cp -R vendor/link/. "/tmp/${STAGING}/vendor/link/"
+          # Fail loudly if the headers the cgo binding needs aren't where
+          # wail-app/internal/abllink expects them.
+          test -f "/tmp/${STAGING}/vendor/link/extensions/abl_link/include/abl_link.h"
+          test -d "/tmp/${STAGING}/vendor/link/modules/asio-standalone/asio/include"
           # Package and compute checksum
           tar -czf "wail-${VERSION}-src.tar.gz" -C /tmp "${STAGING}"
           sha256sum "wail-${VERSION}-src.tar.gz" | awk '{print $1}' > "wail-${VERSION}-src.tar.gz.sha256"


### PR DESCRIPTION
## Problem

`brew install MostDistant/wail/wail` (v3.0.0) fails to compile:

```
./capture.h:19:10: fatal error: 'abl_link.h' file not found
```

The release workflow's "fat" source tarball is supposed to bundle the `vendor/link` submodule (GitHub's auto-generated archives omit submodules). But `git archive` emits the gitlink as an **empty `vendor/link/` directory**, so the overlay step

```sh
cp -r vendor/link "/tmp/${STAGING}/vendor/link"
```

copied the submodule *into* that existing directory, landing the SDK at `vendor/link/link/`. The cgo include paths in `wail-app/internal/abllink` (`-I…/vendor/link/extensions/abl_link/include`, etc.) then point at an empty tree. Confirmed by inspecting the published `wail-3.0.0-src.tar.gz`.

## Fix

- Copy the submodule's **contents** into the staging dir (`cp -R vendor/link/. …/vendor/link/`) instead of the directory itself.
- Assert `abl_link.h` and the asio include dir are at the paths the cgo binding expects before packaging, so a malformed tarball fails CI instead of shipping.

## Verification

- Reproduced the staging steps locally: `git archive` does emit `vendor/link` as an empty dir; after the fixed copy, `vendor/link/extensions/abl_link/include/abl_link.h` exists and there is no nested `vendor/link/link`.
- Ran the exact formula build command (`go build -tags nolibopusfile -o wail .` in `wail-app/`) from the staged tree — builds clean.
- `go test ./...` passes in both `wail-app` and `signaling-server`.

## Note

A fixed tarball only exists once a new release ships (merge → auto-release PR → v3.0.1), or by re-dispatching `release.yml` from `main` with `tag: v3.0.0` to rebuild and replace the 3.0.0 assets + tap sha in place.

Claude Code found the bug, but the empty directory was there all along, just vibing.