### PR TITLE
feat: user-settable Link Audio Name (defaults to WAIL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ WAIL has two components that work together:
 ## Settings
 
 - **Display name** — Shown to other peers in the session.
+- **Link Audio Name** — The peer name WAIL advertises on Link Audio, so its published channels are easy to spot in your DAW's peer list. Defaults to `WAIL`.
 - **Save debug log locally** — Writes structured logs to a rotating file in the app data directory. Useful for diagnosing connection issues.
 - **Peer log streaming** — When enabled, your app's INFO-level logs are broadcast to all other peers in the session via the signaling server, and their logs are shown in your session log panel with a peer name prefix. Useful for collaborative debugging. Both sending and receiving are controlled by this single toggle.
 - **Remember settings** — Persists room name, password, and display name in localStorage.

--- a/wail-app/app.go
+++ b/wail-app/app.go
@@ -108,6 +108,7 @@ func (a *App) JoinRoom(
 	recordingStems *bool,
 	recordingRetentionDays *uint32,
 	streamCount *uint16,
+	linkAudioName *string,
 ) (*JoinResult, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -131,6 +132,13 @@ func (a *App) JoinRoom(
 	actualStreamCount := uint16(1)
 	if streamCount != nil {
 		actualStreamCount = *streamCount
+	}
+	// The Link Audio peer name is user-settable; empty/unset falls back to "WAIL".
+	actualLinkAudioName := "WAIL"
+	if linkAudioName != nil {
+		if trimmed := strings.TrimSpace(*linkAudioName); trimmed != "" {
+			actualLinkAudioName = trimmed
+		}
 	}
 
 	var recording *RecordingConfig
@@ -157,16 +165,17 @@ func (a *App) JoinRoom(
 	}
 
 	config := SessionConfig{
-		Server:      signalingURL,
-		Room:        room,
-		Password:    password,
-		DisplayName: displayName,
-		Identity:    a.identity,
-		BPM:         actualBPM,
-		Bars:        actualBars,
-		Quantum:     actualQuantum,
-		Recording:   recording,
-		StreamCount: actualStreamCount,
+		Server:        signalingURL,
+		Room:          room,
+		Password:      password,
+		DisplayName:   displayName,
+		LinkAudioName: actualLinkAudioName,
+		Identity:      a.identity,
+		BPM:           actualBPM,
+		Bars:          actualBars,
+		Quantum:       actualQuantum,
+		Recording:     recording,
+		StreamCount:   actualStreamCount,
 	}
 
 	handle, err := SpawnSession(a.emitter, config)

--- a/wail-app/frontend/index.html
+++ b/wail-app/frontend/index.html
@@ -244,6 +244,9 @@
         <label for="settings-display-name">Display Name</label>
         <input type="text" id="settings-display-name" placeholder="Your name" required autocomplete="off">
 
+        <label for="settings-link-audio-name">Link Audio Name</label>
+        <input type="text" id="settings-link-audio-name" placeholder="WAIL" autocomplete="off">
+
         <div class="remember-row">
           <input type="checkbox" id="settings-telemetry" checked>
           <label for="settings-telemetry" class="remember-label">Save debug log locally</label>

--- a/wail-app/frontend/main.js
+++ b/wail-app/frontend/main.js
@@ -18,6 +18,7 @@ const settingsPanel = document.getElementById('settings-panel');
 const settingsCloseBtn = document.getElementById('settings-close-btn');
 const settingsForm = document.getElementById('settings-form');
 const settingsDisplayNameInput = document.getElementById('settings-display-name');
+const settingsLinkAudioNameInput = document.getElementById('settings-link-audio-name');
 const settingsTelemetryCheckbox = document.getElementById('settings-telemetry');
 const settingsLogSharingCheckbox = document.getElementById('settings-log-sharing');
 const settingsRememberCheckbox = document.getElementById('settings-remember');
@@ -246,6 +247,8 @@ let lastNetworkPeers = null;
 
 // --- Display Name Storage ---
 const DISPLAY_NAME_KEY = 'wail-display-name';
+const LINK_AUDIO_NAME_KEY = 'wail-link-audio-name';
+const DEFAULT_LINK_AUDIO_NAME = 'WAIL';
 const TELEMETRY_KEY = 'wail-telemetry';
 const LOG_SHARING_KEY = 'wail-log-sharing';
 const REMEMBER_KEY = 'wail-remember';
@@ -256,6 +259,14 @@ function getDisplayName() {
 
 function saveDisplayName(name) {
   localStorage.setItem(DISPLAY_NAME_KEY, name);
+}
+
+function getLinkAudioName() {
+  return localStorage.getItem(LINK_AUDIO_NAME_KEY) || DEFAULT_LINK_AUDIO_NAME;
+}
+
+function saveLinkAudioName(name) {
+  localStorage.setItem(LINK_AUDIO_NAME_KEY, name || DEFAULT_LINK_AUDIO_NAME);
 }
 
 function getTelemetryEnabled() {
@@ -436,6 +447,7 @@ async function joinPublicRoom(room) {
     room: room,
     password: null,
     displayName: getDisplayName(),
+    linkAudioName: getLinkAudioName(),
     bpm: 120.0,
     bars: parseInt(document.getElementById('bars').value),
     quantum: parseFloat(document.getElementById('quantum').value),
@@ -484,6 +496,7 @@ invoke('get_default_recording_dir').then(dir => {
 // --- Settings Panel ---
 function openSettings() {
   settingsDisplayNameInput.value = getDisplayName();
+  settingsLinkAudioNameInput.value = getLinkAudioName();
   settingsTelemetryCheckbox.checked = getTelemetryEnabled();
   settingsLogSharingCheckbox.checked = getLogSharingEnabled();
   settingsRememberCheckbox.checked = getRememberEnabled();
@@ -509,6 +522,8 @@ settingsForm.addEventListener('submit', (e) => {
   if (name) {
     saveDisplayName(name);
   }
+  // Link Audio name: blank falls back to the default.
+  saveLinkAudioName(settingsLinkAudioNameInput.value.trim());
   // Save telemetry setting
   const telemetryEnabled = settingsTelemetryCheckbox.checked;
   saveTelemetryEnabled(telemetryEnabled);
@@ -621,6 +636,7 @@ joinForm.addEventListener('submit', async (e) => {
     room: document.getElementById('room').value,
     password: document.getElementById('password').value || null,
     displayName: getDisplayName(),
+    linkAudioName: getLinkAudioName(),
     bpm: 120.0,
     bars: parseInt(document.getElementById('bars').value),
     quantum: parseFloat(document.getElementById('quantum').value),

--- a/wail-app/frontend/wails-adapter.js
+++ b/wail-app/frontend/wails-adapter.js
@@ -54,7 +54,7 @@
     const argOrder = {
         'join_room': ['room', 'password', 'displayName', 'bpm', 'bars', 'quantum',
                        'recordingEnabled', 'recordingDirectory', 'recordingStems',
-                       'recordingRetentionDays', 'streamCount'],
+                       'recordingRetentionDays', 'streamCount', 'linkAudioName'],
         'change_bpm': ['bpm'],
         'send_chat': ['text'],
         'set_test_tone': ['streamIndex'],

--- a/wail-app/main.go
+++ b/wail-app/main.go
@@ -104,7 +104,7 @@ func main() {
 			pw = password
 		}
 		go func() {
-			result, err := appBackend.JoinRoom(*room, pw, displayName, &bpm, nil, nil, nil, nil, nil, nil, nil)
+			result, err := appBackend.JoinRoom(*room, pw, displayName, &bpm, nil, nil, nil, nil, nil, nil, nil, nil)
 			if err != nil {
 				log.Printf("Failed to auto-join room: %v", err)
 				return
@@ -139,7 +139,7 @@ func runHeadless(app *App, room, password string, bpm float64, name, wavFile str
 
 	log.Printf("Headless mode: joining room %q as %q at %.0f BPM", room, displayName, bpm)
 
-	result, err := app.JoinRoom(room, pw, displayName, &bpm, nil, nil, nil, nil, nil, nil, nil)
+	result, err := app.JoinRoom(room, pw, displayName, &bpm, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		log.Fatalf("Failed to join room: %v", err)
 	}

--- a/wail-app/session.go
+++ b/wail-app/session.go
@@ -24,12 +24,15 @@ type SessionConfig struct {
 	Room        string
 	Password    *string
 	DisplayName string
-	Identity    string
-	BPM         float64
-	Bars        uint32
-	Quantum     float64
-	Recording   *RecordingConfig
-	StreamCount uint16
+	// LinkAudioName is the peer name WAIL advertises to Link Audio (and the
+	// own-channel filter key); defaults to "WAIL" upstream in JoinRoom.
+	LinkAudioName string
+	Identity      string
+	BPM           float64
+	Bars          uint32
+	Quantum       float64
+	Recording     *RecordingConfig
+	StreamCount   uint16
 }
 
 // SessionCommand represents commands from the UI to the session.
@@ -146,12 +149,11 @@ func sessionLoop(
 		engineFramesSent.Add(1)
 		mesh.BroadcastAudio(waif)
 	}
-	// Advertise as a Link Audio peer under a "WAIL-" prefix so WAIL reads
-	// clearly in a DAW's peer list and stays distinct from native publishers
-	// that default to the machine name. This is also the own-channel filter
-	// key (audio_engine_real.go), so the engine must use the prefixed name
-	// end to end; the room display name is unaffected.
-	audioEngine := newAudioEngine(link, "WAIL-"+displayName, engineSend, offsetD)
+	// Advertise the user's Link Audio name (defaults to "WAIL") so WAIL reads
+	// clearly in a DAW's peer list. This is also the own-channel filter key
+	// (audio_engine_real.go), so the engine uses it end to end; it is separate
+	// from the room display name.
+	audioEngine := newAudioEngine(link, config.LinkAudioName, engineSend, offsetD)
 	if err := audioEngine.Start(); err != nil {
 		logWarn("Link Audio engine failed to start: %v", err)
 	}


### PR DESCRIPTION
## What

Adds a dedicated **Link Audio Name** field in Settings, right below Display Name. It's the name WAIL advertises to Link Audio (so its published channels are easy to pick out in a DAW's peer list), and it **defaults to `WAIL`** when left blank.

This replaces the previous hardcoded `WAIL-<display name>` scheme (#370) with something the user controls directly and that reads cleanly as just `WAIL` out of the box.

## Why

The `WAIL-<display name>` prefix was a quick way to make WAIL stand out in Ableton Live's peer list, but it coupled the Link Audio identity to the room display name and produced noisy names like `WAIL-andrew`. A plain, user-editable field defaulting to `WAIL` is clearer.

## Details

- The Link Audio name is also the **own-channel filter key** (so the engine doesn't recapture its own republished audio). It's threaded through end to end: `JoinRoom` → `SessionConfig.LinkAudioName` → `newAudioEngine`. Empty/unset falls back to `WAIL` in `JoinRoom`, so headless/auto-join paths keep working.
- Stored in `localStorage` under its own key (`wail-link-audio-name`), same as Display Name — saved on the Settings form submit.
- README settings list updated.

## Testing

- `go build ./...` (cgo) — clean
- `go test ./...` — all pass
- `go build -tags linkstub -o /dev/null ./...` + `go vet` — clean

🎛️ Claude Code fiddled with the knobs; supervision was minimal