### PR TITLE
chore: bump action-gh-release to v3 (Node 24 runtime)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,7 @@ jobs:
           echo "windows_zip=$(ls wail-windows-x64-*.zip 2>/dev/null | head -1 || true)" >> "$GITHUB_OUTPUT"
           echo "linux_tarball=$(ls wail-linux-x64-*.tar.gz 2>/dev/null | head -1 || true)" >> "$GITHUB_OUTPUT"
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           files: |


### PR DESCRIPTION
## What

Bumps `softprops/action-gh-release` from `@v2` to `@v3` in the release workflow.

## Why

GitHub Actions runners are deprecating Node.js 20. The release pipeline was emitting:

> The following actions target Node.js 20 but are being forced to run on Node.js 24: `softprops/action-gh-release@v2`.

GitHub currently shims the action onto Node 24, but that bridge is temporary. `v3.0.0` is a runtime-only major bump ("moves the action runtime from Node 20 to Node 24") with no input/API changes affecting our usage (`tag_name`, `files`), so it's a drop-in fix.

## Notes

- CI-config-only change, no Go code paths touched — no tests required.
- All other actions in the workflows are `actions/*` at recent majors already on Node 24.
- `chore:` prefix, no changelog entry needed (CI infra).

Claude Code did the typing, blame it accordingly