### PR TITLE
fix: enable MSVC C11 atomics for CLAP bridge plugin builds

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -20,6 +20,13 @@ function(add_wail_plugin name src)
   add_library(${name} MODULE "${src}")
   target_include_directories(${name} PRIVATE "${CLAP_INCLUDE}" "${CMAKE_CURRENT_SOURCE_DIR}")
   target_link_libraries(${name} PRIVATE Threads::Threads)
+  if(MSVC)
+    # MSVC has no C11 atomics by default (even current VS2022): /std:c11 alone
+    # makes vcruntime_c11_stdatomic.h #error "C atomic support is not enabled".
+    # The plugins only use lock-free atomics (bool/int/u32/u64), which the
+    # experimental flag covers.
+    target_compile_options(${name} PRIVATE /std:c11 /experimental:c11atomics)
+  endif()
   if(WIN32)
     target_link_libraries(${name} PRIVATE ws2_32)
     set_target_properties(${name} PROPERTIES PREFIX "" SUFFIX ".clap")


### PR DESCRIPTION
## Why

The v3.9.0 release run failed on `build-windows` at the **Build & stage CLAP plugins** step:

```
vcruntime_c11_stdatomic.h(12,1): error C1189: #error: "C atomic support is not enabled"
```

Root cause: MSVC has no C11 atomics by default — `/std:c11` alone is not enough, even on current VS2022 (MSFT's `/std` reference: "There's no conforming multithreading, atomic, or complex number support"). Atomics stay gated behind `/experimental:c11atomics`. The CMake `C_STANDARD 11` property only emits `/std:c11`, so the release build choked on the plugins' `<stdatomic.h>`. (The Go app itself built fine; the CLAP PR's own main-branch Windows build was cancelled by concurrency, so this was first seen on the release run.)

## Fix

`plugins/CMakeLists.txt`: pass `/std:c11 /experimental:c11atomics` for MSVC. The plugins only use lock-free atomics (`bool`/`int`/`u32`/`u64`), which the experimental implementation fully covers. GCC/Clang are untouched (still handled by `C_STANDARD 11`).

## Verification

- This branch's `build.yml` run: **build-windows, build-linux, build-macos all green** — MSVC produced `Release/wail-send.clap` and `Release/wail-recv.clap` on the same windows-2022 toolchain the release workflow pins.
- Local macOS/clang plugin build still green.

Note: after merge, the v3.9.0 Windows artifact still needs a rebuilt release (re-dispatch the Release workflow or cut v3.9.1).

Claude Code fiddled the compiler flags and is shockingly pleased with itself.