### PR TITLE
chore(ci): let a failed platform build ship a partial release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,6 +324,11 @@ jobs:
 
   create-release:
     needs: [build-windows, build-linux, build-homebrew-tarball]
+    # A failed platform build must not sink the whole release: run whenever at
+    # least one artifact source succeeded and upload what exists (e.g. a
+    # mac-only release is the Homebrew source tarball when Windows/Linux fail).
+    # The run still reports failure overall, so a missing platform is visible.
+    if: always() && (needs.build-windows.result == 'success' || needs.build-linux.result == 'success' || needs.build-homebrew-tarball.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -351,13 +356,22 @@ jobs:
         run: |
           VERSION="${{ steps.tag.outputs.version }}"
           # Windows: zip, with a top-level wail-<version>/ directory inside.
-          mv wail-release-windows "wail-${VERSION}"
-          zip -r "wail-windows-x64-${VERSION}.zip" "wail-${VERSION}"
-          mv "wail-${VERSION}" wail-release-windows
+          # Skipped when its build job failed — the release ships without it.
+          if [ -d wail-release-windows ]; then
+            mv wail-release-windows "wail-${VERSION}"
+            zip -r "wail-windows-x64-${VERSION}.zip" "wail-${VERSION}"
+            mv "wail-${VERSION}" wail-release-windows
+          else
+            echo "::warning::no Windows artifact — releasing without it"
+          fi
           # Linux: tarball, same top-level directory layout.
-          mv wail-release-linux "wail-${VERSION}"
-          tar -czf "wail-linux-x64-${VERSION}.tar.gz" "wail-${VERSION}"
-          mv "wail-${VERSION}" wail-release-linux
+          if [ -d wail-release-linux ]; then
+            mv wail-release-linux "wail-${VERSION}"
+            tar -czf "wail-linux-x64-${VERSION}.tar.gz" "wail-${VERSION}"
+            mv "wail-${VERSION}" wail-release-linux
+          else
+            echo "::warning::no Linux artifact — releasing without it"
+          fi
 
       - name: Find individual installers
         id: files
@@ -383,6 +397,7 @@ jobs:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           [ -z "${GH_TOKEN}" ] && echo "HOMEBREW_TAP_TOKEN not set, skipping tap update." && exit 0
+          ls wail-homebrew-src/wail-*-src.tar.gz.sha256 >/dev/null 2>&1 || { echo "no source tarball artifact, skipping tap update."; exit 0; }
           VERSION="${{ steps.tag.outputs.version }}"
           SHA=$(cat wail-homebrew-src/wail-*-src.tar.gz.sha256 | head -1)
           URL="https://github.com/MostDistant/WAIL/releases/download/v${VERSION}/wail-${VERSION}-src.tar.gz"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,7 @@ Releases are fully automated — no manual `knope` commands needed:
 
 1. **Push to `main`** → `auto-release.yml` runs `knope prepare-release`, which consumes conventional commits (and `.changeset/` files if present as a fallback), bumps versions, updates `CHANGELOG.md`, and opens/updates a PR from the `release` branch → `main`.
 2. **Merge the release PR** → `release-on-merge.yml` runs `knope release` (creates GitHub release + git tag) and dispatches artifact builds.
-3. **`release.yml`** builds platform artifacts (macOS, Windows, Linux — app binaries + zip archives + Homebrew source tarball) and uploads them to the GitHub release.
+3. **`release.yml`** builds platform artifacts (Windows/Linux app binaries + zip/tar archives, plus the Homebrew source tarball that serves as the macOS channel) and uploads them to the GitHub release. A failed platform build does not block the release: `create-release` packages and uploads whatever artifacts exist (the run still reports failure so a missing platform is visible).
 
 ### Rules for agents
 


### PR DESCRIPTION
## Why

`create-release` hard-`needs` all three build jobs, so when the v3.9.0 Windows build failed (MSVC C11 atomics — fixed in #398), the job was **skipped entirely** and the GitHub release got zero artifacts — not even the Homebrew source tarball that serves as the macOS channel. One broken platform shouldn't sink the release for everyone else.

## Change

- `create-release` now runs whenever **at least one** build job succeeded (`if: always() && (...)`), packaging and uploading whatever artifacts exist.
- The packaging step guards per platform (`[ -d wail-release-windows ]` / `wail-release-linux`) and emits a `::warning::` for each missing one.
- The Homebrew tap update skips gracefully if the source tarball is absent (on top of the existing token check).
- The workflow run still reports **failure overall** when a platform build fails — a missing platform stays loud; it just no longer blocks the others.

So the v3.9.0 scenario now yields: release with Homebrew (mac) source tarball + Linux artifact, Windows visibly missing, instead of nothing at all.

## Verification

- `actionlint` clean (only pre-existing info/style shellcheck notes in the untouched \"Find individual installers\" step — same count before/after).
- Not runtime-tested end to end (release.yml only fires on tags/dispatch) — the logic is standard `needs.X.result` gating.

Claude Code herded these YAML cats into a sensible order and accepts no further responsibility.