### PR TITLE
fix: prevent macOS App Nap throttling; make the emit cushion tunable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,7 @@ Releases are fully automated — no manual `knope` commands needed:
 - **Change Link polling rate**: `linkPollInterval` in `wail-app/link_types.go`
 - **Change Opus bitrate**: `engineBitrateKbps` in `wail-app/audio_engine_real.go` (passed to `NewIntervalEncoder` in `interval_codec.go`)
 - **Change the interval offset D**: `WAIL_INTERVAL_OFFSET` env var (default 1), read in `wail-app/session.go` and applied via `playout.New` in `audio_engine_real.go`
+- **Change the emit cushion**: `WAIL_EMIT_CUSHION_MS` env var (default 80, clamped 10–500), read in `wail-app/audio_engine_real.go`; it adds directly to a Link Audio subscriber's reported buffering
 - **Modify wire format**: `wail-app/wire.go` (bump the flags/format)
 
 

--- a/wail-app/appnap_darwin.go
+++ b/wail-app/appnap_darwin.go
@@ -1,0 +1,35 @@
+//go:build darwin
+
+package main
+
+/*
+#cgo CFLAGS: -x objective-c -fobjc-arc
+#cgo LDFLAGS: -framework Foundation
+#import <Foundation/Foundation.h>
+
+static id wailActivityToken = nil;
+
+static void wail_disable_app_nap(void) {
+	@autoreleasepool {
+		if (wailActivityToken != nil) {
+			return;
+		}
+		wailActivityToken = [[NSProcessInfo processInfo]
+			beginActivityWithOptions:(NSActivityUserInitiated | NSActivityLatencyCritical)
+			                  reason:@"WAIL relays realtime audio"];
+	}
+}
+*/
+import "C"
+
+import "log"
+
+// disableAppNap pins the process out of macOS App Nap / timer coalescing for
+// the app's lifetime. WAIL opens no audio device, so once its window is
+// hidden macOS throttles the whole process — the 5ms emit ticker and the Link
+// Audio SDK's drain thread stall past the cushion, an audible dropout every
+// time the DAW takes focus.
+func disableAppNap() {
+	C.wail_disable_app_nap()
+	log.Println("[app] App Nap disabled (latency-critical activity)")
+}

--- a/wail-app/appnap_other.go
+++ b/wail-app/appnap_other.go
@@ -1,0 +1,6 @@
+//go:build !darwin
+
+package main
+
+// disableAppNap is a no-op off macOS (App Nap is a macOS mechanism).
+func disableAppNap() {}

--- a/wail-app/audio_engine_real.go
+++ b/wail-app/audio_engine_real.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -47,8 +48,9 @@ const (
 	// stall tolerance for the emit loop. Receivers tolerate near-future stamps
 	// (the reference renderer stalls on far-future buffers and plays ~4 beats
 	// behind; Live's policy is unverified, so stay well under 100ms ≈ "now").
-	emitCushionMs     = 80
-	emitCushionFrames = engineInternalRate * emitCushionMs / 1000
+	// The cushion adds directly to a subscriber's reported buffering (stamps
+	// lead "now" by up to this much); WAIL_EMIT_CUSHION_MS overrides it.
+	emitCushionMs = 80
 	// plcMaxFramesPerGap caps Opus packet-loss concealment per seq gap (120ms):
 	// libopus fades PLC to silence past ~100ms; a deeper gap's tail stays silent.
 	plcMaxFramesPerGap = 6
@@ -95,6 +97,25 @@ type linkAudioEngine struct {
 	emit         map[affinity.Key]*emitStream
 	own          *affinity.OwnChannels // our published sinks, for discovery exclusion
 	nextStreamID uint16
+
+	cushionFrames int // per-sink feed-ahead (emitCushionMs or WAIL_EMIT_CUSHION_MS)
+}
+
+// engineCushionFrames resolves the emit cushion: emitCushionMs unless
+// WAIL_EMIT_CUSHION_MS overrides it (clamped to 10..500ms — below one tick's
+// jitter the feeder can't keep up; far above, receivers may drop far-future
+// stamps).
+func engineCushionFrames() int {
+	ms := emitCushionMs
+	if v := os.Getenv("WAIL_EMIT_CUSHION_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			ms = min(max(n, 10), 500)
+			log.Printf("[audio] emit cushion override: %dms (WAIL_EMIT_CUSHION_MS)", ms)
+		} else {
+			log.Printf("[audio] warn: bad WAIL_EMIT_CUSHION_MS %q: %v", v, err)
+		}
+	}
+	return engineInternalRate * ms / 1000
 }
 
 type captureChannel struct {
@@ -181,6 +202,8 @@ func newAudioEngine(lb *LinkBridge, peerName string, send func(waif []byte), off
 		capture:  make(map[string]*captureChannel),
 		emit:     make(map[affinity.Key]*emitStream),
 		own:      affinity.NewOwnChannels(),
+
+		cushionFrames: engineCushionFrames(),
 	}
 }
 
@@ -606,7 +629,7 @@ func (e *linkAudioEngine) HandleRemoteAudio(fromIdentity, displayName, streamNam
 			reasm:           emit.New(channels, samplesPerWaifFrame(engineInternalRate)),
 			sched:           playout.New(e.offsetD),
 			sink:            e.link.NewSink(sinkName, engineInternalRate*2),
-			feeder:          emit.NewFeeder(emitCushionFrames, emitChunkFrames),
+			feeder:          emit.NewFeeder(e.cushionFrames, emitChunkFrames),
 			lastDisplayName: displayName,
 			lastStreamName:  streamName,
 		}

--- a/wail-app/main.go
+++ b/wail-app/main.go
@@ -40,6 +40,7 @@ func main() {
 	defer FlushHoneybadger()
 
 	log.Println("WAIL - WebSocket Audio Interchange for Link (Go/Wails)")
+	disableAppNap()
 
 	appBackend := NewApp(*instance)
 


### PR DESCRIPTION
## App Nap dropouts

WAIL opens no audio device, so as soon as its window is hidden macOS treats it as an idle background app and throttles the whole process — the 5ms emit ticker **and** the Link Audio SDK's internal 1ms drain thread stall past the cushion. Observed live: an audible dropout on every switch between the DAW and other apps, with paired health-counter events (`sink underrun` from the stalled emit loop + `sink write rejected` from the SDK's backed-up 128-buffer queue — the two firing together is the App Nap signature; Go GC was ruled out, its pauses are sub-ms against an 80ms cushion).

Fix: a latency-critical `NSProcessInfo` activity (`NSActivityUserInitiated | NSActivityLatencyCritical`) pins the process for its lifetime, the standard mechanism for audio-adjacent apps. Darwin-only (`appnap_darwin.go`), no-op elsewhere.

## Tunable emit cushion

The emit cushion stamps audio ahead of "now" by its depth, so it **adds directly to a Link Audio subscriber's reported buffering** — Live shows its configured Link Latency plus our cushion, at any setting (confirmed live at 100ms and 383ms). `WAIL_EMIT_CUSHION_MS` (default 80, clamped 10–500) makes it tunable; with App Nap gone, the main reason for a fat cushion goes with it, so a lower default is a likely follow-up once field-validated.

Notes:
- Independent of #363 (based on `main`), but touches the same constants block in `audio_engine_real.go` — whichever merges second needs a trivial rebase.
- All suites pass on this branch: cgo, `-tags linkstub`.

🤖 Claude Code, in an ongoing dispute with macOS power management