### PR TITLE
fix: install real plugin bundles instead of broken Cellar symlinks

### DIFF
--- a/scripts/wail-install-plugins.sh
+++ b/scripts/wail-install-plugins.sh
@@ -49,7 +49,10 @@ install_bundle() {
     fi
     local dest="${CLAP_DEST}/${name}"
     rm -rf "$dest"
-    cp -R "$src" "$dest"
+    # -L: dereference symlinks. Under Homebrew, ${PREFIX}/lib/<name>.clap is a
+    # *relative* symlink into the Cellar — a plain `cp -R` copies the link
+    # verbatim, leaving a broken symlink in the CLAP folder.
+    cp -RL "$src" "$dest"
     echo "Installed: $dest"
 }
 

--- a/wail-app/plugin_install.go
+++ b/wail-app/plugin_install.go
@@ -84,8 +84,17 @@ func InstallPluginsIfMissing(pluginDir string) []string {
 			continue // not bundled in this build
 		}
 		dest := filepath.Join(destDir, name)
-		if _, err := os.Stat(dest); err == nil {
-			continue // already installed
+		if info, err := os.Lstat(dest); err == nil {
+			if info.Mode()&os.ModeSymlink == 0 {
+				continue // already installed
+			}
+			// A symlink here is stale: Homebrew's relative Cellar links break
+			// when copied into the CLAP folder, and links into the Cellar go
+			// dead on `brew uninstall`. Replace with a real copy.
+			if err := os.Remove(dest); err != nil {
+				errs = append(errs, fmt.Sprintf("%s: remove stale symlink: %v", name, err))
+				continue
+			}
 		}
 		if err := os.MkdirAll(destDir, 0o755); err != nil {
 			errs = append(errs, fmt.Sprintf("%s: create dir: %v", name, err))

--- a/wail-app/plugin_install_test.go
+++ b/wail-app/plugin_install_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// makeFakeBundle creates a minimal .clap bundle (dir with one file) under dir.
+func makeFakeBundle(t *testing.T, dir, name string) string {
+	t.Helper()
+	bundle := filepath.Join(dir, name)
+	inner := filepath.Join(bundle, "Contents", "MacOS")
+	if err := os.MkdirAll(inner, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(inner, name[:len(name)-len(".clap")]), []byte("mach-o"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bundle
+}
+
+func clapDestDir(t *testing.T) string {
+	t.Helper()
+	switch runtime.GOOS {
+	case "darwin":
+		return filepath.Join(os.Getenv("HOME"), "Library", "Audio", "Plug-Ins", "CLAP")
+	case "linux":
+		return filepath.Join(os.Getenv("HOME"), ".clap")
+	default:
+		t.Skipf("unsupported test platform: %s", runtime.GOOS)
+		return ""
+	}
+}
+
+func TestInstallPluginsFreshInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	pluginDir := t.TempDir()
+	makeFakeBundle(t, pluginDir, "wail-send.clap")
+
+	if errs := InstallPluginsIfMissing(pluginDir); len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	dest := filepath.Join(clapDestDir(t), "wail-send.clap")
+	info, err := os.Lstat(dest)
+	if err != nil {
+		t.Fatalf("dest not installed: %v", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("dest should be a real directory, got mode %v", info.Mode())
+	}
+	if _, err := os.Stat(filepath.Join(dest, "Contents", "MacOS", "wail-send")); err != nil {
+		t.Fatalf("bundle contents missing: %v", err)
+	}
+}
+
+// A previous wail-install-plugins.sh bug copied Homebrew's relative Cellar
+// symlink verbatim, leaving a broken symlink in the CLAP folder. The app
+// installer must replace such a symlink with a real copy instead of erroring.
+func TestInstallPluginsReplacesBrokenSymlink(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	pluginDir := t.TempDir()
+	makeFakeBundle(t, pluginDir, "wail-send.clap")
+
+	destDir := clapDestDir(t)
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(destDir, "wail-send.clap")
+	// Relative symlink, broken from the CLAP folder's perspective — exactly
+	// what the buggy script produced (../Cellar/wail/<ver>/lib/...).
+	if err := os.Symlink(filepath.Join("..", "Cellar", "wail", "0.0.0", "lib", "wail-send.clap"), dest); err != nil {
+		t.Fatal(err)
+	}
+
+	if errs := InstallPluginsIfMissing(pluginDir); len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	info, err := os.Lstat(dest)
+	if err != nil {
+		t.Fatalf("dest not installed: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("broken symlink was not replaced with a real copy")
+	}
+	if _, err := os.Stat(filepath.Join(dest, "Contents", "MacOS", "wail-send")); err != nil {
+		t.Fatalf("bundle contents missing: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

After `brew install wail` + `wail-install-plugins`, the user's CLAP folder contained **broken symlinks** instead of plugin bundles:

```
wail-send.clap -> ../Cellar/wail/3.9.2/lib/wail-send.clap   (broken)
```

`/opt/homebrew/lib/wail-*.clap` are Homebrew's *relative* symlinks into the Cellar. The script's plain `cp -R` copies the link verbatim; relative to `~/Library/Audio/Plug-Ins/CLAP/` it resolves to nothing, so DAWs saw no WAIL plugins.

The in-app auto-installer had the mirror-image bug: a broken symlink at the destination fails `os.Stat`, so it looked "missing", the copy was attempted, and died with `mkdir ...: file exists`.

## Fix

- `scripts/wail-install-plugins.sh`: `cp -RL` — dereference symlinks so real bundles land in the CLAP folder
- `wail-app/plugin_install.go`: if the destination is a symlink (stale Homebrew link, dead Cellar target after `brew uninstall`), remove it and install a real copy

## Tests

New `wail-app/plugin_install_test.go`:
- fresh install copies the bundle contents as a real directory
- **broken-symlink regression test** (reproduces the exact `../Cellar/...` link the buggy script produced — fails before the fix with `mkdir ... file exists`, passes after)

Full `go test -tags linkstub ./...` green. Script verified end-to-end on macOS against a real Homebrew prefix: installs proper `Contents/MacOS` + `Info.plist` bundles.