### PR TITLE
fix: include vendor/clap in Homebrew source tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,11 @@ on:
         type: string
 
 jobs:
-  # Build a "fat" source tarball that includes the vendor/link git submodule.
-  # GitHub's auto-generated archives omit submodule contents, so we produce our
-  # own tarball and upload it as a release artifact.  The Homebrew formula uses
-  # this tarball as its `url` so that the Ableton Link SDK is available during
+  # Build a "fat" source tarball that includes the vendor/link and vendor/clap
+  # git submodules. GitHub's auto-generated archives omit submodule contents, so
+  # we produce our own tarball and upload it as a release artifact. The Homebrew
+  # formula uses this tarball as its `url` so that the Ableton Link SDK (cgo
+  # binding) and the CLAP headers (plugins/ cmake build) are available during
   # `brew install --build-from-source`.
   build-homebrew-tarball:
     runs-on: ubuntu-latest
@@ -36,16 +37,21 @@ jobs:
           # Export the repo tree (excludes .git) into a named staging directory
           mkdir -p "/tmp/${STAGING}"
           git archive --format=tar HEAD | tar -x -C "/tmp/${STAGING}"
-          # Overlay the submodule contents. git archive emits the gitlink as an
-          # empty vendor/link/ directory, so copy the submodule's *contents* into
-          # it — `cp -r vendor/link dest/vendor/link` would nest them one level
-          # too deep (vendor/link/link/), breaking the cgo include paths.
-          mkdir -p "/tmp/${STAGING}/vendor/link"
+          # Overlay the submodule contents. git archive emits the gitlinks as
+          # empty vendor/link/ and vendor/clap/ directories, so copy each
+          # submodule's *contents* into it — `cp -r vendor/link dest/vendor/link`
+          # would nest them one level too deep (vendor/link/link/), breaking the
+          # cgo include paths.
+          mkdir -p "/tmp/${STAGING}/vendor/link" "/tmp/${STAGING}/vendor/clap"
           cp -R vendor/link/. "/tmp/${STAGING}/vendor/link/"
+          cp -R vendor/clap/. "/tmp/${STAGING}/vendor/clap/"
           # Fail loudly if the headers the cgo binding needs aren't where
-          # wail-app/internal/abllink expects them.
+          # wail-app/internal/abllink expects them, or if the CLAP headers the
+          # plugins/ cmake build needs are missing (the Homebrew formula builds
+          # the plugins from this tarball).
           test -f "/tmp/${STAGING}/vendor/link/extensions/abl_link/include/abl_link.h"
           test -d "/tmp/${STAGING}/vendor/link/modules/asio-standalone/asio/include"
+          test -f "/tmp/${STAGING}/vendor/clap/include/clap/clap.h"
           # Package and compute checksum
           tar -czf "wail-${VERSION}-src.tar.gz" -C /tmp "${STAGING}"
           sha256sum "wail-${VERSION}-src.tar.gz" | awk '{print $1}' > "wail-${VERSION}-src.tar.gz.sha256"


### PR DESCRIPTION
## Problem

`brew install mostdistant/wail/wail` fails at the plugins cmake step:

```
CMake Error at CMakeLists.txt:16 (message):
  CLAP headers not found at
  /private/tmp/wail-.../wail-3.9.1/plugins/../vendor/clap/include.
  Run: git submodule update --init vendor/clap
```

The `build-homebrew-tarball` job in `release.yml` overlays only `vendor/link` onto the `git archive` output, but the formula (`homebrew/wail.rb`) also builds the CLAP bridge plugins with cmake, which needs `vendor/clap/include/clap/clap.h`. GitHub archives omit submodule contents, so the published tarball has no CLAP headers.

## Fix

- Overlay `vendor/clap` contents into the fat tarball alongside `vendor/link`
- Add `test -f .../vendor/clap/include/clap/clap.h` so a missing submodule fails the release loudly instead of shipping a broken tarball
- Update the job comment to reflect both submodules

## Verification

Simulated the tarball job locally (`git archive` + both submodule overlays), extracted fresh, and ran the formula's exact steps — `cmake -S plugins -B build/plugins` now configures and both `wail-send.clap` and `wail-recv.clap` build cleanly. Workflow-only change; no code paths affected, no tests run.

## Follow-up after merge

The already-published `wail-3.9.1-src.tar.gz` is still broken. Re-run `release.yml` via `workflow_dispatch` with tag `v3.9.1` to rebuild/re-upload the tarball and refresh the tap's sha256.