### PR TITLE
chore: unblock the #428 release + align the auto-release guard with k…

### DIFF
--- a/.changeset/grid-steer-extraction.md
+++ b/.changeset/grid-steer-extraction.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Extract the grid steer into `internal/align` (#428): ADR-0006's grid-alignment orchestration (entry conformance, gated slew, snapshot-tempo arbitration, committed-tempo record, post-snap room-label derivation) moves out of the session select loop into one unit-tested module. Also adds NINJAM-like interval-placement verification to the tier2 audio E2E (step mode, now the default).

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -49,7 +49,11 @@ jobs:
           else
             RANGE="HEAD"
           fi
-          if git log --oneline "$RANGE" | grep -qE '^[0-9a-f]+ (feat|fix|feat!|fix!|refactor|perf)[(:!]'; then
+          # NOTE: keep this regex aligned with what knope actually bumps on
+          # (stock config: feat!/feat/fix!/fix only). refactor/perf used to be
+          # listed here, which skipped the fallback changeset and then failed
+          # knope prepare-release with "No packages are ready to release".
+          if git log --oneline "$RANGE" | grep -qE '^[0-9a-f]+ (feat|fix|feat!|fix!)[(:!]'; then
             HAS_CONVENTIONAL=true
           fi
 


### PR DESCRIPTION
…nope

The squash-merged refactor: commit matched auto-release.yml's feat|fix|refactor|perf guard, so no fallback changeset was created — but stock knope only bumps on feat/fix, so prepare-release failed with "No packages are ready to release". Add a patch changeset for #428 and narrow the guard regex to what knope actually bumps on (feat!/feat/fix!/fix), so future refactor/perf-only pushes get the fallback changeset like test/chore/docs pushes do.