### PR TITLE
fix: prefix WAIL's Link Audio peer name with "WAIL-"

### DIFF
--- a/wail-app/session.go
+++ b/wail-app/session.go
@@ -146,7 +146,12 @@ func sessionLoop(
 		engineFramesSent.Add(1)
 		mesh.BroadcastAudio(waif)
 	}
-	audioEngine := newAudioEngine(link, displayName, engineSend, offsetD)
+	// Advertise as a Link Audio peer under a "WAIL-" prefix so WAIL reads
+	// clearly in a DAW's peer list and stays distinct from native publishers
+	// that default to the machine name. This is also the own-channel filter
+	// key (audio_engine_real.go), so the engine must use the prefixed name
+	// end to end; the room display name is unaffected.
+	audioEngine := newAudioEngine(link, "WAIL-"+displayName, engineSend, offsetD)
 	if err := audioEngine.Start(); err != nil {
 		logWarn("Link Audio engine failed to start: %v", err)
 	}


### PR DESCRIPTION
## What

WAIL now advertises itself as a Link Audio peer as **`WAIL-<display name>`** (e.g. `WAIL-Quasor`) instead of the bare display name.

## Why

In a DAW's Link Audio peer list, WAIL's bare display name was indistinguishable from the DAW's own entry and from native publishers — notably the Bitwig `VoidLinkAudioSend` plugin, which defaults its peer name to the machine name "Quasor" and collided with the WAIL display name (the ambiguity that drove the own-channel-filter work). The prefix makes it obvious at a glance which peers are WAIL, and as a bonus removes that name collision so the peer-name signal is unambiguous again.

## How

The name is prefixed at the **single point** where the audio engine is constructed (`session.go`). That value is used both for `SetPeerName` (what the DAW sees) *and* as the own-channel filter key (`c.PeerName == e.peerName`, to avoid WAIL capturing its own republished channels in a feedback loop) — so prefixing at construction keeps the advertised name and the filter key identical end to end. The room display name, sync identity, and how remote peers label our republished channels (carried separately via the StreamNames sync) are all unaffected.

## Scope

- `wail-app/session.go` — one-line change + comment. No wire-format, protocol, or API change.
- Existing `newAudioEngine` unit tests pass unchanged (they pass explicit peer names and bypass the session layer).

## Tests

`wail-app` cgo build + tests pass (`-count=1`); `-tags linkstub` build clean.

Claude Code, wearing a name tag so you know who to blame