### PR TITLE
fix: quit the macOS app when the window is closed

### DIFF
--- a/wail-app/main.go
+++ b/wail-app/main.go
@@ -80,6 +80,13 @@ func main() {
 		Assets: application.AssetOptions{
 			Handler: application.BundledAssetFileServer(assets),
 		},
+		Mac: application.MacOptions{
+			// WAIL has no windowless/tray mode: with the default (false),
+			// closing the window leaves the process running with no UI —
+			// session, Link peer, and websockets all still alive — and the
+			// only way out is Cmd-Q or killing the process.
+			ApplicationShouldTerminateAfterLastWindowClosed: true,
+		},
 	})
 
 	appBackend.SetEmitter(NewWailsEmitter(wailsApp))


### PR DESCRIPTION
## Problem

On macOS, closing the WAIL window did **not** quit the app: the process kept running with no UI (session, Link peer, websockets all still alive) and had to be killed manually / Cmd-Q.

## Cause

Wails v3's `MacOptions.ApplicationShouldTerminateAfterLastWindowClosed` defaults to `false` (standard macOS doc-based-app behavior). WAIL has no windowless/tray mode and no way to reopen the window, so the default leaves a zombie process. Windows/Linux already quit on last-window-close in Wails.

## Fix

Set `Mac.ApplicationShouldTerminateAfterLastWindowClosed: true` in `application.Options`.

## Verification

Built the app, launched it, closed the window via the red close button — the process exits cleanly (previously it stayed running). Confirmed on macOS 26.5 (arm64).
