### PR TITLE
feat: simplify session UI, move diagnostics to a Debug tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ WAIL has two components that work together:
 - **Display name** — Shown to other peers in the session.
 - **Link Audio Name** — The peer name WAIL advertises on Link Audio, so its published channels are easy to spot in your DAW's peer list. Defaults to `WAIL`.
 - **Save debug log locally** — Writes structured logs to a rotating file in the app data directory. Useful for diagnosing connection issues.
-- **Peer log streaming** — When enabled, your app's INFO-level logs are broadcast to all other peers in the session via the signaling server, and their logs are shown in your session log panel with a peer name prefix. Useful for collaborative debugging. Both sending and receiving are controlled by this single toggle.
-- **Remember settings** — Persists room name, password, and display name in localStorage.
+- **Share my debug log with the room** — When enabled, your app's INFO-level logs are broadcast to all other peers in the session via the signaling server, and their logs are shown in your Debug tab's log panel with a peer name prefix. Useful for collaborative debugging. Both sending and receiving are controlled by this single toggle.
+- **Remember settings** — Persists room name, password, and display name in localStorage, plus your enabled capture channels (by app and channel name) so they re-enable automatically in future sessions.
 
 ## Troubleshooting
 
@@ -104,7 +104,7 @@ WAIL has two components that work together:
 
 **Changing tempo mid-jam** — Not recommended. WAIL uses NINJAM-style intervals, so audio is recorded and played back in full interval chunks. If you change the tempo, the current interval must finish before the new tempo takes effect. If you do need to change tempo, agree on it beforehand and have one person change it — Link will propagate it to all peers within a few seconds.
 
-**Debugging what you're sending** — Two live toggles under *Capture channels*: **Dump capture to WAV** writes each enabled channel's audio to pre-Opus and post-Opus WAV files under `~/.wail/dumps` (A/B them to localize where audio degrades). **Loopback my audio via server** asks the relay to echo your own audio back; it reappears one interval late as a `(loopback)` Link Audio channel — subscribe to it in your DAW to hear exactly what remote peers hear, including the full encode → relay → decode round trip.
+**Debugging what you're sending** — Two live toggles on the session's *Debug* tab: **Dump capture to WAV** writes each enabled channel's audio to pre-Opus and post-Opus WAV files under `~/.wail/dumps` (A/B them to localize where audio degrades). **Loopback my audio via server** asks the relay to echo your own audio back; it reappears one interval late as a `(loopback)` Link Audio channel — subscribe to it in your DAW to hear exactly what remote peers hear, including the full encode → relay → decode round trip. The Debug tab also carries audio stats, per-peer relay RTT, local audio-health counters, and the session log.
 
 ## Development
 

--- a/wail-app/app.go
+++ b/wail-app/app.go
@@ -34,6 +34,12 @@ type App struct {
 	dataDir     string
 	fileLog     *RotatingFileWriter
 	wsLog       *WsLogWriter
+	// rememberEnabled mirrors the frontend "Remember settings" checkbox (pushed
+	// via SetRememberEnabled); it gates persisting captureEnabled to disk.
+	rememberEnabled bool
+	// captureEnabled is the remembered set of enabled capture channels, keyed
+	// by (peer, channel) name; restored into each session's audio engine.
+	captureEnabled []CaptureChannelKey
 }
 
 // NewApp creates a new App instance. Pass instance=0 for the default instance.
@@ -47,9 +53,11 @@ func NewApp(instance int) *App {
 	streamNames := LoadStreamNames(dataDir)
 
 	return &App{
-		streamNames: streamNames,
-		dataDir:     dataDir,
-		identity:    identity,
+		streamNames:     streamNames,
+		dataDir:         dataDir,
+		identity:        identity,
+		rememberEnabled: true, // frontend default; corrected on settings load
+		captureEnabled:  LoadCaptureEnabled(dataDir),
 	}
 }
 
@@ -165,17 +173,26 @@ func (a *App) JoinRoom(
 	}
 
 	config := SessionConfig{
-		Server:        signalingURL,
-		Room:          room,
-		Password:      password,
-		DisplayName:   displayName,
-		LinkAudioName: actualLinkAudioName,
-		Identity:      a.identity,
-		BPM:           actualBPM,
-		Bars:          actualBars,
-		Quantum:       actualQuantum,
-		Recording:     recording,
-		StreamCount:   actualStreamCount,
+		Server:         signalingURL,
+		Room:           room,
+		Password:       password,
+		DisplayName:    displayName,
+		LinkAudioName:  actualLinkAudioName,
+		Identity:       a.identity,
+		BPM:            actualBPM,
+		Bars:           actualBars,
+		Quantum:        actualQuantum,
+		Recording:      recording,
+		StreamCount:    actualStreamCount,
+		CaptureRestore: a.captureEnabled,
+		OnCaptureEnabledChanged: func(keys []CaptureChannelKey) {
+			a.mu.Lock()
+			defer a.mu.Unlock()
+			a.captureEnabled = keys
+			if a.rememberEnabled {
+				SaveCaptureEnabled(a.dataDir, keys)
+			}
+		},
 	}
 
 	handle, err := SpawnSession(a.emitter, config)
@@ -303,6 +320,21 @@ func (a *App) GetActiveSession() *JoinResult {
 		return nil
 	}
 	return &JoinResult{PeerID: a.session.PeerID, Room: a.session.Room, BPM: 120.0}
+}
+
+// SetRememberEnabled mirrors the frontend "Remember settings" checkbox. When
+// off, the persisted enabled-capture-channel set is deleted; when on, the
+// current in-memory set is written out.
+func (a *App) SetRememberEnabled(enabled bool) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.rememberEnabled = enabled
+	if enabled {
+		SaveCaptureEnabled(a.dataDir, a.captureEnabled)
+	} else {
+		DeleteCaptureEnabled(a.dataDir)
+	}
+	return nil
 }
 
 // SetTelemetry toggles file logging (telemetry).

--- a/wail-app/audio_engine.go
+++ b/wail-app/audio_engine.go
@@ -32,6 +32,10 @@ type AudioEngine interface {
 	CaptureChannels() []CaptureChannelInfo
 	// SetCaptureEnabled toggles whether a discovered channel is bridged.
 	SetCaptureEnabled(channelID string, on bool)
+	// SetCaptureRestore replaces the remembered set of enabled capture
+	// channels (keyed by peer/channel name, loaded at session start);
+	// matching discovered channels auto-enable.
+	SetCaptureRestore(keys []CaptureChannelKey)
 	// SetCaptureDump toggles a debug dump: while on, each enabled capture channel
 	// writes two WAV files — the PCM fed to Opus and that audio decoded as a
 	// receiver would — for diagnosing where transmitted audio degrades.

--- a/wail-app/audio_engine_real.go
+++ b/wail-app/audio_engine_real.go
@@ -96,6 +96,11 @@ type linkAudioEngine struct {
 	own          *affinity.OwnChannels // our published sinks, for discovery exclusion
 	nextStreamID uint16
 
+	// restore is the remembered set of user-enabled capture channels, keyed by
+	// human-stable (peer, channel) name. A discovered channel matching the set
+	// auto-enables; SetCaptureEnabled keeps it in sync with the user's toggles.
+	restore map[CaptureChannelKey]bool
+
 	cushionFrames int // per-sink feed-ahead (emitCushionMs or WAIL_EMIT_CUSHION_MS)
 }
 
@@ -203,6 +208,7 @@ func newAudioEngine(lb *LinkBridge, peerName string, send func(waif []byte), off
 		capture:  make(map[string]*captureChannel),
 		emit:     make(map[affinity.Key]*emitStream),
 		own:      affinity.NewOwnChannels(),
+		restore:  make(map[CaptureChannelKey]bool),
 
 		cushionFrames: engineCushionFrames(),
 	}
@@ -282,6 +288,12 @@ func (e *linkAudioEngine) CaptureChannels() []CaptureChannelInfo {
 	defer e.mu.Unlock()
 	out := make([]CaptureChannelInfo, 0, len(e.capture))
 	for id, ch := range e.capture {
+		// Defense in depth: own republished channels are excluded at discovery
+		// (reconcileChannels), but never let one reach the GUI even if that
+		// filter leaks — the send-mixer must only show non-WAIL channels.
+		if e.own.Own(id, ch.peerName == e.peerName, ch.name) {
+			continue
+		}
 		out = append(out, CaptureChannelInfo{
 			ChannelID: id, Name: ch.name, PeerName: ch.peerName, Enabled: ch.enabled,
 			StreamID: ch.streamID,
@@ -307,11 +319,45 @@ func (e *linkAudioEngine) SetCaptureEnabled(channelID string, on bool) {
 	if !ok {
 		return
 	}
+	key := CaptureChannelKey{PeerName: ch.peerName, ChannelName: ch.name}
+	if on {
+		e.restore[key] = true
+	} else {
+		delete(e.restore, key)
+	}
 	if on && !ch.enabled {
 		e.startCaptureLocked(ch)
 	} else if !on && ch.enabled {
 		e.stopCaptureLocked(ch)
 	}
+}
+
+// SetCaptureRestore replaces the remembered set of enabled capture channels
+// (loaded from disk at session start). Already-discovered channels matching
+// the set enable immediately; later discoveries are matched in reconcile.
+func (e *linkAudioEngine) SetCaptureRestore(keys []CaptureChannelKey) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.restore = make(map[CaptureChannelKey]bool, len(keys))
+	for _, k := range keys {
+		e.restore[k] = true
+	}
+	for _, ch := range e.capture {
+		if !ch.enabled && e.restore[CaptureChannelKey{PeerName: ch.peerName, ChannelName: ch.name}] {
+			e.startCaptureLocked(ch)
+		}
+	}
+}
+
+// restoreSet returns a copy of the current restore set (for persistence).
+func (e *linkAudioEngine) restoreSet() map[CaptureChannelKey]bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make(map[CaptureChannelKey]bool, len(e.restore))
+	for k := range e.restore {
+		out[k] = true
+	}
+	return out
 }
 
 // SetCaptureDump toggles the debug capture-to-WAV dump (pre-Opus + post-Opus)
@@ -415,10 +461,15 @@ func (e *linkAudioEngine) reconcileChannels(chans []abllink.Channel) {
 		ch, ok := e.capture[id]
 		if !ok {
 			// Register discovered channel as available but disabled; the user
-			// enables it via SetCaptureEnabled (explicit opt-in send-mixer).
+			// enables it via SetCaptureEnabled (explicit opt-in send-mixer) —
+			// unless it matches the remembered set, in which case it starts now.
 			ch = &captureChannel{id: c.ID, name: c.Name, peerName: c.PeerName, streamID: e.nextStreamID}
 			e.nextStreamID++
 			e.capture[id] = ch
+			if e.restore[CaptureChannelKey{PeerName: c.PeerName, ChannelName: c.Name}] {
+				log.Printf("[audio] auto-enabling remembered capture channel %q · %q", c.PeerName, c.Name)
+				e.startCaptureLocked(ch)
+			}
 		} else {
 			ch.name = c.Name
 			ch.peerName = c.PeerName

--- a/wail-app/audio_engine_real_test.go
+++ b/wail-app/audio_engine_real_test.go
@@ -2,7 +2,13 @@
 
 package main
 
-import "testing"
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"github.com/nicholasgasior/wail/wail-app/internal/abllink"
+)
 
 // TestAudioEngineEmitIngestion drives the emit ingestion path end-to-end without
 // the network or the engine goroutines: real WAIF frames (built by the real Opus
@@ -152,5 +158,111 @@ func TestEngineConcealsSeqGapWithPLC(t *testing.T) {
 	}
 	if _, concealed := st.reasm.Missing(5); concealed != 0 {
 		t.Fatalf("concealed = %d, want 0 after real replacement", concealed)
+	}
+}
+
+// --- capture restore: remembering which channels the user enabled ---
+
+// newCaptureTestEngine builds a real engine with a live (offline) Link but
+// without Start()'s discovery/emit loops; drain goroutines get a context so
+// auto-enabled channels are exercisable. Stop runs at cleanup.
+func newCaptureTestEngine(t *testing.T) *linkAudioEngine {
+	t.Helper()
+	eng := newAudioEngine(NewLinkBridge(120, 4), "WAIL", func([]byte) {}, 1)
+	le, ok := eng.(*linkAudioEngine)
+	if !ok {
+		t.Fatalf("expected *linkAudioEngine, got %T", eng)
+	}
+	le.ctx, le.cancel = context.WithCancel(context.Background())
+	t.Cleanup(eng.Stop)
+	return le
+}
+
+func testDiscoveredChannel(idByte byte, peer, name string) abllink.Channel {
+	var id abllink.ChannelID
+	id[0] = idByte
+	return abllink.Channel{ID: id, Name: name, PeerName: peer}
+}
+
+func captureEntry(t *testing.T, le *linkAudioEngine, c abllink.Channel) *captureChannel {
+	t.Helper()
+	id := hex.EncodeToString(c.ID[:])
+	ch, ok := le.capture[id]
+	if !ok {
+		t.Fatalf("channel %q not registered in capture map", c.Name)
+	}
+	return ch
+}
+
+func TestReconcileRegistersDiscoveredChannelDisabled(t *testing.T) {
+	le := newCaptureTestEngine(t)
+	c := testDiscoveredChannel(1, "Live", "Main")
+
+	le.reconcileChannels([]abllink.Channel{c})
+
+	if ch := captureEntry(t, le, c); ch.enabled {
+		t.Fatal("discovered channel must start disabled (explicit opt-in)")
+	}
+}
+
+func TestReconcileAutoEnablesRememberedChannel(t *testing.T) {
+	le := newCaptureTestEngine(t)
+	le.SetCaptureRestore([]CaptureChannelKey{{PeerName: "Live", ChannelName: "Main"}})
+
+	le.reconcileChannels([]abllink.Channel{testDiscoveredChannel(1, "Live", "Main")})
+
+	if ch := captureEntry(t, le, testDiscoveredChannel(1, "Live", "Main")); !ch.enabled {
+		t.Fatal("remembered channel should auto-enable on discovery")
+	}
+}
+
+func TestReconcileDoesNotRestoreNameCollisionFromOtherPeer(t *testing.T) {
+	le := newCaptureTestEngine(t)
+	le.SetCaptureRestore([]CaptureChannelKey{{PeerName: "Live", ChannelName: "Main"}})
+
+	// Same channel name, different publishing app: not the remembered channel.
+	le.reconcileChannels([]abllink.Channel{testDiscoveredChannel(1, "Reaper", "Main")})
+
+	if ch := captureEntry(t, le, testDiscoveredChannel(1, "Reaper", "Main")); ch.enabled {
+		t.Fatal("restore key is (peer, channel): a different peer's same-named channel must not auto-enable")
+	}
+}
+
+func TestSetCaptureEnabledUpdatesRestoreSet(t *testing.T) {
+	le := newCaptureTestEngine(t)
+	c := testDiscoveredChannel(1, "Live", "Main")
+	le.reconcileChannels([]abllink.Channel{c})
+	id := hex.EncodeToString(c.ID[:])
+
+	le.SetCaptureEnabled(id, true)
+	if !le.capture[id].enabled {
+		t.Fatal("SetCaptureEnabled(true) did not enable the channel")
+	}
+	if !le.restoreSet()[CaptureChannelKey{PeerName: "Live", ChannelName: "Main"}] {
+		t.Fatal("enabling a channel must add it to the restore set")
+	}
+
+	le.SetCaptureEnabled(id, false)
+	if le.capture[id].enabled {
+		t.Fatal("SetCaptureEnabled(false) did not disable the channel")
+	}
+	if le.restoreSet()[CaptureChannelKey{PeerName: "Live", ChannelName: "Main"}] {
+		t.Fatal("disabling a channel must remove it from the restore set")
+	}
+}
+
+func TestCaptureChannelsNeverSerializesOwnChannels(t *testing.T) {
+	le := newCaptureTestEngine(t)
+	// Learn a sink name as ours, then place a matching channel in the capture
+	// map directly (as if the reconcile-time Own() filter leaked it through).
+	le.own.Published("WAIL · stream 0")
+	ownCh := testDiscoveredChannel(1, "WAIL", "WAIL · stream 0")
+	otherCh := testDiscoveredChannel(2, "Live", "Main")
+	le.capture[hex.EncodeToString(ownCh.ID[:])] = &captureChannel{id: ownCh.ID, name: ownCh.Name, peerName: ownCh.PeerName}
+	le.capture[hex.EncodeToString(otherCh.ID[:])] = &captureChannel{id: otherCh.ID, name: otherCh.Name, peerName: otherCh.PeerName}
+
+	infos := le.CaptureChannels()
+	if len(infos) != 1 || infos[0].Name != "Main" {
+		t.Fatalf("CaptureChannels must exclude own republished channels, got %+v", infos)
 	}
 }

--- a/wail-app/audio_engine_stub.go
+++ b/wail-app/audio_engine_stub.go
@@ -18,5 +18,6 @@ func (s *stubAudioEngine) SetRoomAnchor(_ int64, _ float64, _ uint32, _ float64)
 func (s *stubAudioEngine) RoomIndex(_ int64) (int64, bool)                       { return 0, false }
 func (s *stubAudioEngine) CaptureChannels() []CaptureChannelInfo                 { return nil }
 func (s *stubAudioEngine) SetCaptureEnabled(_ string, _ bool)                    {}
+func (s *stubAudioEngine) SetCaptureRestore(_ []CaptureChannelKey)               {}
 func (s *stubAudioEngine) SetCaptureDump(_ bool)                                 {}
 func (s *stubAudioEngine) Health() EngineHealth                                  { return EngineHealth{} }

--- a/wail-app/capture_persist.go
+++ b/wail-app/capture_persist.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+const captureEnabledFilename = "capture_enabled.json"
+
+// CaptureChannelKey identifies a local Link Audio channel by its human-stable
+// identity. Channel IDs are minted per publisher lifetime (a DAW restart
+// changes them), so persistence keys on (peer name, channel name) — what a
+// user thinks of as "the same channel".
+type CaptureChannelKey struct {
+	PeerName    string `json:"peer_name"`
+	ChannelName string `json:"channel_name"`
+}
+
+// LoadCaptureEnabled loads the remembered set of enabled capture channels.
+// Returns nil on any failure (missing file, corrupt JSON).
+func LoadCaptureEnabled(dataDir string) []CaptureChannelKey {
+	path := filepath.Join(dataDir, captureEnabledFilename)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var keys []CaptureChannelKey
+	if err := json.Unmarshal(data, &keys); err != nil {
+		log.Printf("[capture] Failed to parse %s: %v", captureEnabledFilename, err)
+		return nil
+	}
+	if len(keys) > 0 {
+		log.Printf("[capture] Loaded %d remembered capture channels", len(keys))
+	}
+	return keys
+}
+
+// SaveCaptureEnabled persists the set of enabled capture channels.
+// Logs on failure, never panics.
+func SaveCaptureEnabled(dataDir string, keys []CaptureChannelKey) {
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		log.Printf("[capture] Failed to create data dir: %v", err)
+		return
+	}
+	data, err := json.MarshalIndent(keys, "", "  ")
+	if err != nil {
+		log.Printf("[capture] Failed to serialize: %v", err)
+		return
+	}
+	path := filepath.Join(dataDir, captureEnabledFilename)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		log.Printf("[capture] Failed to write %s: %v", captureEnabledFilename, err)
+	}
+}
+
+// DeleteCaptureEnabled removes the persisted set (when "Remember settings" is
+// turned off). A missing file is not an error.
+func DeleteCaptureEnabled(dataDir string) {
+	path := filepath.Join(dataDir, captureEnabledFilename)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		log.Printf("[capture] Failed to delete %s: %v", captureEnabledFilename, err)
+	}
+}

--- a/wail-app/capture_persist_test.go
+++ b/wail-app/capture_persist_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadCaptureEnabledEmptyDirReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	keys := LoadCaptureEnabled(dir)
+	if len(keys) != 0 {
+		t.Fatalf("expected empty, got %d", len(keys))
+	}
+}
+
+func TestCaptureEnabledSaveAndLoadRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	keys := []CaptureChannelKey{
+		{PeerName: "Live", ChannelName: "Main"},
+		{PeerName: "Live", ChannelName: "Synth Bus"},
+		{PeerName: "Reaper", ChannelName: "Drums"},
+	}
+
+	SaveCaptureEnabled(dir, keys)
+	loaded := LoadCaptureEnabled(dir)
+
+	if len(loaded) != len(keys) {
+		t.Fatalf("expected %d keys, got %d", len(keys), len(loaded))
+	}
+	got := make(map[CaptureChannelKey]bool, len(loaded))
+	for _, k := range loaded {
+		got[k] = true
+	}
+	for _, k := range keys {
+		if !got[k] {
+			t.Fatalf("missing key after roundtrip: %+v (got %v)", k, loaded)
+		}
+	}
+}
+
+func TestCaptureEnabledSaveEmptyOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	SaveCaptureEnabled(dir, []CaptureChannelKey{{PeerName: "Live", ChannelName: "Main"}})
+
+	SaveCaptureEnabled(dir, nil)
+	loaded := LoadCaptureEnabled(dir)
+	if len(loaded) != 0 {
+		t.Fatalf("expected empty after overwrite, got %d", len(loaded))
+	}
+}
+
+func TestLoadCaptureEnabledInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, captureEnabledFilename), []byte("not json"), 0o644)
+	keys := LoadCaptureEnabled(dir)
+	if len(keys) != 0 {
+		t.Fatal("expected empty for invalid JSON")
+	}
+}
+
+func TestDeleteCaptureEnabled(t *testing.T) {
+	dir := t.TempDir()
+	SaveCaptureEnabled(dir, []CaptureChannelKey{{PeerName: "Live", ChannelName: "Main"}})
+
+	DeleteCaptureEnabled(dir)
+	if _, err := os.Stat(filepath.Join(dir, captureEnabledFilename)); !os.IsNotExist(err) {
+		t.Fatalf("expected file removed, stat err = %v", err)
+	}
+	// Deleting a missing file is not an error.
+	DeleteCaptureEnabled(dir)
+}

--- a/wail-app/frontend/index.html
+++ b/wail-app/frontend/index.html
@@ -109,6 +109,7 @@
         <img src="logo.png" alt="" class="header-logo header-logo-sm">
         <h2>WAIL</h2>
         <span id="session-room" class="room-badge"></span>
+        <span id="peer-count" class="log-badge" title="Room peers sending / connected">0/0</span>
         <span id="link-clock" class="link-clock" title="Interval progress" style="display:none"></span>
       </div>
       <button type="button" id="session-settings-btn" class="icon-btn" title="Settings">&#9881;</button>
@@ -117,19 +118,11 @@
     <div class="tab-bar">
       <button type="button" class="tab active" id="session-tab-session">Session</button>
       <button type="button" class="tab" id="session-tab-chat">Chat</button>
-      <button type="button" class="tab" id="session-tab-logs">Logs <span id="log-count" class="log-badge">0</span></button>
-      <button type="button" class="tab" id="session-tab-network">Peers <span id="peer-count" class="log-badge">0/0</span></button>
+      <button type="button" class="tab" id="session-tab-debug">Debug <span id="log-count" class="log-badge">0</span></button>
     </div>
 
     <!-- Session tab -->
     <div id="session-tab-session-content">
-      <!-- In-app senders only (test tone / WAV). Remote peers and their sent
-           channels live on the Peers tab. Shown only while you're sending. -->
-      <section class="session-section" id="sends-section" style="display:none">
-        <h3 class="section-label">Your Sends</h3>
-        <div id="peer-list" class="peer-list"></div>
-      </section>
-
       <div id="link-no-peers-warning" class="warning" style="display:none">
         Start Ableton Link in your DAW — audio is not being transmitted
       </div>
@@ -152,15 +145,6 @@
             <label>Link Peers</label>
             <span class="status-value" id="session-link-peers">0</span>
           </div>
-          <div class="status-cell">
-            <label>Link Audio</label>
-            <span class="status-value" id="session-plugin">on</span>
-          </div>
-          <div class="status-cell">
-            <label>Audio <button type="button" id="stats-mode-btn" class="stats-mode-toggle">all time</button></label>
-            <span class="status-value" id="session-audio">0 / 0</span>
-            <span id="session-audio-bytes" class="audio-bytes">0 B / 0 B</span>
-          </div>
           <div class="status-cell" id="recording-stat" style="display:none">
             <label>Recording</label>
             <div class="recording-row">
@@ -176,16 +160,15 @@
           <div id="capture-channels" class="capture-channels">
             <span class="empty">No local Link Audio channels discovered</span>
           </div>
-          <!-- Debug: dump each enabled channel's audio pre- and post-Opus to WAV -->
-          <label class="capture-dump" title="Writes pre-Opus and post-Opus WAV files under ~/.wail/dumps for debugging; path is shown in the log.">
-            <input type="checkbox" id="capture-dump-toggle">
-            <span>Dump capture to WAV (debug)</span>
-          </label>
-          <!-- Debug: relay echoes our own audio back; republished as a "(loopback)" Link Audio channel -->
-          <label class="capture-dump" title="The relay echoes your own audio back to you. It reappears one interval late as a '(loopback)' Link Audio channel — subscribe to it in your DAW to hear exactly what peers hear.">
-            <input type="checkbox" id="loopback-toggle">
-            <span>Loopback my audio via server (debug)</span>
-          </label>
+        </div>
+      </section>
+
+      <!-- Unified peers tree: your sends (enabled capture channels + in-app
+           senders) as the "you" node, remote peers with their channels below. -->
+      <section class="session-section">
+        <h3 class="section-label">Peers</h3>
+        <div id="peer-tree" class="peer-tree">
+          <span class="empty">No peers connected</span>
         </div>
       </section>
 
@@ -200,22 +183,55 @@
       </div>
     </div>
 
-    <!-- Peers tab: tree of remote peers with the channels each is sending -->
-    <div id="session-tab-network-content" style="display:none">
-      <div id="peer-tree" class="peer-tree">
-        <span class="empty">No peers connected</span>
-      </div>
+    <!-- Debug tab: diagnostics and debug controls, out of the common path -->
+    <div id="session-tab-debug-content" style="display:none">
+      <section class="session-section">
+        <h3 class="section-label">About</h3>
+        <div class="debug-about">WAIL <span class="version" id="debug-version"></span></div>
+      </section>
+
+      <section class="session-section">
+        <h3 class="section-label">Capture debug</h3>
+        <!-- Dump each enabled channel's audio pre- and post-Opus to WAV -->
+        <label class="capture-dump" title="Writes pre-Opus and post-Opus WAV files under ~/.wail/dumps for debugging; path is shown in the log.">
+          <input type="checkbox" id="capture-dump-toggle">
+          <span>Dump capture to WAV</span>
+        </label>
+        <!-- Relay echoes our own audio back; republished as a "(loopback)" Link Audio channel -->
+        <label class="capture-dump" title="The relay echoes your own audio back to you. It reappears one interval late as a '(loopback)' Link Audio channel — subscribe to it in your DAW to hear exactly what peers hear.">
+          <input type="checkbox" id="loopback-toggle">
+          <span>Loopback my audio via server</span>
+        </label>
+      </section>
+
+      <section class="session-section">
+        <h3 class="section-label">Audio stats <button type="button" id="stats-mode-btn" class="stats-mode-toggle">all time</button></h3>
+        <div class="debug-stats">
+          <div class="health-row"><span>Intervals sent / received</span><span id="session-audio">0 / 0</span></div>
+          <div class="health-row"><span>Audio bytes sent / received</span><span id="session-audio-bytes">0 B / 0 B</span></div>
+        </div>
+      </section>
+
+      <!-- Per-peer relay round-trip times -->
+      <section class="session-section">
+        <h3 class="section-label">Peers detail</h3>
+        <div id="peer-detail">
+          <span class="empty">No peers connected</span>
+        </div>
+      </section>
 
       <!-- Local audio-path health counters (each increment ≈ one audible-risk event) -->
-      <h3 class="section-label network-health-label">Local audio health</h3>
-      <div id="network-health" class="network-health">
-        <span class="empty">No diagnostics yet</span>
-      </div>
-    </div>
+      <section class="session-section">
+        <h3 class="section-label">Local audio health</h3>
+        <div id="network-health" class="network-health">
+          <span class="empty">No diagnostics yet</span>
+        </div>
+      </section>
 
-    <!-- Logs tab -->
-    <div id="session-tab-logs-content" style="display:none">
-      <div id="log-list" class="log-list"></div>
+      <section class="session-section">
+        <h3 class="section-label">Logs</h3>
+        <div id="log-list" class="log-list"></div>
+      </section>
     </div>
 
     <button type="button" id="disconnect-btn">Disconnect</button>
@@ -259,7 +275,7 @@
 
         <div class="remember-row">
           <input type="checkbox" id="settings-log-sharing">
-          <label for="settings-log-sharing" class="remember-label">Peer log streaming (share &amp; view live logs in session)</label>
+          <label for="settings-log-sharing" class="remember-label">Share my debug log with the room</label>
         </div>
 
         <div class="remember-row">

--- a/wail-app/frontend/main.js
+++ b/wail-app/frontend/main.js
@@ -521,9 +521,10 @@ document.getElementById('browse-recording-dir').addEventListener('click', async 
   }
 });
 
-// Sync telemetry and log sharing state on load
+// Sync telemetry, log sharing, and remember-settings state on load
 invoke('set_telemetry', { enabled: getTelemetryEnabled() }).catch(() => {});
 invoke('set_log_sharing', { enabled: getLogSharingEnabled() }).catch(() => {});
+invoke('set_remember_enabled', { enabled: getRememberEnabled() }).catch(() => {});
 
 // Populate default recording dir on load
 invoke('get_default_recording_dir').then(dir => {
@@ -580,6 +581,7 @@ settingsForm.addEventListener('submit', (e) => {
   // Save remember setting
   const rememberEnabled = settingsRememberCheckbox.checked;
   saveRememberEnabled(rememberEnabled);
+  invoke('set_remember_enabled', { enabled: rememberEnabled }).catch(() => {});
   if (rememberEnabled) {
     saveSettings();
   } else {

--- a/wail-app/frontend/main.js
+++ b/wail-app/frontend/main.js
@@ -1019,7 +1019,7 @@ function renderPeerNode(n) {
   const chans = n.channels.slice().sort((a, b) => a.channel_index - b.channel_index);
   const channelsHtml = chans.length
     ? chans.map(c => {
-        const label = c.stream_name ? escapeHtml(c.stream_name) : `Channel ${c.channel_index}`;
+        const label = c.stream_name ? escapeHtml(c.stream_name) : `stream ${c.channel_index}`;
         return `<div class="peer-channel"><span class="channel-name">${label}</span></div>`;
       }).join('')
     : '<div class="peer-channel peer-channel--none"><span class="channel-name">no channels</span></div>';

--- a/wail-app/frontend/main.js
+++ b/wail-app/frontend/main.js
@@ -27,9 +27,10 @@ const chatInput = document.getElementById('chat-input');
 const chatSendBtn = document.getElementById('chat-send-btn');
 const chatMessages = document.getElementById('chat-messages');
 
-// Version label
+// Version labels (join screen header + Debug tab About)
 window.__TAURI__.app.getVersion().then(v => {
   document.getElementById('version-label').textContent = 'v' + v;
+  document.getElementById('debug-version').textContent = 'v' + v;
 });
 
 // Capture send-mixer: render discovered local Link Audio channels as checkboxes.
@@ -593,18 +594,15 @@ settingsForm.addEventListener('submit', (e) => {
 // --- Session screen tab switching ---
 const sessionTabSessionBtn = document.getElementById('session-tab-session');
 const sessionTabChatBtn = document.getElementById('session-tab-chat');
-const sessionTabLogsBtn = document.getElementById('session-tab-logs');
-const sessionTabNetworkBtn = document.getElementById('session-tab-network');
+const sessionTabDebugBtn = document.getElementById('session-tab-debug');
 const sessionTabSessionContent = document.getElementById('session-tab-session-content');
 const sessionTabChatContent = document.getElementById('session-tab-chat-content');
-const sessionTabLogsContent = document.getElementById('session-tab-logs-content');
-const sessionTabNetworkContent = document.getElementById('session-tab-network-content');
+const sessionTabDebugContent = document.getElementById('session-tab-debug-content');
 
 const SESSION_TABS = [
   { btn: sessionTabSessionBtn, content: sessionTabSessionContent },
   { btn: sessionTabChatBtn,    content: sessionTabChatContent },
-  { btn: sessionTabLogsBtn,    content: sessionTabLogsContent },
-  { btn: sessionTabNetworkBtn, content: sessionTabNetworkContent },
+  { btn: sessionTabDebugBtn,   content: sessionTabDebugContent },
 ];
 
 function switchSessionTab(activeBtn) {
@@ -616,8 +614,7 @@ function switchSessionTab(activeBtn) {
 
 sessionTabSessionBtn.addEventListener('click', () => switchSessionTab(sessionTabSessionBtn));
 sessionTabChatBtn.addEventListener('click', () => switchSessionTab(sessionTabChatBtn));
-sessionTabLogsBtn.addEventListener('click', () => switchSessionTab(sessionTabLogsBtn));
-sessionTabNetworkBtn.addEventListener('click', () => switchSessionTab(sessionTabNetworkBtn));
+sessionTabDebugBtn.addEventListener('click', () => switchSessionTab(sessionTabDebugBtn));
 
 function resetStatsWindow() {
   statusSnapshots = [];
@@ -649,16 +646,13 @@ function showSession(room) {
   clearLog();
   clearChatMessages();
   document.getElementById('session-room').textContent = room;
-  document.getElementById('sends-section').style.display = 'none';
-  document.getElementById('peer-list').innerHTML = '';
   document.getElementById('peer-tree').innerHTML = '<span class="empty">No peers connected</span>';
+  document.getElementById('peer-detail').innerHTML = '<span class="empty">No peers connected</span>';
   const peerCount = document.getElementById('peer-count');
   peerCount.textContent = '0/0';
   peerCount.className = 'log-badge';
   document.getElementById('session-audio').textContent = '0 / 0';
   document.getElementById('session-audio-bytes').textContent = '0 B / 0 B';
-  document.getElementById('session-plugin').textContent = 'disconnected';
-  document.getElementById('session-plugin').className = 'status-value';
   document.getElementById('session-link-peers').textContent = '0';
   hideClock(); // stays hidden until the first status:update seeds it
   document.getElementById('session-bpi').value = '';
@@ -831,13 +825,9 @@ function renderStatus(s) {
   document.getElementById('session-interval-bars').textContent =
     `(${s.interval_bars} bar${s.interval_bars !== 1 ? 's' : ''})`;
 
-  // Link Audio engine status: show how many local channels are bridged.
-  const captureChannels = s.capture_channels || [];
-  const bridged = captureChannels.filter(c => c.enabled).length;
-  document.getElementById('session-plugin').textContent =
-    bridged > 0 ? `on (${bridged} ch)` : 'on';
-  document.getElementById('session-plugin').className = 'status-value connected';
-  renderCaptureMixer(captureChannels);
+  // Capture send-mixer: discovered local Link Audio channels (own republished
+  // channels never reach this list — the engine excludes them).
+  renderCaptureMixer(s.capture_channels || []);
 
   // Update recording status
   if (s.recording) {
@@ -846,31 +836,8 @@ function renderStatus(s) {
     document.getElementById('recording-size').textContent = `${mb} MB`;
   }
 
-  // "Your Sends": in-app senders (test tone / WAV) only. Remote peers and the
-  // channels they send live on the Peers tab. The section stays hidden unless
-  // you're actually sending, and a status tick never clobbers an edit-in-progress.
-  const localSends = (s.local_sends || []);
-  document.getElementById('sends-section').style.display = localSends.length ? '' : 'none';
-  const slotList = document.getElementById('peer-list');
-  if (localSends.length && slotList.querySelector('.stream-name-input') == null) {
-    slotList.innerHTML = localSends.map(ls => {
-      const label = ls.stream_name
-        ? escapeHtml(ls.stream_name)
-        : (localSends.length > 1 ? `My Send (stream ${ls.stream_index})` : 'My Send');
-      const sendClass = ls.is_sending ? 'peer-status status-connected' : 'peer-status';
-      const sendLabel = ls.is_sending ? 'sending' : 'idle';
-      return `<div class="peer-item peer-item--local">
-        <span class="peer-slot">Send</span><span class="peer-name editable" data-stream-index="${ls.stream_index}">${label}</span>
-        <span class="${sendClass}">${sendLabel}</span>
-        <span class="peer-rtt"></span>
-      </div>`;
-    }).join('');
-    slotList.querySelectorAll('.peer-name.editable').forEach(span => {
-      span.addEventListener('click', startStreamNameEdit);
-    });
-  }
-
   renderPeerTree(s);
+  renderPeerDetail(s);
 }
 
 // --- Interval clock (Ableton Link) ---
@@ -962,15 +929,21 @@ function renderHealth(health) {
   }).join('');
 }
 
-// Peers tab: a tree of remote peers with the Link Audio channels each is
-// sending nested beneath. Built from the status:update payload — peers carry
-// the roster (and the denominator), slots carry each peer's channels. A peer
-// counts as "sending" when we're presently receiving its audio (is_receiving).
+// Unified peers tree (Session tab): a "you" node carrying your sends —
+// enabled capture channels and in-app senders (test tone / WAV), names
+// click-to-rename — above the remote peer nodes with their channels nested
+// beneath. Built from the status:update payload: local_sends carries your
+// sends with effective names, peers carry the roster, slots carry each
+// remote peer's channels. A peer counts as "sending" when we're presently
+// receiving its audio (is_receiving). A status tick never clobbers a
+// rename-in-progress.
 function renderPeerTree(s) {
   const treeEl = document.getElementById('peer-tree');
   const badge = document.getElementById('peer-count');
   const peers = s.peers || [];
   const slots = s.slots || [];
+
+  if (treeEl.querySelector('.stream-name-input')) return; // rename in progress
 
   // Group channels under their peer. peer_id ties a slot to a roster entry;
   // slots whose peer has dropped (id empty / not in the roster) are shown as
@@ -985,7 +958,6 @@ function renderPeerTree(s) {
   const nodes = peers.map(p => ({
     name: p.display_name || p.peer_id.slice(0, 8),
     status: p.status || 'connecting',
-    rtt: p.rtt_ms,
     sending: !!p.is_receiving,
     channels: channelsByPeer.get(p.peer_id) || [],
   }));
@@ -995,7 +967,6 @@ function renderPeerTree(s) {
     nodes.push({
       name: chans[0].display_name || chans[0].short_id || key,
       status: 'reconnecting',
-      rtt: chans[0].rtt_ms,
       sending: chans.some(c => c.is_receiving),
       channels: chans,
     });
@@ -1007,17 +978,47 @@ function renderPeerTree(s) {
   badge.textContent = `${sending}/${peers.length}`;
   badge.className = 'log-badge' + (sending > 0 ? ' has-activity' : '');
 
-  if (nodes.length === 0) {
+  const youHtml = renderYouNode(s.local_sends || []);
+  if (nodes.length === 0 && !youHtml) {
     treeEl.innerHTML = '<span class="empty">No peers connected</span>';
     return;
   }
-  treeEl.innerHTML = nodes.map(renderPeerNode).join('');
+  treeEl.innerHTML = youHtml + nodes.map(renderPeerNode).join('');
+  treeEl.querySelectorAll('.peer-name.editable').forEach(span => {
+    span.addEventListener('click', startStreamNameEdit);
+  });
+}
+
+// The "you" node: one row per active send (enabled capture channel or in-app
+// sender). Empty when you're sending nothing — the node then disappears and
+// only remote peers show.
+function renderYouNode(localSends) {
+  if (localSends.length === 0) return '';
+  const anySending = localSends.some(ls => ls.is_sending);
+  const rows = localSends
+    .slice()
+    .sort((a, b) => a.stream_index - b.stream_index)
+    .map(ls => {
+      const label = ls.stream_name
+        ? escapeHtml(ls.stream_name)
+        : (localSends.length > 1 ? `My Send (stream ${ls.stream_index})` : 'My Send');
+      return `<div class="peer-channel"><span class="channel-name peer-name editable" data-stream-index="${ls.stream_index}">${label}</span></div>`;
+    }).join('');
+  const statusClass = anySending ? 'status-receiving' : 'status-connected';
+  const tag = anySending ? 'sending' : 'idle';
+  return `<div class="peer-node peer-node--you">
+    <div class="peer-node-head">
+      <span class="peer-dot ${statusClass}"></span>
+      <span class="peer-name">You</span>
+      <span class="peer-status ${statusClass}">${tag}</span>
+    </div>
+    <div class="peer-channels">${rows}</div>
+  </div>`;
 }
 
 function renderPeerNode(n) {
   const statusClass = n.sending ? 'status-receiving' : `status-${n.status}`;
   const tag = n.sending ? 'sending' : (n.status === 'connected' ? 'idle' : n.status);
-  const rtt = n.rtt != null ? `${n.rtt.toFixed(0)}ms` : '';
   const chans = n.channels.slice().sort((a, b) => a.channel_index - b.channel_index);
   const channelsHtml = chans.length
     ? chans.map(c => {
@@ -1030,10 +1031,26 @@ function renderPeerNode(n) {
       <span class="peer-dot ${statusClass}"></span>
       <span class="peer-name">${escapeHtml(n.name)}</span>
       <span class="peer-status ${statusClass}">${escapeHtml(tag)}</span>
-      <span class="peer-rtt">${rtt}</span>
     </div>
     <div class="peer-channels">${channelsHtml}</div>
   </div>`;
+}
+
+// Debug tab: per-peer relay round-trip times (drives clock sync; not shown in
+// the common path — it changes nothing a musician would do mid-jam).
+function renderPeerDetail(s) {
+  const el = document.getElementById('peer-detail');
+  const peers = s.peers || [];
+  if (peers.length === 0) {
+    el.innerHTML = '<span class="empty">No peers connected</span>';
+    return;
+  }
+  el.innerHTML = peers.map(p => {
+    const name = p.display_name || p.peer_id.slice(0, 8);
+    const rtt = p.rtt_ms != null ? `${p.rtt_ms.toFixed(0)}ms` : '—';
+    const state = p.is_receiving ? 'sending' : (p.status || 'connecting');
+    return `<div class="health-row"><span>${escapeHtml(name)}</span><span>${rtt} · ${escapeHtml(state)}</span></div>`;
+  }).join('');
 }
 
 // --- Event Listeners ---

--- a/wail-app/frontend/style.css
+++ b/wail-app/frontend/style.css
@@ -654,39 +654,7 @@ summary:hover {
   font-size: 11px;
 }
 
-/* --- Peer list --- */
-.peer-list {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  padding: 4px 0;
-}
-
-.peer-list .empty {
-  color: var(--fg-dim);
-  font-size: 12px;
-  padding: 4px 0;
-}
-
-.peer-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 6px 10px;
-  background: var(--bg-card);
-  border-radius: 6px;
-  transition: background var(--transition);
-}
-
-.peer-item:hover {
-  background: var(--bg-hover);
-}
-
-.peer-item--local {
-  border-left: 2px solid #88aaff;
-  opacity: 0.9;
-}
-
+/* --- Peer tree (unified: "you" node + remote peers) --- */
 .peer-name {
   font-weight: 600;
   font-size: 12px;
@@ -713,19 +681,6 @@ summary:hover {
   padding: 1px 4px;
   outline: none;
   font-family: inherit;
-}
-
-.peer-slot {
-  font-size: 10px;
-  color: var(--fg-muted);
-  font-family: var(--font-mono);
-  margin-right: 8px;
-}
-
-.peer-rtt {
-  color: var(--fg-dim);
-  font-size: 11px;
-  font-family: var(--font-mono);
 }
 
 .peer-status {
@@ -767,13 +722,6 @@ summary:hover {
   background: rgba(52, 211, 153, 0.2);
 }
 
-/* --- Audio bytes --- */
-.audio-bytes {
-  color: var(--fg-dim);
-  font-size: 11px;
-  font-family: var(--font-mono);
-}
-
 /* --- Disconnect --- */
 #disconnect-btn {
   background: transparent;
@@ -788,9 +736,9 @@ summary:hover {
   border-color: var(--state-error);
 }
 
-/* --- Session tab content --- */
+/* --- Session/Debug tab content --- */
 #session-tab-session-content,
-#session-tab-network-content {
+#session-tab-debug-content {
   flex: 1;
   overflow-y: auto;
   min-height: 0;
@@ -818,6 +766,21 @@ summary:hover {
   background: var(--bg-card);
   border-radius: 6px;
   padding: 6px 10px;
+}
+
+.peer-node--you {
+  border-left: 2px solid var(--accent);
+}
+
+/* --- Debug tab --- */
+.debug-about {
+  color: var(--fg-dim);
+  font-size: 12px;
+  padding: 3px 6px;
+}
+
+#session-tab-debug-content .session-section {
+  margin-bottom: 14px;
 }
 
 .peer-node-head {
@@ -878,11 +841,7 @@ summary:hover {
   font-family: var(--font-mono);
 }
 
-/* Local audio health (Network tab): one row per engine diagnostic counter */
-.network-health-label {
-  margin-top: 16px;
-}
-
+/* Local audio health (Debug tab): one row per engine diagnostic counter */
 .network-health {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -890,18 +849,18 @@ summary:hover {
   font-size: 12px;
 }
 
-.network-health .health-row {
+.health-row {
   display: flex;
   justify-content: space-between;
   padding: 3px 6px;
   border-radius: 4px;
 }
 
-.network-health .health-row:hover {
+.health-row:hover {
   background: rgba(255, 255, 255, 0.04);
 }
 
-.network-health .health-row span:last-child {
+.health-row span:last-child {
   font-family: var(--font-mono);
 }
 
@@ -928,15 +887,8 @@ summary:hover {
   color: var(--state-error);
 }
 
-#session-tab-logs-content {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-height: 0;
-}
-
 .log-list {
-  flex: 1;
+  max-height: 220px;
   overflow-y: auto;
   padding-top: 4px;
 }

--- a/wail-app/session.go
+++ b/wail-app/session.go
@@ -33,6 +33,12 @@ type SessionConfig struct {
 	Quantum       float64
 	Recording     *RecordingConfig
 	StreamCount   uint16
+	// CaptureRestore is the remembered set of enabled capture channels (keyed
+	// by peer/channel name), restored into the audio engine at session start.
+	CaptureRestore []CaptureChannelKey
+	// OnCaptureEnabledChanged fires after a user capture-toggle with the full
+	// enabled set, so the app can persist it (gated on "Remember settings").
+	OnCaptureEnabledChanged func([]CaptureChannelKey)
 }
 
 // SessionCommand represents commands from the UI to the session.
@@ -158,6 +164,7 @@ func sessionLoop(
 	// (audio_engine_real.go), so the engine uses it end to end; it is separate
 	// from the room display name.
 	audioEngine := newAudioEngine(link, config.LinkAudioName, engineSend, offsetD)
+	audioEngine.SetCaptureRestore(config.CaptureRestore)
 	if err := audioEngine.Start(); err != nil {
 		logWarn("Link Audio engine failed to start: %v", err)
 	}
@@ -446,6 +453,15 @@ func sessionLoop(
 			case "SetCaptureEnabled":
 				audioEngine.SetCaptureEnabled(cmd.ChannelID, cmd.Enabled)
 				logInfo("[capture] channel %s enabled=%v", cmd.ChannelID, cmd.Enabled)
+				if config.OnCaptureEnabledChanged != nil {
+					var keys []CaptureChannelKey
+					for _, cc := range audioEngine.CaptureChannels() {
+						if cc.Enabled {
+							keys = append(keys, CaptureChannelKey{PeerName: cc.PeerName, ChannelName: cc.Name})
+						}
+					}
+					config.OnCaptureEnabledChanged(keys)
+				}
 				syncStreamNames()
 			case "SetCaptureDump":
 				audioEngine.SetCaptureDump(cmd.Enabled)

--- a/wail-app/session.go
+++ b/wail-app/session.go
@@ -956,8 +956,13 @@ func sessionLoop(
 				})
 			}
 
-			// Build local sends
-			localSends := make([]LocalSendInfo, 0, len(localSendStreams))
+			// Build local sends: in-app senders (test tone / WAV) plus every
+			// enabled capture channel — the unified peers tree renders both in
+			// its "you" node. Capture sends carry their effective (override-aware)
+			// names so the tree matches what receivers see.
+			captureInfos := audioEngine.CaptureChannels()
+			effNames := effectiveStreamNames(captureInfos, localStreamNames)
+			localSends := make([]LocalSendInfo, 0, len(localSendStreams)+len(captureInfos))
 			for streamIdx := range localSendStreams {
 				var sn *string
 				if n, ok := localStreamNames[streamIdx]; ok {
@@ -967,6 +972,17 @@ func sessionLoop(
 					StreamIndex: streamIdx,
 					IsSending:   localSendActive[streamIdx],
 					StreamName:  sn,
+				})
+			}
+			for _, cc := range captureInfos {
+				if !cc.Enabled {
+					continue
+				}
+				n := effNames[cc.StreamID]
+				localSends = append(localSends, LocalSendInfo{
+					StreamIndex: cc.StreamID,
+					IsSending:   true, // enabled = bridged = sending
+					StreamName:  &n,
 				})
 			}
 			sort.Slice(localSends, func(i, j int) bool { return localSends[i].StreamIndex < localSends[j].StreamIndex })

--- a/wail-app/stream_names.go
+++ b/wail-app/stream_names.go
@@ -39,13 +39,19 @@ func LoadStreamNames(dataDir string) map[uint16]string {
 
 // effectiveStreamNames is the map receivers should label our streams with:
 // each enabled capture channel defaults to its discovered Link Audio channel
-// name, overridden by any user-set names (which also carry the test tone /
-// WAV sender labels). Broadcast via the StreamNames sync whenever it changes.
+// name (falling back to "stream N" when the channel is nameless, so receivers
+// never render an unnamed stream), overridden by any user-set names (which
+// also carry the test tone / WAV sender labels). Broadcast via the StreamNames
+// sync whenever it changes.
 func effectiveStreamNames(captureChannels []CaptureChannelInfo, overrides map[uint16]string) map[uint16]string {
 	eff := make(map[uint16]string, len(captureChannels)+len(overrides))
 	for _, cc := range captureChannels {
-		if cc.Enabled && cc.Name != "" {
-			eff[cc.StreamID] = cc.Name
+		if cc.Enabled {
+			name := cc.Name
+			if name == "" {
+				name = fmt.Sprintf("stream %d", cc.StreamID)
+			}
+			eff[cc.StreamID] = name
 		}
 	}
 	for k, v := range overrides {

--- a/wail-app/stream_names_test.go
+++ b/wail-app/stream_names_test.go
@@ -56,7 +56,7 @@ func TestEffectiveStreamNamesDefaultsAndOverrides(t *testing.T) {
 		{StreamID: 0, Name: "Synth Bus", Enabled: true},
 		{StreamID: 1, Name: "Drums", Enabled: true},
 		{StreamID: 2, Name: "Disabled Channel", Enabled: false}, // not sending: no name
-		{StreamID: 3, Name: "", Enabled: true},                  // nameless: no default
+		{StreamID: 3, Name: "", Enabled: true},                  // nameless: falls back to "stream N"
 	}
 	overrides := map[uint16]string{
 		1: "My Custom Drums", // user rename wins over the channel name
@@ -66,6 +66,7 @@ func TestEffectiveStreamNamesDefaultsAndOverrides(t *testing.T) {
 	want := map[uint16]string{
 		0: "Synth Bus",
 		1: "My Custom Drums",
+		3: "stream 3",
 		7: "Test Tone",
 	}
 	if !maps.Equal(got, want) {


### PR DESCRIPTION
## Summary

GUI cleanup focused on keeping the common path simple — diagnostics and debug controls move out of the main flow onto a new **Debug** tab.

### Session tab (Session / Chat / Debug now)
- **Unified Peers section**: a "you" node (enabled capture channels + in-app sends, click-to-rename stream names) above the remote peer tree — replaces the separate *Your Sends* section and the old Peers tab.
- **Status grid** pruned to BPM / Interval / Link Peers / Recording — drops the always-on "Link Audio" cell and the packet/byte counters.
- **Peer-count badge** moves to the session header.
- **Per-peer RTT leaves the common path** (it drives clock sync but changes nothing a musician would do mid-jam).

### Debug tab (was Peers tab)
About/version · capture-dump + loopback toggles · audio stats · per-peer relay RTT · local audio health · session log (folding in the old Logs tab).

### Fixes riding along
- **Remember enabled capture channels across sessions.** Checkboxes reset on every join because the engine wiped its capture map at session stop. Persistence keys on the human-stable `(peer name, channel name)` pair (channel IDs are reminted per DAW lifetime) in `~/.wail/capture_enabled.json`; matches auto-enable on discovery. Gated on "Remember settings" (new `set_remember_enabled` binding); turning it off deletes the file.
- **No more "Channel 0" in the peer tree.** Senders always broadcast a stream name (falling back to `stream N` for nameless channels); receiver fallback matches.
- **Hardening**: WAIL's own republished channels are never serialized into `capture_channels` status, so the send-mixer can't render them even if discovery-time classification leaks one through.

## Testing
- `go test ./...` and `go test -tags linkstub ./...` green (9 new tests: capture persistence roundtrip/delete, restore auto-enable, peer-name collision, restore-set sync, own-channel exclusion, stream-name fallback)
- `node --check` on main.js; all JS-referenced element ids verified present in the HTML
- Not yet eyeballed in a running app — worth a quick `wails dev` pass on the Session/Debug tab layouts