### PR TITLE
chore: squash-merge the release PR in /merge-and-release

### DIFF
--- a/.claude/commands/merge-and-release.md
+++ b/.claude/commands/merge-and-release.md
@@ -57,10 +57,10 @@ If the merged commit was `chore:` / `docs:`, "Prepare Release" concludes `skippe
 ### 5. Merge the release PR
 
 - Confirm it touches only `CHANGELOG.md` + `VERSION`: `gh pr diff <RELEASE_PR> --name-only`. Anything else → stop and investigate.
-- Matching `/release`, let CI settle, then merge with a merge commit and delete the branch (knope recreates `release` on the next prepare-release):
+- Let CI settle, then squash-merge and delete the branch (knope recreates `release` on the next prepare-release). **This repo disallows merge commits — use `--squash`, not `--merge`** (a `--merge` attempt fails with "Merge commits are not allowed on this repository"). `release-on-merge.yml` triggers on the merge regardless of method.
 
 ```sh
-sleep 120 && gh pr merge <RELEASE_PR> --merge --delete-branch
+sleep 120 && gh pr merge <RELEASE_PR> --squash --delete-branch
 ```
 
 ### 6. Wait for the release to complete


### PR DESCRIPTION
## What

Fixes step 5 of the `/merge-and-release` command doc. This repo disallows merge commits, so `gh pr merge <RELEASE_PR> --merge` fails with:

> GraphQL: Merge commits are not allowed on this repository. (mergePullRequest)

Switched the documented command to `--squash --delete-branch` and noted the constraint. `release-on-merge.yml` triggers on the merge regardless of method, so nothing else changes.

Hit live while shipping v3.5.0 (the interval-clock feature).

## Note

`chore:` change — knope ignores it, so this won't cut a release (as documented in the command itself).

---
Claude Code stepped on this rake so future-Claude doesn't have to.