### PR TITLE
chore(ci): cache the cgo C++ compile with ccache to speed up Windows/Linux builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,9 +69,24 @@ jobs:
       # when GOCACHE misses. Routed in via CC/CXX on the build step below.
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2.23
+        continue-on-error: true
         with:
           key: ${{ github.job }}-${{ runner.os }}
           max-size: 500M
+
+      # cgo uses ccache only if it actually installed; otherwise CC/CXX stay
+      # unset and cgo falls back to the default gcc/g++ (slower, but still green).
+      # The action downloads a binary each run, so a network blip must not fail CI.
+      - name: Enable ccache for cgo if available
+        shell: bash
+        run: |
+          if command -v ccache >/dev/null 2>&1; then
+            echo "CC=ccache gcc" >> "$GITHUB_ENV"
+            echo "CXX=ccache g++" >> "$GITHUB_ENV"
+            echo "cgo will use ccache"
+          else
+            echo "ccache unavailable — building without compiler cache"
+          fi
 
       - name: Cache vcpkg
         id: vcpkg-cache
@@ -125,15 +140,14 @@ jobs:
 
       - name: Build Go app
         env:
-          CC: ccache gcc
-          CXX: ccache g++
           PKG_CONFIG_PATH: C:\vcpkg\installed\x64-mingw-static\lib\pkgconfig
         run: go build -tags nolibopusfile -o NUL .
         working-directory: wail-app
 
       - name: ccache stats
         if: always()
-        run: ccache -s
+        shell: bash
+        run: command -v ccache >/dev/null 2>&1 && ccache -s || echo "ccache not installed"
 
       - name: Build & test signaling-server
         run: go build ./... && go test ./...
@@ -162,9 +176,24 @@ jobs:
       # when GOCACHE misses. Routed in via CC/CXX on the build/test steps below.
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2.23
+        continue-on-error: true
         with:
           key: ${{ github.job }}-${{ runner.os }}
           max-size: 500M
+
+      # cgo uses ccache only if it actually installed; otherwise CC/CXX stay
+      # unset and cgo falls back to the default gcc/g++ (slower, but still green).
+      # The action downloads a binary each run, so a network blip must not fail CI.
+      - name: Enable ccache for cgo if available
+        shell: bash
+        run: |
+          if command -v ccache >/dev/null 2>&1; then
+            echo "CC=ccache gcc" >> "$GITHUB_ENV"
+            echo "CXX=ccache g++" >> "$GITHUB_ENV"
+            echo "cgo will use ccache"
+          else
+            echo "ccache unavailable — building without compiler cache"
+          fi
 
       - name: Install system dependencies
         run: |
@@ -182,22 +211,17 @@ jobs:
             g++
 
       - name: Build Go app
-        env:
-          CC: ccache gcc
-          CXX: ccache g++
         run: go build -tags nolibopusfile -o /dev/null .
         working-directory: wail-app
 
       - name: Test Go app
-        env:
-          CC: ccache gcc
-          CXX: ccache g++
         run: go test -tags nolibopusfile ./...
         working-directory: wail-app
 
       - name: ccache stats
         if: always()
-        run: ccache -s
+        shell: bash
+        run: command -v ccache >/dev/null 2>&1 && ccache -s || echo "ccache not installed"
 
       - name: Build & test signaling-server
         run: go build ./... && go test ./...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,10 @@ jobs:
     # whose newer toolchain breaks the CGo builds. See #329.
     runs-on: windows-2022
     if: "!startsWith(github.event.head_commit.message, 'chore: prepare release')"
+    env:
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_NOHASHDIR: "true"
+      CCACHE_COMPILERCHECK: content
     steps:
       - uses: actions/checkout@v6
         with:
@@ -61,14 +65,25 @@ jobs:
           # go.sum — otherwise setup-go looks only at the repo root and warns.
           cache-dependency-path: "**/go.sum"
 
+      # Reuse the heavy CGo C++ (Ableton Link + asio) compile across runs, even
+      # when GOCACHE misses. Routed in via CC/CXX on the build step below.
+      - name: Set up ccache
+        uses: hendrikmuhs/ccache-action@v1.2.23
+        with:
+          key: ${{ github.job }}-${{ runner.os }}
+          max-size: 500M
+
       - name: Cache vcpkg
         id: vcpkg-cache
         uses: actions/cache@v5
         with:
           path: C:\vcpkg\installed
-          # Bump the suffix whenever the package list below changes, otherwise a
-          # stale cache is restored and the new packages are never installed.
-          key: vcpkg-opus-mingw-static-pkgconf-x64-windows-v3
+          # Exact key; bump the suffix when the package list changes. restore-keys
+          # falls back to the newest prior cache on a miss, and the install step
+          # below still re-runs on a non-exact hit (its `if` checks the exact key).
+          key: vcpkg-opus-mingw-static-pkgconf-x64-windows-v5
+          restore-keys: |
+            vcpkg-opus-mingw-static-pkgconf-x64-windows-
 
       - name: Install opus + pkgconf via vcpkg
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'
@@ -110,9 +125,15 @@ jobs:
 
       - name: Build Go app
         env:
+          CC: ccache gcc
+          CXX: ccache g++
           PKG_CONFIG_PATH: C:\vcpkg\installed\x64-mingw-static\lib\pkgconfig
         run: go build -tags nolibopusfile -o NUL .
         working-directory: wail-app
+
+      - name: ccache stats
+        if: always()
+        run: ccache -s
 
       - name: Build & test signaling-server
         run: go build ./... && go test ./...
@@ -121,6 +142,10 @@ jobs:
   build-linux:
     runs-on: ubuntu-22.04
     if: "!startsWith(github.event.head_commit.message, 'chore: prepare release')"
+    env:
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_NOHASHDIR: "true"
+      CCACHE_COMPILERCHECK: content
     steps:
       - uses: actions/checkout@v6
         with:
@@ -132,6 +157,14 @@ jobs:
           # Both Go modules live in subdirs, so point the built-in cache at every
           # go.sum — otherwise setup-go looks only at the repo root and warns.
           cache-dependency-path: "**/go.sum"
+
+      # Reuse the heavy CGo C++ (Ableton Link + asio) compile across runs, even
+      # when GOCACHE misses. Routed in via CC/CXX on the build/test steps below.
+      - name: Set up ccache
+        uses: hendrikmuhs/ccache-action@v1.2.23
+        with:
+          key: ${{ github.job }}-${{ runner.os }}
+          max-size: 500M
 
       - name: Install system dependencies
         run: |
@@ -149,12 +182,22 @@ jobs:
             g++
 
       - name: Build Go app
+        env:
+          CC: ccache gcc
+          CXX: ccache g++
         run: go build -tags nolibopusfile -o /dev/null .
         working-directory: wail-app
 
       - name: Test Go app
+        env:
+          CC: ccache gcc
+          CXX: ccache g++
         run: go test -tags nolibopusfile ./...
         working-directory: wail-app
+
+      - name: ccache stats
+        if: always()
+        run: ccache -s
 
       - name: Build & test signaling-server
         run: go build ./... && go test ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,9 +85,24 @@ jobs:
       # when GOCACHE misses. Routed in via CC/CXX on the build step below.
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2.23
+        continue-on-error: true
         with:
           key: ${{ github.job }}-${{ runner.os }}
           max-size: 500M
+
+      # cgo uses ccache only if it actually installed; otherwise CC/CXX stay
+      # unset and cgo falls back to the default gcc/g++ (slower, but still green).
+      # The action downloads a binary each run, so a network blip must not fail CI.
+      - name: Enable ccache for cgo if available
+        shell: bash
+        run: |
+          if command -v ccache >/dev/null 2>&1; then
+            echo "CC=ccache gcc" >> "$GITHUB_ENV"
+            echo "CXX=ccache g++" >> "$GITHUB_ENV"
+            echo "cgo will use ccache"
+          else
+            echo "ccache unavailable — building without compiler cache"
+          fi
 
       - name: Cache vcpkg
         id: vcpkg-cache
@@ -150,8 +165,6 @@ jobs:
       - name: Build wail desktop app
         shell: bash
         env:
-          CC: ccache gcc
-          CXX: ccache g++
           # opus for the CGo link comes from the MinGW (x64-mingw-static) prefix
           # so its ABI matches the GCC that compiles the CGo objects. Windows
           # system libs (ws2_32, winmm, iphlpapi) are set via cgo LDFLAGS in the
@@ -164,7 +177,7 @@ jobs:
       - name: ccache stats
         if: always()
         shell: bash
-        run: ccache -s
+        run: command -v ccache >/dev/null 2>&1 && ccache -s || echo "ccache not installed"
 
       - name: Stage release artifacts
         shell: bash
@@ -216,9 +229,24 @@ jobs:
       # when GOCACHE misses. Routed in via CC/CXX on the build step below.
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2.23
+        continue-on-error: true
         with:
           key: ${{ github.job }}-${{ runner.os }}
           max-size: 500M
+
+      # cgo uses ccache only if it actually installed; otherwise CC/CXX stay
+      # unset and cgo falls back to the default gcc/g++ (slower, but still green).
+      # The action downloads a binary each run, so a network blip must not fail CI.
+      - name: Enable ccache for cgo if available
+        shell: bash
+        run: |
+          if command -v ccache >/dev/null 2>&1; then
+            echo "CC=ccache gcc" >> "$GITHUB_ENV"
+            echo "CXX=ccache g++" >> "$GITHUB_ENV"
+            echo "cgo will use ccache"
+          else
+            echo "ccache unavailable — building without compiler cache"
+          fi
 
       - name: Install system dependencies
         run: |
@@ -246,15 +274,13 @@ jobs:
           echo "value=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build wail desktop app
-        env:
-          CC: ccache gcc
-          CXX: ccache g++
         run: go build -tags nolibopusfile -ldflags "-X main.appVersion=${{ steps.version.outputs.value }}" -o "$GITHUB_WORKSPACE/dist/bin/wail" .
         working-directory: wail-app
 
       - name: ccache stats
         if: always()
-        run: ccache -s
+        shell: bash
+        run: command -v ccache >/dev/null 2>&1 && ccache -s || echo "ccache not installed"
 
       - name: Stage release artifacts
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,10 @@ jobs:
     # the Go/CGo desktop-app build (the same headers compile cleanly on the
     # Linux runner's GCC 11). See #329.
     runs-on: windows-2022
+    env:
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_NOHASHDIR: "true"
+      CCACHE_COMPILERCHECK: content
     steps:
       - uses: actions/checkout@v6
         with:
@@ -77,14 +81,25 @@ jobs:
           # go.sum — otherwise setup-go looks only at the repo root and warns.
           cache-dependency-path: "**/go.sum"
 
+      # Reuse the heavy CGo C++ (Ableton Link + asio) compile across runs, even
+      # when GOCACHE misses. Routed in via CC/CXX on the build step below.
+      - name: Set up ccache
+        uses: hendrikmuhs/ccache-action@v1.2.23
+        with:
+          key: ${{ github.job }}-${{ runner.os }}
+          max-size: 500M
+
       - name: Cache vcpkg
         id: vcpkg-cache
         uses: actions/cache@v5
         with:
           path: C:\vcpkg\installed
-          # Bump the suffix whenever the package list below changes, otherwise a
-          # stale cache is restored and the new packages are never installed.
-          key: vcpkg-opus-mingw-static-pkgconf-x64-windows-v4
+          # Exact key; bump the suffix when the package list changes. restore-keys
+          # falls back to the newest prior cache on a miss, and the install step
+          # below still re-runs on a non-exact hit (its `if` checks the exact key).
+          key: vcpkg-opus-mingw-static-pkgconf-x64-windows-v5
+          restore-keys: |
+            vcpkg-opus-mingw-static-pkgconf-x64-windows-
 
       - name: Install opus + pkgconf via vcpkg
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'
@@ -135,6 +150,8 @@ jobs:
       - name: Build wail desktop app
         shell: bash
         env:
+          CC: ccache gcc
+          CXX: ccache g++
           # opus for the CGo link comes from the MinGW (x64-mingw-static) prefix
           # so its ABI matches the GCC that compiles the CGo objects. Windows
           # system libs (ws2_32, winmm, iphlpapi) are set via cgo LDFLAGS in the
@@ -143,6 +160,11 @@ jobs:
           PKG_CONFIG_PATH: C:\vcpkg\installed\x64-mingw-static\lib\pkgconfig
         working-directory: wail-app
         run: go build -tags nolibopusfile -ldflags "-X main.appVersion=${{ steps.version.outputs.value }}" -o "$GITHUB_WORKSPACE/dist/bin/wail.exe" .
+
+      - name: ccache stats
+        if: always()
+        shell: bash
+        run: ccache -s
 
       - name: Stage release artifacts
         shell: bash
@@ -173,6 +195,10 @@ jobs:
 
   build-linux:
     runs-on: ubuntu-22.04
+    env:
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_NOHASHDIR: "true"
+      CCACHE_COMPILERCHECK: content
     steps:
       - uses: actions/checkout@v6
         with:
@@ -185,6 +211,14 @@ jobs:
           # Both Go modules live in subdirs, so point the built-in cache at every
           # go.sum — otherwise setup-go looks only at the repo root and warns.
           cache-dependency-path: "**/go.sum"
+
+      # Reuse the heavy CGo C++ (Ableton Link + asio) compile across runs, even
+      # when GOCACHE misses. Routed in via CC/CXX on the build step below.
+      - name: Set up ccache
+        uses: hendrikmuhs/ccache-action@v1.2.23
+        with:
+          key: ${{ github.job }}-${{ runner.os }}
+          max-size: 500M
 
       - name: Install system dependencies
         run: |
@@ -212,8 +246,15 @@ jobs:
           echo "value=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build wail desktop app
+        env:
+          CC: ccache gcc
+          CXX: ccache g++
         run: go build -tags nolibopusfile -ldflags "-X main.appVersion=${{ steps.version.outputs.value }}" -o "$GITHUB_WORKSPACE/dist/bin/wail" .
         working-directory: wail-app
+
+      - name: ccache stats
+        if: always()
+        run: ccache -s
 
       - name: Stage release artifacts
         run: |


### PR DESCRIPTION
## Why

Windows/Linux CI and release builds recompile one enormous cgo translation unit whenever `GOCACHE` misses: `wail-app/internal/abllink/wrap.cpp` `#include`s `abl_link.cpp`, instantiating the **entire header-only Ableton Link SDK + standalone asio** (~7 MB of C++17) in a single g++ call. Its only cache was Go's `GOCACHE` (via `setup-go`), which misses often — `go.sum` bumps, `cancel-in-progress` skipping the post-run save, tag-scoped release runs, and 7-day / 10 GB eviction. Every miss = a full cold recompile. (opus is a red herring — prebuilt via vcpkg.)

## What

- **ccache around the cgo C/C++ compiler** on the Windows + Linux jobs in both `build.yml` and `release.yml`, wired via `CC`/`CXX`. ccache hashes the *preprocessed source*, not `go.sum` or the git ref, so the asio/Link object is reused across runs even when `GOCACHE` is cold.
- **Best-effort by design:** the ccache install is `continue-on-error`, `CC`/`CXX` are set only if ccache actually lands on `PATH`, and the stats step is tolerant. A flaky ccache-binary download (I hit one: `curl (35) Recv failure`) yields a slower cold build, **never a red one**. ccache is purely additive.
- **Unify the mismatched vcpkg opus cache key** (`v3`/`v4` → `v5`) + `restore-keys`, so releases stop rebuilding opus from source and can restore the cache `main`'s CI populated.
- macOS left alone (already ~8s).

## Why ccache and not sccache

Tried sccache first and validated locally that it gets **0 hits** here — Go compiles cgo through per-build `$WORK` temp dirs whose paths change every run, defeating sccache's hashing. ccache in preprocessor mode (+ `CCACHE_BASEDIR`/`CCACHE_NOHASHDIR`) hits the expensive TU: `CCACHE_LOGFILE` showed `wrap.cpp -> preprocessed_cache_hit` across a wiped `GOCACHE`. `hendrikmuhs/ccache-action` downloads the binary directly (no choco — matching the repo's existing choco avoidance).

## Results (measured via manual `workflow_dispatch` on this branch)

`build.yml` only auto-runs on `main`/`claude/**`/merge-queue, so I dispatched it manually. Cold (first) run vs warm run, Windows:

| Step (Windows) | cold | warm |
| --- | --- | --- |
| Build Go app | 44s | **17s** |
| Install opus (vcpkg) | 15s | **0s** |
| whole job | 149s | 111s |

ccache hits confirmed in CI: Windows 11 preprocessed hits, Linux 27. Linux compile steps drop (`Test Go app` 24s→6s), but its whole-job time is dominated by the `apt-get` GTK/WebKit install — caching that is a sensible follow-up if Linux CI time still bites.

## Verification

- `actionlint` clean on both workflows; `go test -tags nolibopusfile ./...` (wail-app) + signaling-server tests pass locally.
- Mechanism proven locally: with `CC="ccache clang"`, the asio/Link TU is served from ccache after wiping `GOCACHE`.
- Three dispatched CI runs: run 1 (cold) green + populated the cache; run 3 (warm) green with ccache hits. (Run 2 caught the download flake — hence the best-effort hardening above.)

---
🧊 Warm caches, cold takes — courtesy of Claude Code.
