### PR TITLE
feat: launch-quantization summary in a rounded box above Advanced

### DIFF
--- a/wail-app/frontend/index.html
+++ b/wail-app/frontend/index.html
@@ -53,10 +53,11 @@
 
         <label for="bpi">Beats per interval</label>
         <input type="number" id="bpi" value="16" min="1" max="256">
-        <div id="bpi-helper" class="hint"></div>
 
         <label for="quantum">Beats per bar</label>
         <input type="number" id="quantum" value="4" min="1" max="16" step="0.1">
+
+        <div id="quant-summary" class="quant-summary"></div>
 
         <details id="advanced-toggle">
           <summary>Advanced</summary>

--- a/wail-app/frontend/main.js
+++ b/wail-app/frontend/main.js
@@ -488,11 +488,14 @@ function bpiMath() {
 }
 
 function updateBpiHelper() {
-  const el = document.getElementById('bpi-helper');
+  const el = document.getElementById('quant-summary');
   const m = bpiMath();
   if (!m) { el.textContent = ''; el.classList.remove('error-text'); return; }
   if (m.whole) {
-    el.textContent = `(e.g. ${m.bars} bar${m.bars !== 1 ? 's' : ''} in ${m.bpb}/4)`;
+    const barsWord = `${m.bars} Bar${m.bars !== 1 ? 's' : ''}`;
+    el.innerHTML =
+      `<span class="quant-summary-eq">BEATS PER INTERVAL ${m.bpi} / BEATS PER BAR ${m.bpb} =</span>` +
+      `<span class="quant-summary-result">Set your Global Launch Quantization to ${barsWord}</span>`;
     el.classList.remove('error-text');
   } else {
     el.textContent = `${m.bars.toFixed(2)} bars in ${m.bpb}/4 — must be a whole number of bars`;

--- a/wail-app/frontend/style.css
+++ b/wail-app/frontend/style.css
@@ -379,7 +379,7 @@ summary:hover {
 
 /* --- Launch-quantization summary (rounded, prominent) --- */
 .quant-summary {
-  margin: 4px 0 10px;
+  margin: 12px 0 10px;
   padding: 12px 14px;
   border: 1px solid var(--accent);
   border-radius: var(--radius-lg);

--- a/wail-app/frontend/style.css
+++ b/wail-app/frontend/style.css
@@ -377,6 +377,45 @@ summary:hover {
   color: var(--state-error);
 }
 
+/* --- Launch-quantization summary (rounded, prominent) --- */
+.quant-summary {
+  margin: 4px 0 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-lg);
+  background: var(--accent-dim);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-align: center;
+}
+
+.quant-summary:empty {
+  display: none;
+}
+
+.quant-summary-eq {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  color: var(--fg-dim);
+  text-transform: uppercase;
+}
+
+.quant-summary-result {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.quant-summary.error-text {
+  border-color: var(--state-error);
+  background: transparent;
+  color: var(--state-error);
+  font-size: 12px;
+  text-align: left;
+}
+
 .bpi-inline-row {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What

Reworks the *Beats per interval* helper on the Join form. The old small hint under the input (`(e.g. 4 bars in 4/4)`) is replaced by a prominent **rounded-corner display** placed above the **Advanced** section that live-updates as you change the two fields:

> **BEATS PER INTERVAL 16 / BEATS PER BAR 4 =**
> **Set your Global Launch Quantization to 4 Bars**

## Why

Makes the DAW launch-quantization guidance far more visible — it's the number a joiner needs to set in their DAW to line up with the room interval.

## Details

- `index.html` — moved the display element to sit above `<details id="advanced-toggle">`.
- `main.js` — `updateBpiHelper()` renders the two-line wording into `#quant-summary` with proper `Bar`/`Bars` pluralization; the invalid case (non-whole bars) still shows the "must be a whole number of bars" warning in the same box.
- `style.css` — new `.quant-summary` styling (accent border, rounded, tinted background, centered), with the error state reusing the red warning styling and `:empty` hiding the box.

Frontend-only; no Go code paths changed.

---
🤖 Claude Code did the typing, blame it accordingly