### PR TITLE
feat: stream capture audio in real time during the interval

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,9 +108,9 @@ WAIL is an Ableton Link Audio peer. There are no plugins and no IPC — the whol
 
 **Capture (send side):**
 1. Subscribe to local Link Audio channels (`LinkAudioSource`). The realtime capture callback is pure C (`internal/abllink/capture.c`) and pushes buffers into a lock-free ring; a Go goroutine drains it off-thread (ADR-0002 invariant: never a Go callback on the audio thread).
-2. `internal/capture` buckets buffers into fixed-length NINJAM intervals (local index).
-3. `interval_codec.go` Opus-encodes the interval into 20ms WAIF frames.
-4. Frames are broadcast over the WebSocket relay (binary) to all room peers.
+2. `internal/capture` buckets buffers into fixed-length NINJAM intervals (local index), emitting each 20ms window as its audio arrives (the interval is a playout concept, not a transmission one).
+3. `interval_codec.go` Opus-encodes each window into a WAIF frame as it fills.
+4. Frames stream over the WebSocket relay (binary) to all room peers in real time during the interval.
 
 **Playback (recv side):**
 1. Receive WAIF frames from the relay.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,8 +90,8 @@ Interval N+1: [CAPTURE local Link Audio] ──→ on boundary ──→ Opus-en
               [EMIT remote audio for room interval N+1-D]
 ```
 
-- **Capture** (`internal/capture`): each Link Audio buffer is written at its sample offset in a fixed-length interval PCM buffer; when a buffer opens the next interval, the completed one is handed off for Opus encoding + transmission.
-- **Send pacing** (`internal/pace`): the encoded interval (hundreds of WAIF frames) is never burst into the socket. A per-stream paced sender emits one frame per 10ms (2× real time). With the default offset `D=1`, playback of interval `N` starts at the same boundary at which sending starts, so delivery is concurrent with playback — the invariant is that the send position stays ahead of the playhead (frame `k` is sent at `k×10ms`, played at `k×20ms`), without overflowing send queues or the relay's per-peer rate limiter. The first frames of an interval arrive network-latency late and are live-appended by `internal/playout`, as with any `D=1` delivery.
+- **Capture** (`internal/capture`): each Link Audio buffer is written at its sample offset in a fixed-length interval PCM buffer. Capture **streams**: as coverage passes each 20ms window, the window is emitted for immediate Opus encoding + transmission (NINJAM-style — the interval is a playout concept, not a transmission one), so WAIF frames leave in real time *during* the interval. When a buffer opens the next interval, the previous interval's remaining windows flush zero-padded (gaps read as silence), ending with the final frame that carries the interval trailer. With the default offset `D=1`, every frame therefore arrives roughly a full interval before the receiver's playout boundary needs it.
+- **Send pacing** (`internal/pace`): defense in depth behind streaming capture. Normal operation emits single frames at real-time cadence, which pass through the pacer untouched; only abnormal batches (an interval-close flush after a capture stall, config edges) are spaced out at one frame per 10ms instead of bursting into the send queue or the relay's per-peer rate limiter.
 - **Playback** (`internal/emit` + `internal/playout`): decoded frames are reassembled per room interval index; the hold-until-boundary scheduler releases interval `N` at the local boundary labeled `N+D` (offset D, default 1), and a paced reader tops the Link Audio sink up a few ms at a time (never a burst). Late frames for the interval currently playing are **live-appended** (play-partial) rather than dropped or delayed a whole interval.
 - **Channel affinity** (`internal/affinity`): each remote `(persistent identity, stream index)` maps to a stable published Link Audio channel. When a peer disconnects and reconnects (new session peer id, same identity), it reclaims the same channel/sink, so LAN apps' routing survives the blip. There is no fixed 15-slot cap — each remote stream is its own channel.
 - **Own-channel exclusion** (`internal/affinity.OwnChannels`): capture discovery must skip WAIL's own republished channels (feedback loop) but must not hide a third-party publisher that merely shares WAIL's Link peer name. Since the sink channel ID isn't exposed by the `abl_link` C API, the classifier records every sink name WAIL mints and learns each sink's channel ID from the first discovery snapshot that pairs a minted name with WAIL's peer name; from then on exclusion is by ID (rename-proof).
@@ -103,9 +103,10 @@ Interval N+1: [CAPTURE local Link Audio] ──→ on boundary ──→ Opus-en
 ```
 DAW / Link-Audio app A publishes a Link Audio channel on LAN A
   → WAIL A subscribes (LinkAudioSource); pure-C callback → C ring → Go drainer
-  → internal/capture buckets buffers into a fixed-length interval (local index)
-  → interval_codec.go Opus-encodes each 20ms frame → WAIF frames (labeled with the room index)
-  → internal/pace spaces the frames out (one per 10ms, 2× real time)
+  → internal/capture buckets buffers into a fixed-length interval (local index),
+    emitting each 20ms window as its audio arrives
+  → interval_codec.go Opus-encodes the window → one WAIF frame (labeled with the room
+    index), sent immediately — frames stream in real time during the interval
   → WebSocket binary frame → relay server → Peer B
   → WAIL B receives WAIF
   → interval_codec.go Opus-decodes; internal/emit reassembles per (identity, stream index)

--- a/tradeoffs.md
+++ b/tradeoffs.md
@@ -145,9 +145,14 @@ Deferred decisions and remaining code quality items. Each entry has enough conte
 **Decision:** Peer-name-only matching hid a third-party publisher (Bitwig VoidLinkAudioSend defaulting its peer name to the machine name) in a live test. The `abl_link` C API still doesn't expose a sink's channel id, so `affinity.OwnChannels` records every sink name WAIL mints and learns each sink's id from the first discovery snapshot pairing a minted name with our peer name; exclusion is by learned id thereafter (rename-proof). Residual theoretical false-skip: a same-LAN publisher matching both our peer name and a minted name.
 
 ### Send pacing rate and relay burst limits
-**Status:** Decided (issue #352)
-**File:** `wail-app/internal/pace/pace.go`, `wail-app/audio_engine_real.go`, `signaling-server/main.go`
-**Decision:** Outgoing interval frames are paced at 2× real time (one 20ms frame per 10ms). With D=1, delivery is concurrent with playback (both start at the same boundary), so the requirement is staying ahead of the playhead: frame k is sent at k×10ms and plays at k×20ms, a linearly growing margin. 1× would leave zero catch-up margin after any hiccup; much faster re-approaches the burst that overflowed queues. The relay keeps a flat per-stream token bucket (rate 100/s, burst 2500) rather than an interval-aware limit derived from bars/quantum/BPM — simpler, and the burst covers a full interval even at slow tempos (1200 frames at 40 BPM / 4 bars). Revisit if intervals ever exceed ~25s.
+**Status:** Superseded by streaming capture (kept as defense in depth)
+**File:** `wail-app/internal/pace/pace.go`, `wail-app/internal/capture/assembler.go`, `signaling-server/main.go`
+**Decision:** Capture now streams each 20ms window as it fills (like the old plugins / NINJAM), so frames leave at real-time cadence during the interval and arrive ~a full interval before the D=1 playout boundary — no burst exists in normal operation. The pacer (2× real time, one frame per 10ms) stays wired as defense in depth for abnormal batches (interval-close flushes after a capture stall). The relay keeps the flat per-stream bucket (rate 100/s, burst 2500) rather than an interval-aware limit — simpler, and now far above steady-state.
+
+### Emitted capture windows are immutable
+**Status:** Decided
+**File:** `wail-app/internal/capture/assembler.go` (`AddWindows`)
+**Decision:** Streaming capture emits a window once coverage passes its end; a buffer that lands behind the emitted boundary is trimmed/dropped and counted (`DroppedBackfill`). Link Audio buffers arrive in temporal order from the C ring, so backfill only occurs on pathological reordering — accepted in exchange for real-time transmission. The relay keeps a flat per-stream token bucket (rate 100/s, burst 2500) rather than an interval-aware limit derived from bars/quantum/BPM — simpler, and the burst covers a full interval even at slow tempos (1200 frames at 40 BPM / 4 bars). Revisit if intervals ever exceed ~25s.
 
 ### Cross-platform binding link unverified
 **Status:** Open

--- a/wail-app/audio_engine_real.go
+++ b/wail-app/audio_engine_real.go
@@ -64,6 +64,7 @@ type linkAudioEngine struct {
 	wg     sync.WaitGroup
 
 	wireDecodeFailures atomic.Uint64 // WAIF wire-decode errors (pre-Opus)
+	unlabeledWindows   atomic.Uint64 // capture windows dropped before a room anchor
 
 	mu       sync.Mutex
 	labeler  interval.RoomLabeler
@@ -314,7 +315,7 @@ func (e *linkAudioEngine) startCaptureLocked(ch *captureChannel) {
 		return
 	}
 	ch.enc = enc
-	ch.asm = capture.New(e.cfg, 2, engineInternalRate)
+	ch.asm = capture.NewWindowed(e.cfg, 2, engineInternalRate, samplesPerWaifFrame(engineInternalRate))
 	name := ch.name // stable copy: the onDrop callback runs off the pacer goroutine
 	ch.pacer = pace.New(sendFrameGap, sendQueueBatches, e.send, func(n int) {
 		log.Printf("[audio] WARN: send backlog on %q — dropped a batch of %d frames", name, n)
@@ -379,31 +380,48 @@ func (e *linkAudioEngine) drainCapture(ctx context.Context, ch *captureChannel) 
 					pcm = dsp.ResampleLinearInterleaved(pcm, buf.NumChannels, int(buf.SampleRate), engineInternalRate)
 				}
 				nFrames := len(pcm) / max1(buf.NumChannels)
-				if done := ch.asm.Add(beat, buf.TempoBPM, pcm, nFrames); done != nil {
-					e.emitCaptured(ch, done)
+				for _, w := range ch.asm.AddWindows(beat, buf.TempoBPM, pcm, nFrames) {
+					e.emitWindow(ch, w)
 				}
 			}
 		}
 	}
 }
 
-// emitCaptured labels a completed local interval with the room index and ships
-// it as WAIF frames to the relay.
-func (e *linkAudioEngine) emitCaptured(ch *captureChannel, done *capture.CompletedInterval) {
+// emitWindow labels one capture window with the room index, encodes it, and
+// ships it. Windows arrive as their 20ms of audio fills, so WAIF frames leave
+// in real time during the interval — the receiver has nearly the whole
+// interval before its N+D playout boundary instead of racing the playhead.
+func (e *linkAudioEngine) emitWindow(ch *captureChannel, w capture.Window) {
 	e.mu.Lock()
-	roomIdx, ok := e.labeler.RoomIndex(done.Index)
+	roomIdx, ok := e.labeler.RoomIndex(w.IntervalIndex)
 	bpm, cfg := e.tempoBPM, e.cfg
 	e.mu.Unlock()
 	if !ok {
-		return // no room anchor yet; can't label
+		// No room anchor yet; can't label. Same drop as the old whole-interval
+		// path, now per window.
+		if n := e.unlabeledWindows.Add(1); n == 1 || n%1000 == 0 {
+			log.Printf("[audio] warn: dropping unlabeled capture windows on %q (%d total)", ch.name, n)
+		}
+		return
 	}
-	frames, next, err := ch.enc.EncodeInterval(done.Samples, roomIdx, ch.streamID, ch.seq, bpm, cfg.Quantum, cfg.Bars)
+	wire, err := ch.enc.EncodeWindow(w.Samples, WindowMeta{
+		RoomIndex:   roomIdx,
+		StreamID:    ch.streamID,
+		FrameNumber: uint32(w.Number),
+		Seq:         ch.seq,
+		IsFinal:     w.IsFinal,
+		TotalFrames: uint32(w.Total),
+		BPM:         bpm,
+		Quantum:     cfg.Quantum,
+		Bars:        cfg.Bars,
+	})
 	if err != nil {
 		log.Printf("[audio] encode failed on %q: %v", ch.name, err)
 		return
 	}
-	ch.seq = next
-	ch.pacer.Enqueue(frames)
+	ch.seq++
+	ch.pacer.Enqueue([][]byte{wire})
 }
 
 // --- emit ---

--- a/wail-app/internal/capture/assembler.go
+++ b/wail-app/internal/capture/assembler.go
@@ -31,6 +31,10 @@ type Assembler struct {
 	sampleRate uint32
 	cur        *intervalBuf
 	droppedLate uint64
+
+	// Windowed (streaming) mode: 0 in batch mode.
+	windowFrames    int
+	droppedBackfill uint64
 }
 
 type intervalBuf struct {
@@ -38,6 +42,8 @@ type intervalBuf struct {
 	pcm           []int16
 	frames        int
 	writtenFrames int
+	emitted       int // windows already emitted (windowed mode)
+	totalWindows  int // fixed at interval open (windowed mode)
 }
 
 // New creates an assembler for a channel with the given interval config and
@@ -47,6 +53,19 @@ func New(cfg interval.Config, channels int, sampleRate uint32) *Assembler {
 		channels = 1
 	}
 	return &Assembler{cfg: cfg, channels: channels, sampleRate: sampleRate}
+}
+
+// NewWindowed creates an assembler in streaming mode: instead of handing back
+// whole intervals, AddWindows emits fixed-size encode-ready windows (one WAIF
+// frame each) as soon as capture coverage passes them, so transmission can run
+// during the interval rather than bursting at its boundary.
+func NewWindowed(cfg interval.Config, channels int, sampleRate uint32, windowFrames int) *Assembler {
+	a := New(cfg, channels, sampleRate)
+	if windowFrames < 1 {
+		windowFrames = 1
+	}
+	a.windowFrames = windowFrames
+	return a
 }
 
 // Add places a buffer beginning at local beat `beat` (from Source.BeginBeats)
@@ -87,9 +106,138 @@ func (a *Assembler) Flush() *CompletedInterval {
 // emitted interval (out-of-order arrivals).
 func (a *Assembler) DroppedLate() uint64 { return a.droppedLate }
 
+// Window is one encode-ready chunk of an interval in streaming mode: exactly
+// windowFrames × channels interleaved samples (the short final window of an
+// odd-length interval is zero-padded). Number is the window index within the
+// interval — the WAIF frame number — and IsFinal marks the interval's last
+// window (its WAIF frame carries the interval trailer). Samples may alias the
+// assembler's interval buffer and is valid until the next call on the
+// assembler; encode it before adding more audio.
+type Window struct {
+	IntervalIndex int64
+	Number        int
+	Total         int
+	IsFinal       bool
+	Samples       []int16
+}
+
+// AddWindows is the streaming counterpart of Add (requires NewWindowed). It
+// places the buffer exactly like Add and returns the windows that became ready:
+// a window is ready once coverage passes its end, and when a buffer opens a new
+// interval the previous interval's remaining windows flush first (zero-padded —
+// capture gaps read as silence), ending with its final window.
+//
+// Emitted windows are immutable: a buffer that lands behind the emitted
+// boundary is trimmed to it (fully-behind buffers are dropped) and counted in
+// DroppedBackfill. Capture buffers arrive in temporal order, so this only
+// fires on pathological reordering.
+func (a *Assembler) AddWindows(beat, tempoBPM float64, samples []int16, numFrames int) []Window {
+	idx := a.cfg.IndexAtBeat(beat)
+
+	var out []Window
+	if a.cur == nil {
+		a.cur = a.newBuf(idx, tempoBPM)
+	} else if idx > a.cur.index {
+		out = a.remainingWindows()
+		a.cur = a.newBuf(idx, tempoBPM)
+	} else if idx < a.cur.index {
+		a.droppedLate++
+		return nil
+	}
+
+	off := a.cfg.FrameOffset(beat, a.cur.index, a.sampleRate, tempoBPM)
+	if lim := a.cur.emitted * a.windowFrames; off < lim {
+		a.droppedBackfill++
+		skip := lim - off
+		if skip >= numFrames {
+			return out
+		}
+		samples = samples[skip*a.channels:]
+		numFrames -= skip
+		off = lim
+	}
+	a.write(off, samples, numFrames)
+	return append(out, a.readyWindows()...)
+}
+
+// FlushWindows emits the current interval's remaining windows (zero-padded,
+// ending with its final window) and clears it — the streaming counterpart of
+// Flush, for shutdown / channel removal.
+func (a *Assembler) FlushWindows() []Window {
+	if a.cur == nil {
+		return nil
+	}
+	w := a.remainingWindows()
+	a.cur = nil
+	if len(w) == 0 {
+		return nil
+	}
+	return w
+}
+
+// DroppedBackfill is the number of buffers trimmed or dropped for landing
+// behind the emitted-window boundary (windowed mode only).
+func (a *Assembler) DroppedBackfill() uint64 { return a.droppedBackfill }
+
+// readyWindows emits every window whose end is covered. Exact full coverage
+// also readies the (possibly short) final window without waiting for close.
+func (a *Assembler) readyWindows() []Window {
+	b := a.cur
+	ready := b.writtenFrames / a.windowFrames
+	if b.writtenFrames >= b.frames || ready > b.totalWindows {
+		ready = b.totalWindows
+	}
+	var out []Window
+	for k := b.emitted; k < ready; k++ {
+		out = append(out, a.window(k))
+	}
+	if ready > b.emitted {
+		b.emitted = ready
+	}
+	return out
+}
+
+// remainingWindows flushes every not-yet-emitted window of the current interval.
+func (a *Assembler) remainingWindows() []Window {
+	b := a.cur
+	var out []Window
+	for k := b.emitted; k < b.totalWindows; k++ {
+		out = append(out, a.window(k))
+	}
+	b.emitted = b.totalWindows
+	return out
+}
+
+func (a *Assembler) window(k int) Window {
+	b := a.cur
+	start := k * a.windowFrames * a.channels
+	end := start + a.windowFrames*a.channels
+	var s []int16
+	if end <= len(b.pcm) {
+		s = b.pcm[start:end]
+	} else {
+		// Short final window of an odd-length interval: pad to a full frame.
+		s = make([]int16, a.windowFrames*a.channels)
+		if start < len(b.pcm) {
+			copy(s, b.pcm[start:])
+		}
+	}
+	return Window{
+		IntervalIndex: b.index,
+		Number:        k,
+		Total:         b.totalWindows,
+		IsFinal:       k == b.totalWindows-1,
+		Samples:       s,
+	}
+}
+
 func (a *Assembler) newBuf(idx int64, tempoBPM float64) *intervalBuf {
 	frames := a.cfg.IntervalSamples(a.sampleRate, tempoBPM)
-	return &intervalBuf{index: idx, pcm: make([]int16, frames*a.channels), frames: frames}
+	b := &intervalBuf{index: idx, pcm: make([]int16, frames*a.channels), frames: frames}
+	if a.windowFrames > 0 {
+		b.totalWindows = (frames + a.windowFrames - 1) / a.windowFrames
+	}
+	return b
 }
 
 // write copies numFrames of interleaved samples into the current interval at

--- a/wail-app/internal/capture/windowed_test.go
+++ b/wail-app/internal/capture/windowed_test.go
@@ -1,0 +1,234 @@
+package capture
+
+import (
+	"testing"
+
+	"github.com/nicholasgasior/wail/wail-app/internal/interval"
+)
+
+// Windowed-mode tests use a tiny sample rate so intervals stay small:
+// 16 beats at 120 BPM = 8s; at 100 Hz that is 800 frames per interval.
+// With windowFrames=100 an interval is exactly 8 windows.
+const (
+	wsr     = 100
+	wframes = 100
+)
+
+func wcfg() interval.Config { return interval.Config{Bars: 4, Quantum: 4} }
+
+// beatAt converts a frame offset within interval 0 to a beat at 120 BPM /
+// wsr Hz: one beat = 0.5s = 50 frames.
+func beatAt(frameOff int) float64 { return float64(frameOff) / 50.0 }
+
+func collectWindows(rs ...[]Window) []Window {
+	var all []Window
+	for _, r := range rs {
+		all = append(all, r...)
+	}
+	return all
+}
+
+func TestWindowsEmitAsCoverageAdvances(t *testing.T) {
+	a := NewWindowed(wcfg(), 2, wsr, wframes)
+
+	// 60 frames from offset 0: no full window yet.
+	if w := a.AddWindows(beatAt(0), 120, fill(60, 2, 1), 60); len(w) != 0 {
+		t.Fatalf("expected no windows after 60/100 frames, got %d", len(w))
+	}
+	// 60 more (coverage 120): window 0 is complete.
+	w := a.AddWindows(beatAt(60), 120, fill(60, 2, 2), 60)
+	if len(w) != 1 {
+		t.Fatalf("expected exactly window 0, got %d windows", len(w))
+	}
+	if w[0].IntervalIndex != 0 || w[0].Number != 0 || w[0].IsFinal {
+		t.Fatalf("window 0 mislabeled: %+v", w[0])
+	}
+	if w[0].Total != 8 {
+		t.Fatalf("total windows = %d, want 8", w[0].Total)
+	}
+	if len(w[0].Samples) != wframes*2 {
+		t.Fatalf("window sample count = %d, want %d", len(w[0].Samples), wframes*2)
+	}
+	// Content: frames 0..59 value 1, frames 60..99 value 2.
+	if w[0].Samples[0] != 1 || w[0].Samples[59*2] != 1 || w[0].Samples[60*2] != 2 || w[0].Samples[99*2+1] != 2 {
+		t.Fatal("window 0 content does not match written buffers")
+	}
+}
+
+func TestGapWithinIntervalEmitsSilenceWindows(t *testing.T) {
+	a := NewWindowed(wcfg(), 1, wsr, wframes)
+
+	a.AddWindows(beatAt(0), 120, fill(100, 1, 5), 100) // window 0 ready
+	// Jump to offset 350 (gap 100..350 is silence). Coverage reaches 450:
+	// windows 1..3 become ready (1,2 all/partial silence, 3 holds data).
+	w := a.AddWindows(beatAt(350), 120, fill(100, 1, 6), 100)
+	if len(w) != 3 {
+		t.Fatalf("expected windows 1..3, got %d windows", len(w))
+	}
+	if w[0].Number != 1 || w[1].Number != 2 || w[2].Number != 3 {
+		t.Fatalf("window numbers = %d,%d,%d want 1,2,3", w[0].Number, w[1].Number, w[2].Number)
+	}
+	if w[0].Samples[0] != 0 || w[1].Samples[99] != 0 {
+		t.Fatal("gap windows should read as silence")
+	}
+	if w[2].Samples[50] != 6 {
+		t.Fatal("window 3 should hold the second buffer's samples")
+	}
+}
+
+func TestIntervalCloseFlushesZeroPaddedTailWithFinal(t *testing.T) {
+	a := NewWindowed(wcfg(), 1, wsr, wframes)
+
+	a.AddWindows(beatAt(0), 120, fill(200, 1, 3), 200) // windows 0,1 emitted
+	// Next buffer opens interval 1 → remaining windows 2..7 flush zero-padded,
+	// last one final; the new buffer (100 frames) completes interval 1 window 0.
+	w := a.AddWindows(16, 120, fill(100, 1, 9), 100)
+	if len(w) != 7 {
+		t.Fatalf("expected 6 tail windows + 1 new-interval window, got %d", len(w))
+	}
+	for i, win := range w[:6] {
+		if win.IntervalIndex != 0 || win.Number != 2+i {
+			t.Fatalf("tail window %d mislabeled: %+v", i, win)
+		}
+		if win.Samples[0] != 0 {
+			t.Fatal("tail windows must be silence")
+		}
+	}
+	last := w[5]
+	if !last.IsFinal || last.Number != 7 {
+		t.Fatalf("last tail window should be final #7, got %+v", last)
+	}
+	if w[6].IntervalIndex != 1 || w[6].Number != 0 || w[6].Samples[0] != 9 {
+		t.Fatalf("new interval window mislabeled: %+v", w[6])
+	}
+	// Only the very last window of an interval is final.
+	for _, win := range w[:5] {
+		if win.IsFinal {
+			t.Fatalf("non-last window marked final: %+v", win)
+		}
+	}
+}
+
+func TestExactCoverageEmitsFinalWithoutClose(t *testing.T) {
+	a := NewWindowed(wcfg(), 1, wsr, wframes)
+
+	var all []Window
+	for off := 0; off < 800; off += 100 {
+		all = collectWindows(all, a.AddWindows(beatAt(off), 120, fill(100, 1, 1), 100))
+	}
+	if len(all) != 8 {
+		t.Fatalf("expected all 8 windows once coverage is exact, got %d", len(all))
+	}
+	if !all[7].IsFinal {
+		t.Fatal("window 7 should be final as soon as it is fully covered")
+	}
+	// Closing the interval later must not re-emit anything.
+	w := a.AddWindows(16, 120, fill(10, 1, 2), 10)
+	if len(w) != 0 {
+		t.Fatalf("close after full emission should emit nothing, got %d windows", len(w))
+	}
+}
+
+func TestShortFinalWindowIsPadded(t *testing.T) {
+	// sr=90: 8s interval = 720 frames; windows of 100 → 8 windows, final holds
+	// 20 frames + 80 frames of padding.
+	a := NewWindowed(wcfg(), 1, 90, wframes)
+	// One beat = 45 frames at 90 Hz / 120 BPM.
+	var all []Window
+	all = collectWindows(all, a.AddWindows(0, 120, fill(720, 1, 4), 720))
+	if len(all) != 8 {
+		t.Fatalf("expected 8 windows for a 720-frame interval, got %d", len(all))
+	}
+	final := all[7]
+	if !final.IsFinal || final.Total != 8 {
+		t.Fatalf("final window mislabeled: %+v", final)
+	}
+	if len(final.Samples) != wframes {
+		t.Fatalf("final window must be padded to %d frames, got %d", wframes, len(final.Samples))
+	}
+	if final.Samples[19] != 4 || final.Samples[20] != 0 {
+		t.Fatal("final window should hold 20 data frames then silence padding")
+	}
+}
+
+func TestFlushWindowsEmitsRemainingTail(t *testing.T) {
+	a := NewWindowed(wcfg(), 1, wsr, wframes)
+	a.AddWindows(beatAt(0), 120, fill(150, 1, 2), 150) // window 0 emitted
+	w := a.FlushWindows()
+	if len(w) != 7 {
+		t.Fatalf("flush should emit windows 1..7, got %d", len(w))
+	}
+	if !w[6].IsFinal || w[6].Number != 7 {
+		t.Fatalf("flushed tail should end with final #7, got %+v", w[6])
+	}
+	if a.FlushWindows() != nil {
+		t.Fatal("second flush should be empty")
+	}
+}
+
+func TestBackfillBehindEmittedWindowIsDropped(t *testing.T) {
+	a := NewWindowed(wcfg(), 1, wsr, wframes)
+	w := a.AddWindows(beatAt(0), 120, fill(100, 1, 1), 100)
+	if len(w) != 1 {
+		t.Fatalf("window 0 should be emitted, got %d", len(w))
+	}
+	// A buffer entirely behind the emitted boundary cannot amend window 0.
+	if w := a.AddWindows(beatAt(10), 120, fill(50, 1, 9), 50); len(w) != 0 {
+		t.Fatal("backfill must not emit windows")
+	}
+	if a.DroppedBackfill() == 0 {
+		t.Fatal("backfill drop should be counted")
+	}
+}
+
+func TestLateIntervalBufferStillDropped(t *testing.T) {
+	a := NewWindowed(wcfg(), 1, wsr, wframes)
+	a.AddWindows(16, 120, fill(10, 1, 1), 10) // opens interval 1
+	if w := a.AddWindows(0, 120, fill(10, 1, 2), 10); len(w) != 0 {
+		t.Fatal("buffer for an already-passed interval must be dropped")
+	}
+	if a.DroppedLate() == 0 {
+		t.Fatal("late drop should be counted")
+	}
+}
+
+func TestStreamingMatchesBatchAssembly(t *testing.T) {
+	// The same buffer sequence through batch and windowed assemblers must
+	// yield identical interval PCM (windows concatenated == batch samples,
+	// modulo final-window padding).
+	batch := New(wcfg(), 2, wsr)
+	stream := NewWindowed(wcfg(), 2, wsr, wframes)
+
+	type buf struct {
+		off, n int
+		v      int16
+	}
+	bufs := []buf{{0, 130, 1}, {130, 70, 2}, {200, 250, 3}, {520, 200, 4}} // gap 450..520
+	var windows []Window
+	for _, b := range bufs {
+		batch.Add(beatAt(b.off), 120, fill(b.n, 2, b.v), b.n)
+		windows = collectWindows(windows, stream.AddWindows(beatAt(b.off), 120, fill(b.n, 2, b.v), b.n))
+	}
+	completed := batch.Add(16, 120, fill(10, 2, 0), 10) // close interval 0
+	windows = collectWindows(windows, stream.AddWindows(16, 120, fill(10, 2, 0), 10))
+
+	if completed == nil {
+		t.Fatal("batch assembler should complete interval 0")
+	}
+	var got []int16
+	for _, w := range windows {
+		if w.IntervalIndex != 0 {
+			continue
+		}
+		got = append(got, w.Samples...)
+	}
+	want := completed.Samples // 800 frames × 2ch; window concat is the same length here
+	if len(got) != len(want) {
+		t.Fatalf("streamed length %d != batch length %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sample %d differs: stream %d, batch %d", i, got[i], want[i])
+		}
+	}
+}

--- a/wail-app/interval_codec.go
+++ b/wail-app/interval_codec.go
@@ -51,6 +51,63 @@ func NewIntervalEncoder(channels, sampleRate, bitrateKbps int) (*IntervalEncoder
 	}, nil
 }
 
+// WindowMeta labels one 20ms window for WAIF encoding. FrameNumber is the
+// window's index within its interval; Seq is the running per-stream frame
+// sequence (WAN loss detection). The trailer fields (TotalFrames, BPM,
+// Quantum, Bars) are written only when IsFinal is set.
+type WindowMeta struct {
+	RoomIndex   int64
+	StreamID    uint16
+	FrameNumber uint32
+	Seq         uint32
+	IsFinal     bool
+	TotalFrames uint32
+	BPM         float64
+	Quantum     float64
+	Bars        uint32
+}
+
+// EncodeWindow Opus-encodes one 20ms window into one WAIF frame. A chunk
+// shorter than a full window is zero-padded; windows must be fed in order on
+// one encoder (Opus is stateful). This is the streaming unit: the capture path
+// calls it as each window fills, so frames leave in real time during the
+// interval instead of bursting at its boundary.
+func (e *IntervalEncoder) EncodeWindow(chunk []int16, m WindowMeta) ([]byte, error) {
+	frameLen := e.samplesPerFrame * e.channels
+	if len(chunk) < frameLen {
+		padded := e.zeroScratch()
+		copy(padded, chunk)
+		chunk = padded
+	} else if len(chunk) > frameLen {
+		chunk = chunk[:frameLen]
+	}
+
+	n, err := e.enc.Encode(chunk, e.opusBuf)
+	if err != nil {
+		return nil, err
+	}
+	opusData := make([]byte, n)
+	copy(opusData, e.opusBuf[:n])
+
+	f := &AudioFrame{
+		IntervalIndex: m.RoomIndex,
+		StreamID:      m.StreamID,
+		FrameNumber:   m.FrameNumber,
+		FrameSeq:      m.Seq,
+		Channels:      uint16(e.channels),
+		OpusData:      opusData,
+		IsFinal:       m.IsFinal,
+	}
+	if m.IsFinal {
+		f.SampleRate = uint32(e.sampleRate)
+		f.TotalFrames = m.TotalFrames
+		f.BPM = m.BPM
+		f.Quantum = m.Quantum
+		f.Bars = m.Bars
+	}
+	return EncodeAudioFrameWire(f), nil
+}
+
 // EncodeInterval splits interleaved interval PCM into 20ms Opus WAIF frames
 // labeled with the shared room interval index. seqStart is the running per-stream
 // frame sequence (for WAN loss detection); the returned nextSeq continues it. The
@@ -72,40 +129,28 @@ func (e *IntervalEncoder) EncodeInterval(pcm []int16, roomIndex int64, streamID 
 		start := i * frameLen
 		var chunk []int16
 		if start >= len(pcm) {
-			chunk = e.zeroScratch()
+			chunk = nil // EncodeWindow pads to a full frame of silence
 		} else if end := start + frameLen; end <= len(pcm) {
 			chunk = pcm[start:end]
 		} else {
-			// Short trailing chunk: pad with silence to a full Opus frame.
-			chunk = e.zeroScratch()
-			copy(chunk, pcm[start:])
+			chunk = pcm[start:]
 		}
 
-		n, err := e.enc.Encode(chunk, e.opusBuf)
+		wire, err := e.EncodeWindow(chunk, WindowMeta{
+			RoomIndex:   roomIndex,
+			StreamID:    streamID,
+			FrameNumber: uint32(i),
+			Seq:         seq,
+			IsFinal:     i == numFrames-1,
+			TotalFrames: uint32(numFrames),
+			BPM:         bpm,
+			Quantum:     quantum,
+			Bars:        bars,
+		})
 		if err != nil {
 			return frames, seq, err
 		}
-		opusData := make([]byte, n)
-		copy(opusData, e.opusBuf[:n])
-
-		isFinal := i == numFrames-1
-		f := &AudioFrame{
-			IntervalIndex: roomIndex,
-			StreamID:      streamID,
-			FrameNumber:   uint32(i),
-			FrameSeq:      seq,
-			Channels:      uint16(e.channels),
-			OpusData:      opusData,
-			IsFinal:       isFinal,
-		}
-		if isFinal {
-			f.SampleRate = uint32(e.sampleRate)
-			f.TotalFrames = uint32(numFrames)
-			f.BPM = bpm
-			f.Quantum = quantum
-			f.Bars = bars
-		}
-		frames = append(frames, EncodeAudioFrameWire(f))
+		frames = append(frames, wire)
 		seq++
 	}
 	return frames, seq, nil

--- a/wail-app/interval_codec_streaming_test.go
+++ b/wail-app/interval_codec_streaming_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+// TestEncodeWindowMatchesEncodeInterval feeds the same interval PCM through
+// EncodeInterval (batch) and a window-at-a-time EncodeWindow sequence with
+// matching metadata; the WAIF frames must be byte-identical, proving the
+// streaming path changes delivery timing only, never the bitstream.
+func TestEncodeWindowMatchesEncodeInterval(t *testing.T) {
+	const (
+		channels = 2
+		sr       = 48000
+		bpm      = 120.0
+		quantum  = 4.0
+		bars     = uint32(4)
+		roomIdx  = int64(7)
+		streamID = uint16(3)
+		seq0     = uint32(1000)
+	)
+	spf := samplesPerWaifFrame(sr)
+
+	// 5.5 windows of a sine so the final window exercises padding.
+	pcm := make([]int16, spf*channels*5+spf*channels/2)
+	for i := 0; i < len(pcm); i += channels {
+		v := int16(8000 * math.Sin(2*math.Pi*440*float64(i/channels)/float64(sr)))
+		for c := 0; c < channels; c++ {
+			pcm[i+c] = v
+		}
+	}
+
+	batchEnc, err := NewIntervalEncoder(channels, sr, 128)
+	if err != nil {
+		t.Fatal(err)
+	}
+	streamEnc, err := NewIntervalEncoder(channels, sr, 128)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	batch, nextSeq, err := batchEnc.EncodeInterval(pcm, roomIdx, streamID, seq0, bpm, quantum, bars)
+	if err != nil {
+		t.Fatal(err)
+	}
+	total := uint32(len(batch))
+
+	var streamed [][]byte
+	seq := seq0
+	frameLen := spf * channels
+	for i := uint32(0); i < total; i++ {
+		start := int(i) * frameLen
+		end := start + frameLen
+		var chunk []int16
+		if end <= len(pcm) {
+			chunk = pcm[start:end]
+		} else {
+			chunk = pcm[start:] // short final chunk: EncodeWindow must pad
+		}
+		f, err := streamEnc.EncodeWindow(chunk, WindowMeta{
+			RoomIndex:   roomIdx,
+			StreamID:    streamID,
+			FrameNumber: i,
+			Seq:         seq,
+			IsFinal:     i == total-1,
+			TotalFrames: total,
+			BPM:         bpm,
+			Quantum:     quantum,
+			Bars:        bars,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		streamed = append(streamed, f)
+		seq++
+	}
+
+	if seq != nextSeq {
+		t.Fatalf("sequence mismatch: streaming ended at %d, batch at %d", seq, nextSeq)
+	}
+	if len(streamed) != len(batch) {
+		t.Fatalf("frame count mismatch: streaming %d, batch %d", len(streamed), len(batch))
+	}
+	for i := range batch {
+		if !bytes.Equal(streamed[i], batch[i]) {
+			t.Fatalf("frame %d differs between streaming and batch encode", i)
+		}
+	}
+}
+
+// TestEncodeWindowFinalCarriesTrailer decodes the wire bytes of a final window
+// and checks the interval trailer fields round-trip.
+func TestEncodeWindowFinalCarriesTrailer(t *testing.T) {
+	enc, err := NewIntervalEncoder(1, 48000, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chunk := make([]int16, samplesPerWaifFrame(48000))
+	wire, err := enc.EncodeWindow(chunk, WindowMeta{
+		RoomIndex: 3, StreamID: 9, FrameNumber: 41, Seq: 500,
+		IsFinal: true, TotalFrames: 42, BPM: 97.5, Quantum: 4, Bars: 8,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := DecodeAudioFrameWire(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !f.IsFinal || f.TotalFrames != 42 || f.BPM != 97.5 || f.Bars != 8 || f.SampleRate != 48000 {
+		t.Fatalf("trailer did not round-trip: %+v", f)
+	}
+	if f.IntervalIndex != 3 || f.StreamID != 9 || f.FrameNumber != 41 || f.FrameSeq != 500 {
+		t.Fatalf("header did not round-trip: %+v", f)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #353, replacing its delivery-side patch with the right architecture: **capture streams WAIF frames in real time during the interval**, the way the old plugins (and NINJAM) did.

Previously the engine encoded a whole interval at its boundary and sent frames afterwards. With the default offset D=1 the receiver starts *playing* an interval at the same synced boundary at which the sender starts *transmitting* it, so delivery raced the playhead — the first frames of every interval arrived network-latency late and relied on the playout live-append path.

The interval is a playout concept, not a transmission one, and the relay is TCP (reliable, in-order) — there is no reason to withhold frames until capture completes. Now:

- **`internal/capture`**: windowed streaming mode (`NewWindowed` / `AddWindows` / `FlushWindows`). As coverage passes each 20ms window, the window is emitted for immediate encode+send. When a buffer opens the next interval, the previous interval's remaining windows flush zero-padded (capture gaps read as silence), ending with the final window. Emitted windows are immutable — backfill behind the emitted boundary is trimmed and counted (`DroppedBackfill`).
- **`interval_codec.go`**: `EncodeWindow` encodes one window into one WAIF frame (interval trailer on the final frame). `EncodeInterval` now delegates to it — and stays for the test-tone/WAV senders.
- **`audio_engine_real.go`**: the capture drain emits windows as they fill, with per-window room labeling. Frames now leave at ~50/s steady during the interval and arrive roughly a **full interval** before the receiver's N+D boundary needs them — the head-of-interval live-append case disappears in normal operation.
- **`internal/pace`** stays wired as defense in depth: single real-time frames pass through untouched; only abnormal batches (interval-close flush after a capture stall) get spaced out instead of bursting.

Wire format unchanged — fully compatible with existing receivers.

Docs: `docs/architecture.md`, `CLAUDE.md` capture flow, and `tradeoffs.md` (pacing entry marked superseded; new immutable-windows entry).

## Key invariants, tested

- **Streaming ≡ batch**: the same buffer sequence through the windowed and batch assemblers yields identical interval PCM (`TestStreamingMatchesBatchAssembly`).
- **Bitstream identical**: a window-at-a-time `EncodeWindow` sequence produces byte-identical WAIF frames to `EncodeInterval` on the same PCM (`TestEncodeWindowMatchesEncodeInterval`) — this change moves *timing only*, never bytes.
- Window readiness/ordering, zero-padded tail flush with final marker, short-final-window padding, gap-as-silence windows, backfill immutability, late-interval drops — all unit-tested in `internal/capture/windowed_test.go`.

## Testing

- `wail-app`: `go test ./...` green (cgo) and with `-tags linkstub`; `-race` on `internal/capture` + `internal/pace`
- `signaling-server`: green
- `./scripts/tier2-e2e.sh`: **PASS** (lossless, in-order sweep, `maxLost=0`)
- Caveat, stated plainly: tier2's send leg uses the WAV sender, which bypasses the capture assembler — the Link-Audio-source capture leg is covered by the unit equivalence tests and needs a live DAW pass to observe end-to-end (same standing caveat as before this PR; the next Bitwig/Void session will exercise it).

---
Artisanal, small-batch frames, delivered fresh every 20 milliseconds. Claude Code, farm to table.
