### PR TITLE
chore: note chore/docs PRs don't cut a release in /merge-and-release

### DIFF
--- a/.claude/commands/merge-and-release.md
+++ b/.claude/commands/merge-and-release.md
@@ -29,6 +29,7 @@ If there's **no feature PR to merge** — e.g. a `chore: prepare release` PR is 
 
 - `gh pr view <N> --json title,mergeable,mergeStateStatus,headRefName` and `gh pr checks <N>`.
 - The **title must be a conventional commit** (`feat:` / `fix:` / `feat!:`): you'll squash-merge, so the title becomes the commit knope reads for the bump (`feat`→minor, `fix`→patch, `!`→major). Fix it with `gh pr edit <N> --title ...` if it's wrong.
+- A `chore:` / `docs:` PR is fine to merge, but knope ignores it — it **won't cut a release**, so expect no release PR in step 4 and stop after step 3.
 - If `mergeStateStatus` is `DIRTY` / `mergeable` is `CONFLICTING`: resolve in a throwaway worktree — `git worktree add`, merge `origin/main`, fix the conflicts, run `cd wail-app && go build ./... && go test ./...` (plus `signaling-server` if it was touched), push the branch, re-check mergeability. Remove the worktree afterward.
 - If checks are red: stop and report. Don't merge over failing CI.
 
@@ -51,7 +52,7 @@ gh run list --limit 6 --json name,status,conclusion,headBranch,event \
 gh pr list --state open --head release --base main --json number,title,url
 ```
 
-Give up and report if nothing shows after a few minutes (check `gh run view` for a failed prepare-release). Sanity-check the version bump matches the commit type you merged.
+If the merged commit was `chore:` / `docs:`, "Prepare Release" concludes `skipped` and no PR opens — that's expected; you're done. Otherwise, give up and report if nothing shows after a few minutes (check `gh run view` for a failed prepare-release). Sanity-check the version bump matches the commit type you merged.
 
 ### 5. Merge the release PR
 


### PR DESCRIPTION
A follow-up to #377, found while dogfooding `/merge-and-release` on its own (`chore:`) PR: a `chore:`/`docs:` change merges fine but knope ignores it, so no `chore: prepare release` PR ever opens. Without a note, step 4 ("wait for the prepare-release PR") reads like you should keep waiting.

Adds two one-liners:
- **Step 2** — `chore:`/`docs:` is fine to merge but won't cut a release, so stop after step 3.
- **Step 4** — if the merged commit was `chore:`/`docs:`, "Prepare Release" concludes `skipped` and no PR opens; that's expected, you're done.

Docs/tooling only — `chore:`, so (fittingly) this one won't cut a release either.

Claude Code patching the docs for the command that Claude Code wrote. It's documentation all the way down.