### PR TITLE
fix: implement clap.state in the bridge plugins so hosts can save projects

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -47,3 +47,16 @@ endfunction()
 
 add_wail_plugin(wail-send wail_send.c)
 add_wail_plugin(wail-recv wail_recv.c)
+
+# State-extension roundtrip test: loads each built bundle and drives clap.state
+# with a fake host (see test_state.c). wail-send also asserts its "Stream
+# Index" param survives a save/load cycle.
+if(NOT WIN32)
+  enable_testing()
+  add_executable(test_state test_state.c)
+  target_include_directories(test_state PRIVATE "${CLAP_INCLUDE}")
+  target_link_libraries(test_state PRIVATE ${CMAKE_DL_LIBS})
+  add_dependencies(test_state wail-send wail-recv)
+  add_test(NAME state_send COMMAND test_state $<TARGET_FILE:wail-send> software.wail.send stream-index)
+  add_test(NAME state_recv COMMAND test_state $<TARGET_FILE:wail-recv> software.wail.recv)
+endif()

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -11,6 +11,9 @@ or `WAIL_IPC_ADDR`).
 - **`wail-recv`** — 16 stereo output ports, one per remote stream. Ports are named
   live (`{peer} · {stream}`) as audio arrives.
 
+Both implement `clap.state` (Stream Index persists in project files for send; recv
+saves a version marker), so hosts can save projects/presets containing them.
+
 ## Build
 
 Requires a C11 compiler, CMake ≥ 3.15, and the vendored CLAP headers:
@@ -19,6 +22,7 @@ Requires a C11 compiler, CMake ≥ 3.15, and the vendored CLAP headers:
 git submodule update --init vendor/clap
 cmake -S plugins -B build/plugins -DCMAKE_BUILD_TYPE=Release
 cmake --build build/plugins
+ctest --test-dir build/plugins --output-on-failure   # clap.state roundtrip tests
 ```
 
 Outputs `wail-send.clap` and `wail-recv.clap` in the build dir:

--- a/plugins/test_state.c
+++ b/plugins/test_state.c
@@ -1,0 +1,204 @@
+// test_state — loads a built .clap bundle and exercises the clap.state
+// extension: set a param → save → mutate → load → the param must be restored.
+// Drives the plugin with a minimal fake host (no GUI, no audio thread). Usage:
+//
+//   test_state <path-to-plugin-binary> <plugin-id> [stream-index]
+//
+// <path-to-plugin-binary> is the actual shared object (CMake passes
+// $<TARGET_FILE:...>, which handles the macOS bundle layout). The optional
+// third argument selects the "Stream Index" roundtrip assertions (wail-send);
+// without it only a bare save/load cycle is checked (wail-recv).
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "clap/clap.h"
+
+#ifdef _WIN32
+#include <windows.h>
+static void *lib_open(const char *p) { return (void *)LoadLibraryA(p); }
+static void *lib_sym(void *h, const char *n) { return (void *)GetProcAddress((HMODULE)h, n); }
+#else
+#include <dlfcn.h>
+static void *lib_open(const char *p) { return dlopen(p, RTLD_NOW | RTLD_LOCAL); }
+static void *lib_sym(void *h, const char *n) { return dlsym(h, n); }
+#endif
+
+#define CHECK(cond, msg)                                                                                               \
+   do {                                                                                                                \
+      if (!(cond)) {                                                                                                   \
+         fprintf(stderr, "FAIL: %s (%s:%d)\n", msg, __FILE__, __LINE__);                                               \
+         exit(1);                                                                                                      \
+      }                                                                                                                \
+   } while (0)
+
+// --- memory streams ---
+
+typedef struct {
+   clap_ostream_t s;
+   uint8_t        buf[4096];
+   size_t         len;
+} mem_out;
+
+static int64_t CLAP_ABI mem_write(const clap_ostream_t *stream, const void *buffer, uint64_t size) {
+   mem_out *m = (mem_out *)stream;
+   if (m->len + size > sizeof(m->buf)) return -1;
+   memcpy(m->buf + m->len, buffer, size);
+   m->len += size;
+   return (int64_t)size;
+}
+
+typedef struct {
+   clap_istream_t s;
+   uint8_t        buf[4096];
+   size_t         len, pos;
+} mem_in;
+
+static int64_t CLAP_ABI mem_read(const clap_istream_t *stream, void *buffer, uint64_t size) {
+   mem_in *m = (mem_in *)stream;
+   size_t avail = m->len - m->pos;
+   if (avail == 0) return 0; // EOF
+   if (size > avail) size = avail;
+   memcpy(buffer, m->buf + m->pos, size);
+   m->pos += size;
+   return (int64_t)size;
+}
+
+// --- one-shot input event list carrying a single PARAM_VALUE ---
+
+typedef struct {
+   clap_input_events_t        list;
+   clap_event_param_value_t   ev;
+} one_param_event;
+
+static uint32_t CLAP_ABI one_ev_size(const clap_input_events_t *l) {
+   (void)l;
+   return 1;
+}
+static const clap_event_header_t *CLAP_ABI one_ev_get(const clap_input_events_t *l, uint32_t i) {
+   if (i != 0) return NULL;
+   return (const clap_event_header_t *)&((one_param_event *)l)->ev;
+}
+
+static void send_param_value(const clap_plugin_params_t *params, const clap_plugin_t *plug, double v) {
+   one_param_event in = {0};
+   in.list.ctx = NULL;
+   in.list.size = one_ev_size;
+   in.list.get = one_ev_get;
+   in.ev.header.size = sizeof(in.ev);
+   in.ev.header.time = 0;
+   in.ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+   in.ev.header.type = CLAP_EVENT_PARAM_VALUE;
+   in.ev.header.flags = 0;
+   in.ev.param_id = 0;
+   in.ev.value = v;
+   params->flush(plug, &in.list, NULL);
+}
+
+// --- fake host ---
+
+static int g_rescan_calls;
+
+static void CLAP_ABI host_params_rescan(const clap_host_t *host, clap_param_rescan_flags flags) {
+   (void)host;
+   if (flags & CLAP_PARAM_RESCAN_VALUES) g_rescan_calls++;
+}
+static void CLAP_ABI host_params_clear(const clap_host_t *h, clap_id i, clap_param_clear_flags f) {
+   (void)h;
+   (void)i;
+   (void)f;
+}
+static void CLAP_ABI host_params_request_flush(const clap_host_t *h) { (void)h; }
+static const clap_host_params_t g_host_params = {host_params_rescan, host_params_clear, host_params_request_flush};
+
+static const void *CLAP_ABI host_get_extension(const clap_host_t *host, const char *id) {
+   (void)host;
+   if (!strcmp(id, CLAP_EXT_PARAMS)) return &g_host_params;
+   return NULL;
+}
+static void CLAP_ABI host_request_restart(const clap_host_t *h) { (void)h; }
+static void CLAP_ABI host_request_process(const clap_host_t *h) { (void)h; }
+static void CLAP_ABI host_request_callback(const clap_host_t *h) { (void)h; }
+
+static clap_host_t g_host = {
+    .clap_version = CLAP_VERSION_INIT,
+    .host_data = NULL,
+    .name = "test-state-host",
+    .vendor = "WAIL",
+    .url = "https://github.com/MostDistant/WAIL",
+    .version = "0",
+    .get_extension = host_get_extension,
+    .request_restart = host_request_restart,
+    .request_process = host_request_process,
+    .request_callback = host_request_callback,
+};
+
+int main(int argc, char **argv) {
+   CHECK(argc >= 3, "usage: test_state <plugin-binary> <plugin-id> [stream-index]");
+   const char *path = argv[1];
+   const char *want_id = argv[2];
+   int check_param = argc > 3;
+
+   void *lib = lib_open(path);
+   CHECK(lib != NULL, "load bundle");
+   const clap_plugin_entry_t *entry = (const clap_plugin_entry_t *)lib_sym(lib, "clap_entry");
+   CHECK(entry != NULL, "clap_entry symbol");
+   CHECK(entry->init("/tmp"), "entry init");
+   const clap_plugin_factory_t *fac =
+       (const clap_plugin_factory_t *)entry->get_factory(CLAP_PLUGIN_FACTORY_ID);
+   CHECK(fac != NULL, "plugin factory");
+
+   const clap_plugin_t *plug = fac->create_plugin(fac, &g_host, want_id);
+   CHECK(plug != NULL, "create plugin");
+   CHECK(plug->init(plug), "plugin init");
+
+   const clap_plugin_params_t *params = NULL;
+   if (check_param) {
+      params = (const clap_plugin_params_t *)plug->get_extension(plug, CLAP_EXT_PARAMS);
+      CHECK(params != NULL, "send plugin must expose clap.params");
+      double v = -1;
+      CHECK(params->get_value(plug, 0, &v) && v == 0, "stream index defaults to 0");
+   }
+
+   // The extension under test.
+   const clap_plugin_state_t *state =
+       (const clap_plugin_state_t *)plug->get_extension(plug, CLAP_EXT_STATE);
+   CHECK(state != NULL && state->save && state->load, "plugin must expose clap.state");
+
+   // Set a non-default value, save, mutate, load — the saved value must win.
+   if (check_param) {
+      send_param_value(params, plug, 7);
+      double v = -1;
+      CHECK(params->get_value(plug, 0, &v) && v == 7, "param event sets stream index");
+   }
+
+   mem_out out = {.s = {.ctx = NULL, .write = mem_write}, .len = 0};
+   CHECK(state->save(plug, &out.s), "save");
+   CHECK(out.len > 0, "save wrote bytes");
+
+   if (check_param) send_param_value(params, plug, 3); // diverge from saved state
+
+   mem_in in = {.s = {.ctx = NULL, .read = mem_read}, .len = out.len, .pos = 0};
+   memcpy(in.buf, out.buf, out.len);
+   CHECK(state->load(plug, &in.s), "load");
+
+   if (check_param) {
+      double v = -1;
+      CHECK(params->get_value(plug, 0, &v) && v == 7, "load restores the saved stream index");
+      CHECK(g_rescan_calls > 0, "load asks the host to rescan param values");
+   }
+
+   // A truncated stream must fail cleanly (no crash, no half-applied state).
+   mem_in bad = {.s = {.ctx = NULL, .read = mem_read}, .len = 2, .pos = 0};
+   memcpy(bad.buf, out.buf, 2);
+   CHECK(!state->load(plug, &bad.s), "truncated stream is rejected");
+   if (check_param) {
+      double v = -1;
+      CHECK(params->get_value(plug, 0, &v) && v == 7, "rejected load leaves state untouched");
+   }
+
+   plug->destroy(plug);
+   entry->deinit();
+   printf("PASS: %s state roundtrip\n", want_id);
+   return 0;
+}

--- a/plugins/wail_ipc.h
+++ b/plugins/wail_ipc.h
@@ -127,6 +127,29 @@ static inline int64_t wail_get_i64(const uint8_t *b) {
    return (int64_t)v;
 }
 
+// --- CLAP stream helpers (clap.state) ---
+// The stream contract allows partial reads/writes, so loop until the whole
+// buffer moves. 0 (EOF) and negative (error) both fail the operation.
+
+static inline int wail_stream_write_all(const clap_ostream_t *stream, const uint8_t *buf, size_t len) {
+   size_t off = 0;
+   while (off < len) {
+      int64_t n = stream->write(stream, buf + off, (uint64_t)(len - off));
+      if (n <= 0) return 0;
+      off += (size_t)n;
+   }
+   return 1;
+}
+static inline int wail_stream_read_all(const clap_istream_t *stream, uint8_t *buf, size_t len) {
+   size_t off = 0;
+   while (off < len) {
+      int64_t n = stream->read(stream, buf + off, (uint64_t)(len - off));
+      if (n <= 0) return 0;
+      off += (size_t)n;
+   }
+   return 1;
+}
+
 // --- socket helpers ---
 
 // wail_sock_set_recv_timeout_ms makes a blocking recv() return periodically (with a

--- a/plugins/wail_recv.c
+++ b/plugins/wail_recv.c
@@ -384,9 +384,37 @@ static bool CLAP_ABI recv_ap_get(const clap_plugin_t *plugin, uint32_t idx, bool
 }
 static const clap_plugin_audio_ports_t recv_audio_ports = {recv_ap_count, recv_ap_get};
 
+// --- state extension ---
+// Recv has no parameters today, but it must still implement CLAP_EXT_STATE:
+// hosts like Bitwig refuse to save projects containing a plugin that "does not
+// support saving its state". The blob is a version marker only.
+
+#define RECV_STATE_MAGIC 0x57414C52u   // 'WALR'
+#define RECV_STATE_VERSION 1u
+
+static bool CLAP_ABI recv_state_save(const clap_plugin_t *plugin, const clap_ostream_t *stream) {
+   (void)plugin;
+   uint8_t buf[8];
+   size_t  off = 0;
+   wail_put_u32(buf, &off, RECV_STATE_MAGIC);
+   wail_put_u32(buf, &off, RECV_STATE_VERSION);
+   return wail_stream_write_all(stream, buf, off) != 0;
+}
+
+static bool CLAP_ABI recv_state_load(const clap_plugin_t *plugin, const clap_istream_t *stream) {
+   (void)plugin;
+   uint8_t buf[8];
+   if (!wail_stream_read_all(stream, buf, sizeof(buf))) return false;
+   if (wail_get_u32(buf) != RECV_STATE_MAGIC) return false;
+   if (wail_get_u32(buf + 4) != RECV_STATE_VERSION) return false;
+   return true;
+}
+static const clap_plugin_state_t recv_state = {recv_state_save, recv_state_load};
+
 static const void *CLAP_ABI recv_get_extension(const clap_plugin_t *p, const char *id) {
    (void)p;
    if (!strcmp(id, CLAP_EXT_AUDIO_PORTS)) return &recv_audio_ports;
+   if (!strcmp(id, CLAP_EXT_STATE)) return &recv_state;
    return NULL;
 }
 

--- a/plugins/wail_send.c
+++ b/plugins/wail_send.c
@@ -289,10 +289,43 @@ static void CLAP_ABI send_pp_flush(const clap_plugin_t *p, const clap_input_even
 static const clap_plugin_params_t send_params = {
     send_pp_count, send_pp_info, send_pp_value, send_pp_v2t, send_pp_t2v, send_pp_flush};
 
+// --- state extension: persist "Stream Index" across project saves ---
+// Without CLAP_EXT_STATE hosts like Bitwig refuse to save projects containing
+// this plugin ("Plug-in does not support saving its state").
+
+#define SEND_STATE_MAGIC 0x57414C53u   // 'WALS'
+#define SEND_STATE_VERSION 1u
+
+static bool CLAP_ABI send_state_save(const clap_plugin_t *plugin, const clap_ostream_t *stream) {
+   wail_send *self = plugin->plugin_data;
+   uint8_t buf[12];
+   size_t  off = 0;
+   wail_put_u32(buf, &off, SEND_STATE_MAGIC);
+   wail_put_u32(buf, &off, SEND_STATE_VERSION);
+   wail_put_u32(buf, &off, (uint32_t)atomic_load_explicit(&self->stream_index, memory_order_relaxed));
+   return wail_stream_write_all(stream, buf, off) != 0;
+}
+
+static bool CLAP_ABI send_state_load(const clap_plugin_t *plugin, const clap_istream_t *stream) {
+   wail_send *self = plugin->plugin_data;
+   uint8_t buf[12];
+   if (!wail_stream_read_all(stream, buf, sizeof(buf))) return false;
+   if (wail_get_u32(buf) != SEND_STATE_MAGIC) return false;
+   if (wail_get_u32(buf + 4) != SEND_STATE_VERSION) return false;
+   uint32_t idx = wail_get_u32(buf + 8);
+   if (idx > 15) idx = 15; // clamp, don't fail: a newer build may widen the range
+   atomic_store_explicit(&self->stream_index, (int)idx, memory_order_relaxed);
+   const clap_host_params_t *hp = self->host->get_extension(self->host, CLAP_EXT_PARAMS);
+   if (hp && hp->rescan) hp->rescan(self->host, CLAP_PARAM_RESCAN_VALUES);
+   return true;
+}
+static const clap_plugin_state_t send_state = {send_state_save, send_state_load};
+
 static const void *CLAP_ABI send_get_extension(const clap_plugin_t *p, const char *id) {
    (void)p;
    if (!strcmp(id, CLAP_EXT_AUDIO_PORTS)) return &send_audio_ports;
    if (!strcmp(id, CLAP_EXT_PARAMS)) return &send_params;
+   if (!strcmp(id, CLAP_EXT_STATE)) return &send_state;
    return NULL;
 }
 


### PR DESCRIPTION
## Problem

Bitwig (and likely other hosts) refuse to save projects containing WAIL Send/Recv:

> WAIL Send: Could not save preset … **Plug-in does not support saving its state**

Neither plugin exposed `CLAP_EXT_STATE`.

## Fix

- **wail-send**: `clap.state` save/load persists the *Stream Index* param — versioned 12-byte blob (magic `WALS`, version, index). Load clamps to 0–15 (forward-compatible) and calls `host_params->rescan(CLAP_PARAM_RESCAN_VALUES)` so the host picks up restored values.
- **wail-recv**: `clap.state` with a version-marker blob (no params today) so hosts can save/load projects containing it.
- **wail_ipc.h**: `wail_stream_read_all`/`write_all` helpers honoring the CLAP stream contract (partial reads/writes, EOF/error).

## Tests

New `plugins/test_state.c`, wired into ctest: dlopens each built bundle and drives `clap.state` with a fake host —

- Stream Index survives a set(7) → save → mutate(3) → load cycle
- load asks the host to rescan param values
- truncated streams are rejected **without** touching current state

Written test-first (failed on `plugin must expose clap.state` before the fix); both tests green. Built and installed locally on macOS for manual Bitwig verification.

The ctest targets run on POSIX only; the plugin code itself is unchanged in portability (C11, no new platform deps) and still builds for Windows.
