### PR TITLE
docs: tell joiners to start their transport after joining

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Together they set the interval length: (BPI ÷ BPM) × 60 = seconds. At 120 BPM 
 
 The first peer in a room sets its BPI; everyone who joins adopts it. Anyone can change it mid-jam from the session screen — the change applies at the next interval boundary. BPI must divide evenly into whole bars at the room's beats per bar (default 4), e.g. 4, 8, 16, or 32.
 
-**Match your DAW's launch quantization to the room interval.** WAIL can't read or set your DAW's launch quantization (Ableton Link doesn't carry it), so it tells you instead: when you join a room, WAIL shows the room's interval and asks you to set your DAW to match (e.g. Live's Global Quantization → 4 Bars). This keeps everyone's clip launches aligned with the interval grid.
+**Match your DAW's launch quantization to the room interval.** WAIL can't read or set your DAW's launch quantization (Ableton Link doesn't carry it), so it tells you instead: when you join a room, WAIL shows the room's interval and asks you to set your DAW to match (e.g. Live's Global Quantization → 4 Bars). This keeps everyone's clip launches aligned with the interval grid. Join the room first, then start your DAW's transport — that gives you a clean first interval (WAIL still handles a mid-interval start, so it's a nicety, not a hard requirement).
 
 ## Headless CLI Mode
 

--- a/wail-app/frontend/main.js
+++ b/wail-app/frontend/main.js
@@ -999,7 +999,7 @@ async function setupListeners() {
     const bpi = Math.round(p.bars * p.quantum);
     const barsWord = `${p.bars} bar${p.bars !== 1 ? 's' : ''}`;
     document.getElementById('interval-prompt-text').textContent =
-      `This room runs ${bpi} beats (${barsWord}) per interval — set your DAW's launch quantization to ${barsWord} to match.`;
+      `This room runs ${bpi} beats (${barsWord}) per interval — set your DAW's launch quantization to ${barsWord} to match, then start your transport.`;
     document.getElementById('interval-prompt').style.display = '';
   }));
 


### PR DESCRIPTION
## What

Fold a **"then start your transport"** clause into the two places that already tell a joiner how to line up with a room:

- **Join prompt** (`wail-app/frontend/main.js`) — the existing `interval:prompt` message now reads: *"…set your DAW's launch quantization to N bars to match, **then start your transport**."*
- **README** (launch-quant section) — adds the join-order guidance with an honest caveat.

## Why

Question raised: *should WAIL stop Link transport on launch so it's "ready to go" on join?*

Answer, after grilling it against the code and Ableton's docs: **no.**

- Ableton's own rule for Start/Stop Sync: *"start/stop state changes only follow user actions… applications will not automatically change the start/stop state when joining."*
- WAIL's passive-peer pillar (`CONTEXT.md` #4, ADR-0003): it never forces the local session's transport. Start/Stop Sync isn't even bound in `abllink`, and WAIL has no transport of its own to broadcast.
- Link isn't started until `JoinRoom` anyway (`session.go`), so there's nothing to "stop" at launch.

The real "ready to go" is **user ordering** — join → match launch quant → play — so it's surfaced as guidance at the moment it matters, not baked into WAIL's behavior. No code path changes.

## Testing

Docs + one UI string; no Go code touched, so the suite was skipped (per repo docs-only guidance).

---
Claude Code typed it; the questionable judgment is mine.