### PR TITLE
fix: stop logging the benign "intervals released before their tail arrived" line

### DIFF
--- a/wail-app/session.go
+++ b/wail-app/session.go
@@ -957,7 +957,9 @@ func sessionLoop(
 				delta(logWarn, "sink write rejected mid-stream (chunk lost — audible hole for listeners)", lastHealth.EmitSinkWriteRejected, health.EmitSinkWriteRejected)
 				delta(logWarn, "frames never arrived by playout retirement (played as silence)", lastHealth.EmitFramesMissingAtPlay, health.EmitFramesMissingAtPlay)
 				delta(logInfo, "frames concealed by Opus PLC (masked loss)", lastHealth.EmitFramesConcealed, health.EmitFramesConcealed)
-				delta(logInfo, "intervals released before their streaming tail arrived (benign)", lastHealth.EmitIntervalsIncomplete, health.EmitIntervalsIncomplete)
+				// EmitIntervalsIncomplete is deliberately not logged: it fires once
+				// per interval in normal operation and never aligned with an audible
+				// glitch in the field. Still counted and shipped in the health snapshot.
 				delta(logWarn, "WAIF wire decode failures", lastHealth.WireDecodeFailures, health.WireDecodeFailures)
 				delta(logWarn, "Opus decode failures", lastHealth.OpusDecodeFailures, health.OpusDecodeFailures)
 				lastHealth = health


### PR DESCRIPTION
## What

Removes the per-tick log emission for `EmitIntervalsIncomplete` — the `[audio] intervals released before their streaming tail arrived (benign) +N (total M)` line.

## Why

It fires roughly once per interval in normal operation (an interval reaches its playout boundary just before its final streaming frame lands — expected with real-time streaming capture) and, across extended field sessions, **never once aligned with an audible glitch**. It was pure log/GUI noise that actively distracted from real signals like `sink underrun`.

The counter is **not** removed — it's still incremented and shipped in the `Health()` snapshot with each network/metrics event, so it remains available for telemetry. Only the log line is gone. A comment at the removal site records why, so it doesn't get "helpfully" re-added.

## Changes

- `wail-app/session.go` — drop the `delta(logInfo, "intervals released before their streaming tail arrived (benign)", …)` call; leave the counter in the health snapshot.

## Tests

`wail-app` cgo build + tests pass (forced `-count=1`), and the `-tags linkstub` build is clean. No behavior changes beyond logging, so no test changes.

Claude Code, now with 100% less benign chatter