### PR TITLE
chore: bump setup-go to v6 (Node 24) and fix go.sum cache path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,12 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: wail-app/go.mod
+          # Both Go modules live in subdirs, so point the built-in cache at every
+          # go.sum — otherwise setup-go looks only at the repo root and warns.
+          cache-dependency-path: "**/go.sum"
 
       - name: Install opus
         run: brew install opus
@@ -51,9 +54,12 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: wail-app/go.mod
+          # Both Go modules live in subdirs, so point the built-in cache at every
+          # go.sum — otherwise setup-go looks only at the repo root and warns.
+          cache-dependency-path: "**/go.sum"
 
       - name: Cache vcpkg
         id: vcpkg-cache
@@ -120,9 +126,12 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: wail-app/go.mod
+          # Both Go modules live in subdirs, so point the built-in cache at every
+          # go.sum — otherwise setup-go looks only at the repo root and warns.
+          cache-dependency-path: "**/go.sum"
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,9 +70,12 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
           submodules: recursive
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: wail-app/go.mod
+          # Both Go modules live in subdirs, so point the built-in cache at every
+          # go.sum — otherwise setup-go looks only at the repo root and warns.
+          cache-dependency-path: "**/go.sum"
 
       - name: Cache vcpkg
         id: vcpkg-cache
@@ -176,9 +179,12 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
           submodules: recursive
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: wail-app/go.mod
+          # Both Go modules live in subdirs, so point the built-in cache at every
+          # go.sum — otherwise setup-go looks only at the repo root and warns.
+          cache-dependency-path: "**/go.sum"
 
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
Follow-up to #380. Two more CI issues surfaced in the Build run after that merge.

## 1. `actions/setup-go@v5` on deprecated Node 20

The Build run's annotations flagged:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/setup-go@v5`.

`v6.0.0` moved the runtime to Node 24. Bumps all **five** uses across `build.yml` (3) and `release.yml` (2). No input API changes affect us.

## 2. Go module cache never restored

The same run warned:

> Restore cache failed: Dependencies file is not found in /Users/runner/work/WAIL/WAIL. Supported file pattern: go.sum

Both Go modules live in subdirs (`wail-app/`, `signaling-server/`), so setup-go's default root-only `go.sum` lookup found nothing and skipped caching entirely. Added `cache-dependency-path: "**/go.sum"` to each step so both modules' checksums are hashed and the module cache actually restores.

## Notes

- CI-config-only, no Go code paths touched — no tests required.
- The `aws/tap` "not trusted" annotation is pre-installed-Homebrew noise on the macOS runner, unrelated to our config — intentionally left alone.
- `chore:` prefix, no changelog entry (CI infra).

Powered by artificial mediocrity