### PR TITLE
docs: record that wail-signal was destroyed (pre-3.2.0 clients must upgrade)

### DIFF
--- a/signaling-server/fly.toml
+++ b/signaling-server/fly.toml
@@ -1,8 +1,8 @@
 # fly.toml app configuration for the WAIL relay.
 #
-# Renamed wail-signal → wail-relay (2026-07-20). Fly can't rename apps in
-# place, so wail-relay is a separate app; wail-signal stays deployed for
-# clients released before the switch. Deploy relay changes to wail-relay only.
+# Renamed wail-signal → wail-relay (2026-07-20; fly can't rename apps in
+# place). The old wail-signal app was destroyed the same day — clients older
+# than 3.2.0 must upgrade to connect.
 # Run exactly ONE machine: rooms live in process memory, so a second machine
 # silently splits rooms (fly deploy's --ha default creates two — scale back).
 #

--- a/wail-app/app.go
+++ b/wail-app/app.go
@@ -16,7 +16,7 @@ import (
 // ws://localhost:8899) to point at a local or self-hosted relay — the Tier 2
 // E2E harness (scripts/tier2-e2e.sh) uses this to run against a local server.
 // wail-relay.fly.dev replaced wail-signal.fly.dev (fly apps can't be renamed);
-// the old app stays up for clients released before the switch.
+// the old app was destroyed 2026-07-20 — clients older than 3.2.0 must upgrade.
 var signalingURL = func() string {
 	if u := os.Getenv("WAIL_SIGNAL_URL"); u != "" {
 		return u


### PR DESCRIPTION
The legacy `wail-signal` fly app was destroyed on 2026-07-20 (owner's call — everyone upgrades to 3.2.0). Two comments still claimed it stays deployed for old clients; now they record reality.

Claude Code: present but not responsible