### PR TITLE
feat: Peers tab — tree of peers with their sent channels

### DIFF
--- a/wail-app/events.go
+++ b/wail-app/events.go
@@ -46,38 +46,39 @@ type LocalSendInfo struct {
 }
 
 type SlotInfo struct {
-	Slot         uint32  `json:"slot"`
-	ShortID      string  `json:"short_id"`
-	ClientID     string  `json:"client_id"`
-	ChannelIndex uint16  `json:"channel_index"`
-	DisplayName  *string `json:"display_name,omitempty"`
-	Status       *string `json:"status,omitempty"`
+	Slot         uint32   `json:"slot"`
+	ShortID      string   `json:"short_id"`
+	ClientID     string   `json:"client_id"`
+	PeerID       string   `json:"peer_id"` // relay peer id; groups a slot's channel under its peer (empty if disconnected)
+	ChannelIndex uint16   `json:"channel_index"`
+	DisplayName  *string  `json:"display_name,omitempty"`
+	Status       *string  `json:"status,omitempty"`
 	RTTMs        *float64 `json:"rtt_ms,omitempty"`
-	IsSending    bool    `json:"is_sending"`
-	IsReceiving  bool    `json:"is_receiving"`
-	StreamName   *string `json:"stream_name,omitempty"`
+	IsSending    bool     `json:"is_sending"`
+	IsReceiving  bool     `json:"is_receiving"`
+	StreamName   *string  `json:"stream_name,omitempty"`
 }
 
 type StatusUpdate struct {
-	BPM               float64        `json:"bpm"`
-	Beat              float64        `json:"beat"`
-	Phase             float64        `json:"phase"`
-	LinkPeers         uint64         `json:"link_peers"`
-	Peers             []PeerInfo     `json:"peers"`
-	Slots             []SlotInfo     `json:"slots"`
-	LocalSends        []LocalSendInfo `json:"local_sends"`
-	IntervalBars      uint32         `json:"interval_bars"`
-	AudioSent         uint64         `json:"audio_sent"`
-	AudioRecv         uint64         `json:"audio_recv"`
-	AudioBytesSent    uint64         `json:"audio_bytes_sent"`
-	AudioBytesRecv    uint64         `json:"audio_bytes_recv"`
-	AudioDCOpen       bool           `json:"audio_dc_open"`
-	PluginConnected   bool           `json:"plugin_connected"`
-	Recording         bool           `json:"recording"`
-	RecordingSizeBytes uint64        `json:"recording_size_bytes"`
-	TestToneStream    *uint16        `json:"test_tone_stream,omitempty"`
+	BPM                float64         `json:"bpm"`
+	Beat               float64         `json:"beat"`
+	Phase              float64         `json:"phase"`
+	LinkPeers          uint64          `json:"link_peers"`
+	Peers              []PeerInfo      `json:"peers"`
+	Slots              []SlotInfo      `json:"slots"`
+	LocalSends         []LocalSendInfo `json:"local_sends"`
+	IntervalBars       uint32          `json:"interval_bars"`
+	AudioSent          uint64          `json:"audio_sent"`
+	AudioRecv          uint64          `json:"audio_recv"`
+	AudioBytesSent     uint64          `json:"audio_bytes_sent"`
+	AudioBytesRecv     uint64          `json:"audio_bytes_recv"`
+	AudioDCOpen        bool            `json:"audio_dc_open"`
+	PluginConnected    bool            `json:"plugin_connected"`
+	Recording          bool            `json:"recording"`
+	RecordingSizeBytes uint64          `json:"recording_size_bytes"`
+	TestToneStream     *uint16         `json:"test_tone_stream,omitempty"`
 	// Discovered local Link Audio channels for the capture send-mixer (Step 4).
-	CaptureChannels   []CaptureChannelInfo `json:"capture_channels,omitempty"`
+	CaptureChannels []CaptureChannelInfo `json:"capture_channels,omitempty"`
 }
 
 type PeerNetworkInfo struct {

--- a/wail-app/frontend/index.html
+++ b/wail-app/frontend/index.html
@@ -115,7 +115,7 @@
       <button type="button" class="tab active" id="session-tab-session">Session</button>
       <button type="button" class="tab" id="session-tab-chat">Chat</button>
       <button type="button" class="tab" id="session-tab-logs">Logs <span id="log-count" class="log-badge">0</span></button>
-      <button type="button" class="tab" id="session-tab-network">Network</button>
+      <button type="button" class="tab" id="session-tab-network">Peers <span id="peer-count" class="log-badge">0/0</span></button>
     </div>
 
     <!-- Session tab -->
@@ -194,26 +194,11 @@
       </div>
     </div>
 
-    <!-- Network tab -->
+    <!-- Peers tab: tree of remote peers with the channels each is sending -->
     <div id="session-tab-network-content" style="display:none">
-      <div class="network-header">
-        <button type="button" id="stats-mode-btn-net" class="stats-mode-toggle">all time</button>
+      <div id="peer-tree" class="peer-tree">
+        <span class="empty">No peers connected</span>
       </div>
-      <table class="network-table">
-        <thead>
-          <tr>
-            <th>Peer</th>
-            <th>Slot</th>
-            <th>Connection</th>
-            <th>RTT</th>
-            <th>Recv</th>
-            <th>Lost</th>
-          </tr>
-        </thead>
-        <tbody id="network-table-body">
-          <tr><td colspan="6" class="empty">No peers connected</td></tr>
-        </tbody>
-      </table>
 
       <!-- Local audio-path health counters (each increment ≈ one audible-risk event) -->
       <h3 class="section-label network-health-label">Local audio health</h3>

--- a/wail-app/frontend/index.html
+++ b/wail-app/frontend/index.html
@@ -120,11 +120,11 @@
 
     <!-- Session tab -->
     <div id="session-tab-session-content">
-      <section class="session-section">
-        <h3 class="section-label">Peers</h3>
-        <div id="peer-list" class="peer-list">
-          <span class="empty">No peers connected</span>
-        </div>
+      <!-- In-app senders only (test tone / WAV). Remote peers and their sent
+           channels live on the Peers tab. Shown only while you're sending. -->
+      <section class="session-section" id="sends-section" style="display:none">
+        <h3 class="section-label">Your Sends</h3>
+        <div id="peer-list" class="peer-list"></div>
       </section>
 
       <div id="link-no-peers-warning" class="warning" style="display:none">

--- a/wail-app/frontend/main.js
+++ b/wail-app/frontend/main.js
@@ -240,9 +240,7 @@ let roomRefreshTimer = null;
 const STATS_WINDOW_SIZE = 60; // 60 ticks x 2s = 2 minutes
 let statsMode = 'all';        // 'all' or 'recent'
 let statusSnapshots = [];
-let networkSnapshots = [];
 let lastStatusPayload = null;
-let lastNetworkPeers = null;
 
 // --- Display Name Storage ---
 const DISPLAY_NAME_KEY = 'wail-display-name';
@@ -559,12 +557,9 @@ sessionTabNetworkBtn.addEventListener('click', () => switchSessionTab(sessionTab
 
 function resetStatsWindow() {
   statusSnapshots = [];
-  networkSnapshots = [];
   statsMode = 'all';
   lastStatusPayload = null;
-  lastNetworkPeers = null;
   document.getElementById('stats-mode-btn').textContent = 'all time';
-  document.getElementById('stats-mode-btn-net').textContent = 'all time';
 }
 
 function showJoin() {
@@ -674,7 +669,6 @@ sessionBpmInput.addEventListener('change', applyBpm);
 
 // --- Stats mode toggle click handlers ---
 document.getElementById('stats-mode-btn').addEventListener('click', toggleStatsMode);
-document.getElementById('stats-mode-btn-net').addEventListener('click', toggleStatsMode);
 
 // --- Chat ---
 chatSendBtn.addEventListener('click', sendChatMessage);
@@ -690,9 +684,7 @@ function toggleStatsMode() {
   statsMode = statsMode === 'all' ? 'recent' : 'all';
   const label = statsMode === 'all' ? 'all time' : 'last 2 min';
   document.getElementById('stats-mode-btn').textContent = label;
-  document.getElementById('stats-mode-btn-net').textContent = label;
   if (lastStatusPayload) renderStatus(lastStatusPayload);
-  if (lastNetworkPeers) renderNetwork(lastNetworkPeers);
 }
 
 function renderStatus(s) {
@@ -782,6 +774,8 @@ function renderStatus(s) {
       });
     }
   }
+
+  renderPeerTree(s);
 }
 
 // Engine health counters: [json key, friendly label]. Each increment is a
@@ -816,41 +810,78 @@ function renderHealth(health) {
   }).join('');
 }
 
-function renderNetwork(peers) {
-  const tbody = document.getElementById('network-table-body');
-  if (peers.length === 0) {
-    tbody.innerHTML = '<tr><td colspan="8" class="empty">No peers connected</td></tr>';
+// Peers tab: a tree of remote peers with the Link Audio channels each is
+// sending nested beneath. Built from the status:update payload — peers carry
+// the roster (and the denominator), slots carry each peer's channels. A peer
+// counts as "sending" when we're presently receiving its audio (is_receiving).
+function renderPeerTree(s) {
+  const treeEl = document.getElementById('peer-tree');
+  const badge = document.getElementById('peer-count');
+  const peers = s.peers || [];
+  const slots = s.slots || [];
+
+  // Group channels under their peer. peer_id ties a slot to a roster entry;
+  // slots whose peer has dropped (id empty / not in the roster) are shown as
+  // their own reconnecting node so no channel silently disappears.
+  const channelsByPeer = new Map();
+  for (const sl of slots) {
+    const key = sl.peer_id || `client:${sl.client_id}`;
+    if (!channelsByPeer.has(key)) channelsByPeer.set(key, []);
+    channelsByPeer.get(key).push(sl);
+  }
+
+  const nodes = peers.map(p => ({
+    name: p.display_name || p.peer_id.slice(0, 8),
+    status: p.status || 'connecting',
+    rtt: p.rtt_ms,
+    sending: !!p.is_receiving,
+    channels: channelsByPeer.get(p.peer_id) || [],
+  }));
+  const roster = new Set(peers.map(p => p.peer_id));
+  for (const [key, chans] of channelsByPeer) {
+    if (roster.has(key)) continue;
+    nodes.push({
+      name: chans[0].display_name || chans[0].short_id || key,
+      status: 'reconnecting',
+      rtt: chans[0].rtt_ms,
+      sending: chans.some(c => c.is_receiving),
+      channels: chans,
+    });
+  }
+  nodes.sort((a, b) => a.name.localeCompare(b.name));
+
+  // Count reflects the roster: peers presently sending / total connected.
+  const sending = peers.filter(p => p.is_receiving).length;
+  badge.textContent = `${sending}/${peers.length}`;
+  badge.className = 'log-badge' + (sending > 0 ? ' has-activity' : '');
+
+  if (nodes.length === 0) {
+    treeEl.innerHTML = '<span class="empty">No peers connected</span>';
     return;
   }
-  const oldest = networkSnapshots.length > 1 ? networkSnapshots[0] : null;
-  tbody.innerHTML = peers.map(p => {
-    const name = p.display_name
-      ? escapeHtml(p.display_name)
-      : escapeHtml(p.peer_id.slice(0, 8));
-    const slot = p.slot != null ? `Slot ${p.slot}` : '-';
-    const rtt = p.rtt_ms != null ? `${p.rtt_ms.toFixed(0)}ms` : '-';
+  treeEl.innerHTML = nodes.map(renderPeerNode).join('');
+}
 
-    let fr = p.frames_received;
-    let lost = p.packets_lost;
-
-    if (statsMode === 'recent' && oldest) {
-      const old = oldest.get(p.peer_id);
-      if (old) {
-        fr = Math.max(0, p.frames_received - old.frames_received);
-        lost = Math.max(0, p.packets_lost - old.packets_lost);
-      }
-    }
-
-    const lostClass = lost > 0 ? 'health-bad' : '';
-    return `<tr>
-      <td>${name}</td>
-      <td>${slot}</td>
-      <td class="net-state net-${escapeHtml(p.connection_state)}">${escapeHtml(p.connection_state)}</td>
-      <td>${rtt}</td>
-      <td>${fr}</td>
-      <td class="${lostClass}">${lost}</td>
-    </tr>`;
-  }).join('');
+function renderPeerNode(n) {
+  const statusClass = n.sending ? 'status-receiving' : `status-${n.status}`;
+  const tag = n.sending ? 'sending' : (n.status === 'connected' ? 'idle' : n.status);
+  const rtt = n.rtt != null ? `${n.rtt.toFixed(0)}ms` : '';
+  const chans = n.channels.slice().sort((a, b) => a.channel_index - b.channel_index);
+  const channelsHtml = chans.length
+    ? chans.map(c => {
+        const label = c.stream_name ? escapeHtml(c.stream_name) : `Channel ${c.channel_index}`;
+        return `<div class="peer-channel"><span class="channel-name">${label}</span></div>`;
+      }).join('')
+    : '<div class="peer-channel peer-channel--none"><span class="channel-name">no channels</span></div>';
+  return `<div class="peer-node">
+    <div class="peer-node-head">
+      <span class="peer-dot ${statusClass}"></span>
+      <span class="peer-name">${escapeHtml(n.name)}</span>
+      <span class="peer-status ${statusClass}">${escapeHtml(tag)}</span>
+      <span class="peer-rtt">${rtt}</span>
+    </div>
+    <div class="peer-channels">${channelsHtml}</div>
+  </div>`;
 }
 
 // --- Event Listeners ---
@@ -890,20 +921,9 @@ async function setupListeners() {
     addChatMessage(p.sender_name, p.is_own, p.text);
   }));
 
+  // The peer tree is driven by status:update (it carries peers + slots); this
+  // event now only feeds the local audio-health counters beneath it.
   unlisten.push(await listen('peers:network', (event) => {
-    const peers = event.payload.peers;
-    lastNetworkPeers = peers;
-    const snap = new Map();
-    for (const p of peers) {
-      snap.set(p.peer_id, {
-        audio_recv: p.audio_recv,
-        frames_received: p.frames_received,
-        packets_lost: p.packets_lost,
-      });
-    }
-    networkSnapshots.push(snap);
-    if (networkSnapshots.length > STATS_WINDOW_SIZE) networkSnapshots.shift();
-    renderNetwork(peers);
     renderHealth(event.payload.health);
   }));
 }

--- a/wail-app/frontend/main.js
+++ b/wail-app/frontend/main.js
@@ -584,7 +584,12 @@ function showSession(room) {
   clearLog();
   clearChatMessages();
   document.getElementById('session-room').textContent = room;
-  document.getElementById('peer-list').innerHTML = '<span class="empty">No peers connected</span>';
+  document.getElementById('sends-section').style.display = 'none';
+  document.getElementById('peer-list').innerHTML = '';
+  document.getElementById('peer-tree').innerHTML = '<span class="empty">No peers connected</span>';
+  const peerCount = document.getElementById('peer-count');
+  peerCount.textContent = '0/0';
+  peerCount.className = 'log-badge';
   document.getElementById('session-audio').textContent = '0 / 0';
   document.getElementById('session-audio-bytes').textContent = '0 B / 0 B';
   document.getElementById('session-plugin').textContent = 'disconnected';
@@ -727,16 +732,14 @@ function renderStatus(s) {
     document.getElementById('recording-size').textContent = `${mb} MB`;
   }
 
-  // Update slot list (local sends first, then remote slots)
-  const slotList = document.getElementById('peer-list');
+  // "Your Sends": in-app senders (test tone / WAV) only. Remote peers and the
+  // channels they send live on the Peers tab. The section stays hidden unless
+  // you're actually sending, and a status tick never clobbers an edit-in-progress.
   const localSends = (s.local_sends || []);
-  const slots = (s.slots || []).slice().sort((a, b) => a.slot - b.slot);
-  if (localSends.length === 0 && slots.length === 0) {
-    slotList.innerHTML = '<span class="empty">No peers connected</span>';
-  } else {
-    // Skip re-rendering local sends if user is editing a stream name
-    const isEditingStreamName = slotList.querySelector('.stream-name-input') != null;
-    const localHtml = isEditingStreamName ? null : localSends.map(ls => {
+  document.getElementById('sends-section').style.display = localSends.length ? '' : 'none';
+  const slotList = document.getElementById('peer-list');
+  if (localSends.length && slotList.querySelector('.stream-name-input') == null) {
+    slotList.innerHTML = localSends.map(ls => {
       const label = ls.stream_name
         ? escapeHtml(ls.stream_name)
         : (localSends.length > 1 ? `My Send (stream ${ls.stream_index})` : 'My Send');
@@ -748,31 +751,9 @@ function renderStatus(s) {
         <span class="peer-rtt"></span>
       </div>`;
     }).join('');
-    const remoteHtml = slots.map(sl => {
-      const streamLabel = sl.stream_name ? ` \u2014 ${escapeHtml(sl.stream_name)}` : '';
-      const name = sl.display_name
-        ? `${escapeHtml(sl.display_name)}${streamLabel} (${escapeHtml(sl.short_id)})`
-        : escapeHtml(sl.short_id);
-      const rtt = sl.rtt_ms != null ? `${sl.rtt_ms.toFixed(0)}ms` : '...';
-      const status = sl.status || 'connecting';
-      const statusClass = `peer-status status-${status}`;
-      return `<div class="peer-item">
-        <span class="peer-slot">Slot ${sl.slot}</span><span class="peer-name">${name}</span>
-        <span class="${statusClass}">${escapeHtml(status)}</span>
-        <span class="peer-rtt">${rtt}</span>
-      </div>`;
-    }).join('');
-    if (isEditingStreamName) {
-      // Only update remote slots, preserve local sends (user is editing)
-      const remoteContainer = slotList.querySelector('.remote-slots');
-      if (remoteContainer) remoteContainer.innerHTML = remoteHtml;
-    } else {
-      slotList.innerHTML = localHtml + `<span class="remote-slots">${remoteHtml}</span>`;
-      // Attach inline edit handlers to local send names
-      slotList.querySelectorAll('.peer-name.editable').forEach(span => {
-        span.addEventListener('click', startStreamNameEdit);
-      });
-    }
+    slotList.querySelectorAll('.peer-name.editable').forEach(span => {
+      span.addEventListener('click', startStreamNameEdit);
+    });
   }
 
   renderPeerTree(s);

--- a/wail-app/frontend/style.css
+++ b/wail-app/frontend/style.css
@@ -720,60 +720,67 @@ summary:hover {
    NETWORK TABLE
    ================================================================ */
 
-.network-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 11px;
-  font-family: var(--font-mono);
+/* Peers tab: tree of remote peers with their sent channels nested beneath */
+.peer-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 4px 0;
 }
 
-.network-table th {
-  text-align: left;
-  padding: 6px 8px;
-  color: var(--fg-muted);
-  border-bottom: 1px solid var(--border);
-  font-family: var(--font-sans);
-  font-weight: 600;
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.network-table td {
-  padding: 6px 8px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.02);
-}
-
-.network-table tr:hover td {
-  background: var(--bg-card);
-}
-
-.network-table .empty {
+.peer-tree .empty {
   color: var(--fg-dim);
-  text-align: center;
-  padding: 16px;
-  font-family: var(--font-sans);
+  font-size: 12px;
+  padding: 8px 0;
 }
 
-/* Network state dots */
-.net-state {
+.peer-node {
+  background: var(--bg-card);
+  border-radius: 6px;
+  padding: 6px 10px;
+}
+
+.peer-node-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.peer-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  background: var(--fg-muted);
+}
+.peer-dot.status-receiving { background: var(--state-ok); }
+.peer-dot.status-connected { background: var(--accent); }
+.peer-dot.status-reconnecting { background: var(--state-warn); }
+
+.peer-channels {
+  margin: 5px 0 1px 15px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border-left: 1px solid var(--border);
+  padding-left: 10px;
+}
+
+.peer-channel {
+  font-size: 11px;
+  color: var(--fg-muted);
   font-family: var(--font-mono);
 }
 
-.net-connected, .net-completed, .net-open {
+.peer-channel--none .channel-name {
+  color: var(--fg-dim);
+  font-style: italic;
+}
+
+/* Peers-tab count badge (reuses .log-badge): tinted when audio is flowing */
+.log-badge.has-activity {
+  background: var(--state-ok-dim);
   color: var(--state-ok);
-}
-
-.net-checking, .net-connecting, .net-closing {
-  color: var(--state-warn);
-}
-
-.net-failed, .net-closed, .net-disconnected {
-  color: var(--state-error);
-}
-
-.net-none {
-  color: var(--fg-muted);
 }
 
 .health-good {
@@ -1102,12 +1109,6 @@ summary:hover {
   color: var(--fg);
   border-color: rgba(255, 255, 255, 0.12);
 }
-.network-header {
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 6px;
-}
-
 /* Status indicator */
 .connected {
   color: var(--state-ok);

--- a/wail-app/session.go
+++ b/wail-app/session.go
@@ -894,6 +894,7 @@ func sessionLoop(
 				}
 				slotInfos = append(slotInfos, SlotInfo{
 					Slot: uint32(m.SlotIndex + 1), ShortID: m.ShortID(), ClientID: m.ClientID,
+					PeerID:       pid,
 					ChannelIndex: m.ChannelIndex, DisplayName: dn, Status: &status,
 					RTTMs: rttMs, IsSending: isSend, IsReceiving: isRecv, StreamName: streamName,
 				})


### PR DESCRIPTION
## What

Replaces the **Network** tab with a **Peers** tab that shows a tree of each connected peer with the Link Audio channels they're sending nested beneath them, plus a count badge (styled like the Logs tab) reading **peers presently sending / total connected**.

```
● Geren                    sending   38ms
  └ channels
    Bass
    Drums
● Quasor                   idle      12ms
  └ no channels
```

## Why

The peer-slot table (name / slot / RTT / recv / lost) mattered more when audio routing was opaque. Running alongside Ableton Live, what you actually want at a glance is *who's here and what are they sending* — which maps naturally to a peer → channels tree.

## Details

- **Tree source:** the `status:update` payload already carries both the peer roster (`peers`) and the per-channel slots (`slots`). Channels group under their peer via a new `peer_id` field on `SlotInfo` (the relay peer id, matching `PeerInfo.peer_id`) so grouping is reliable rather than name-matched. Slots whose peer has dropped (id empty / not in the roster) render as their own "reconnecting" node so no channel silently vanishes.
- **Count badge:** numerator = peers we're *presently receiving audio from* (`is_receiving`); denominator = all connected peers. Tinted green while audio is flowing.
- **Session tab de-duplicated:** the old Session-tab peer list showed the same remote slots, so it's now **"Your Sends"** — in-app senders (test tone / WAV) only — and stays hidden unless you're actually sending. Inline stream-name editing is preserved.
- **Kept:** the "Local audio health" counters remain beneath the tree (now fed only by the `peers:network` event).
- **Removed:** the network table, its per-tab all-time/recent stats toggle, and the now-dead `networkSnapshots` bookkeeping + `.network-table`/`.net-*` CSS.

## Testing

- `go build ./...` (cgo) + `go build -tags linkstub -o /dev/null ./...` — clean
- `go test -count=1 ./...` — all pass
- `node --check` on the frontend — clean

📡 Claude Code arranged the branches; any wilting is its own doing