### PR TITLE
feat: debug room + in-app stream offset analysis for latency hunting

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -145,8 +145,10 @@ Two modes (`TIER2_MODE`):
   correlated (absolute grid indices are per-peer — ADR-0003): the sender logs a
   `(room, content-seconds)` marker per boundary (`[wav-sender] boundary room=…
   content=…s`), the receiver's `>>> INTERVAL` log marks which room interval
-  started playing when, and every received second is asserted
-  `captureRoom == playingRoom − D`.
+  started playing when, and each receiver interval's **majority-vote capture
+  room** (per-second tone classification voting by content range; skewed or
+  mixed-tone seconds lose the vote, so no edge margins are needed) is asserted
+  `== playingRoom − D`.
 - **`sweep`** — the original rising log sweep: a PASS means non-silent,
   **lossless** audio whose estimated frequency **climbs with the sweep** (proof
   it's intact and in order).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -75,6 +75,26 @@ sed -i 's/\binterface\b/iface/g' vendor/link/include/ableton/link_audio/Channels
 
 (The Windows CI jobs do this automatically; macOS/Linux don't need it.)
 
+### Debug room + offset analysis (latency hunting, no DAW needed)
+
+For measuring a peer's rhythmic phase offset against the room grid (the
+"GerenM felt 90ms off" class of problem):
+
+- **GUI**: press **Debug Room** on the join screen. It joins the shared
+  `wail-debug` room and arms all diagnostics: the WAIL Metronome broadcast
+  (a grid-rendered reference click), server-echo loopback, and peer log
+  sharing (the room collates everyone's logs into each client).
+- **Headless**: `-metronome-broadcast` (plus `-loopback` for self-echo).
+- **In-app readout (DAW-less)**: the Debug tab's *Stream offsets* section
+  shows each remote stream's measured phase offset vs the room grid in ms
+  (`internal/offset`, computed from labeled WAIF frames — exact, no envelope
+  matching). |offset| > 25ms is highlighted. A peer performing late because
+  their monitoring path is latent shows it directly.
+- **Probe**: `linkaudio-probe -offset-ref "WAIL Metronome"` cross-correlates
+  each channel's envelope against the reference metronome (best for
+  same-period rhythmic content), and `-offset-dump <dir>` writes per-channel
+  RMS envelopes as CSVs for offline analysis.
+
 ### Desktop App (dev mode)
 
 ```sh

--- a/plugins/wail_send.c
+++ b/plugins/wail_send.c
@@ -192,6 +192,14 @@ static void *send_ipc_thread(void *arg) {
          }
          // (Re)sent on every (re)connect: the app registers this stream fresh.
          atomic_store_explicit(&self->name_dirty, true, memory_order_release);
+         // Flush stale ring slots held through the outage: re-sending them
+         // would arm the app's beat anchor with old frame counters and stamp
+         // all subsequent audio by the outage duration (field finding: an
+         // 11-minute outage put capture +82 intervals ahead). The slots are
+         // ~40ms of old audio at most — never worth a poisoned anchor.
+         atomic_store_explicit(&self->head,
+                               atomic_load_explicit(&self->tail, memory_order_acquire),
+                               memory_order_release);
       }
       if (atomic_exchange_explicit(&self->name_dirty, false, memory_order_acq_rel)) {
          if (send_track_name_frame(self, sock) != 0) {

--- a/scripts/tier2-e2e.sh
+++ b/scripts/tier2-e2e.sh
@@ -66,7 +66,11 @@ cleanup() {
   for p in $PIDS; do kill "$p" 2>/dev/null; done
   sleep 0.5
   for p in $PIDS; do kill -9 "$p" 2>/dev/null; done
-  rm -rf "$WORK"
+  if [ "${TIER2_KEEP:-0}" = 1 ]; then
+    echo "[tier2] logs kept in $WORK"
+  else
+    rm -rf "$WORK"
+  fi
 }
 trap cleanup EXIT INT TERM
 
@@ -135,16 +139,17 @@ if [ "$MODE" = step ]; then
   #   releases.txt  — wall time + room interval that STARTED PLAYING at each
   #     of the receiver's boundaries (its INTERVAL log line).
   #   settle        — join-transition window: intervals captured before the
-  #     room's tempo settled (LAN convergence → re-anchor) carry permanently
-  #     rate-skewed labels by design (ADR-0006 entry re-rolls alignment);
-  #     they are excluded, everything after must pass.
-  # Assertion per received second: captureRoom(content) == playingRoom - D.
+  #     room's tempo settled (LAN convergence → re-anchor → label re-derive,
+  #     all boundary-quantized per ADR-0003) can be placed ±1 interval off by
+  #     design; they are excluded, everything after must pass. Settle = the
+  #     first sender boundary at/after the LAST alignment activity (tempo
+  #     change, entry, or label derive) plus one interval of margin.
   SETTLE="$(awk '
-    /Local tempo changed/ { t = $1; gsub(/[:.]/, " ", t); split(t, p, " "); last = p[1]*3600+p[2]*60+p[3]+p[4]/1e6 }
-    /\[wav-sender\] boundary room=/ && last != "" && !done {
+    /Local tempo changed|label derive|entry:/ { t = $1; gsub(/[:.]/, " ", t); split(t, p, " "); last = p[1]*3600+p[2]*60+p[3]+p[4]/1e6 }
+    /\[wav-sender\] boundary room=/ {
       t = $1; gsub(/[:.]/, " ", t); split(t, p, " ")
       bt = p[1]*3600+p[2]*60+p[3]+p[4]/1e6
-      if (bt >= last) { print bt; done = 1 }
+      if (last != "" && !done && bt >= last) { print bt; done = 1 }
     }' "$WORK/sender.log")"
   awk '
     /\[wav-sender\] boundary room=/ {
@@ -188,41 +193,58 @@ if [ "$MODE" = step ]; then
       if (rms >= 500 && freq > 0) {
         nonsilent++
         if (fmin==0 || freq<fmin) fmin=freq; if (freq>fmax) fmax=freq
-        # Which room interval is playing at t? Latest boundary ≤ t, skipping
+        # Which room interval is playing at t? Latest boundary <= t, skipping
         # the straddle second right after a boundary (mixed content).
         ri = 0
         for (i = nr; i >= 1; i--) if (rt[i] <= t) { ri = i; break }
         if (ri == 0 || t - rt[ri] < 1.2) next
-        # Content time from frequency: block k = (f-f0)/step, k*blockdur secs.
+        # Classify the block from its tone. Measured estimate noise on clean
+        # seconds is ±80Hz (Opus + resample jitter), so classify to the
+        # nearest block (half-step threshold): a mixed second just joins the
+        # majority block, harmless under per-block assertions — one wrong
+        # second never outvotes the clean ones.
+        k = int((freq - f0)/step + 0.5)
+        if (k < 0) next
+        diff = freq - (f0 + k*step); if (diff < 0) diff = -diff
+        if (diff > step/2) next
+        # Per-second VOTE for the capture room of what is heard now (no edge
+        # margins anywhere): each receiver interval tallies its seconds and
+        # the majority wins, so the odd skewed/straddle second is harmless.
         c = (freq - f0)/step * blockdur
         if (c < -1) next
-        # Capture room: the content range containing c, skipping seconds
-        # within 2s of a range edge (freq tolerance ±50Hz ⇒ content-time
-        # tolerance ±(50/step)*blockdur, plus pacing drift — a block
-        # straddling a range edge is unclassifiable by frequency).
         bi = 0
         for (i = nb; i >= 1; i--) if (cs[i] <= c) { bi = i; break }
         if (bi == 0) next
-        if (c - cs[bi] < 2.0) next
-        if (bi < nb && cs[bi+1] - c < 2.0) next
         # Join-transition exclusion: intervals captured before the room
         # tempo settled carry skewed labels by design (ADR-0006 entry
         # re-rolls alignment); judge steady-state only.
         if (ct[bi] < settle) { skipped++; next }
-        checks++
-        want = cr[bi] + d   # capture room + D == room now playing
-        if (rr[ri] != want) {
-          fails++
-          printf "  ! placement: t=%d ~%.0f Hz (content %.1fs, captured room %d) heard while room %d plays, want room %d\n", \
-                 t, freq, c, cr[bi], rr[ri], want
-        }
+        votes[rr[ri] SUBSEP cr[bi]]++
       }
     }
     END {
       printf "subscribed=%d  non-silent-sec=%d  silent-sec=%d  maxLost=%d  lossEvents=%d  freq=%d..%d Hz\n", \
              subs+0, nonsilent+0, silent+0, maxlost+0, lossev+0, fmin+0, fmax+0
-      printf "placement: %d checks, %d failures (%d skipped: join-transition) — every received second: playing room == capture room + D\n", checks+0, fails+0, skipped+0
-      pass = (subs>=1 && nonsilent>=10 && maxlost==0 && lossev==0 && checks>=12 && fails==0)
+      # Assert per receiver interval: its majority capture room must equal
+      # the playing room - D (>=2 votes; a tie or split majority abstains —
+      # that interval says nothing, it does not fail).
+      for (key in votes) {
+        split(key, a, SUBSEP); playing = a[1]; cap = a[2]+0; n = votes[key]
+        if (n > best[playing]) { second[playing] = best[playing]; best[playing] = n; winner[playing] = cap }
+        else if (n > second[playing]) { second[playing] = n }
+      }
+      for (playing in best) {
+        if (best[playing] < 2 || best[playing] == second[playing]) continue
+        checks++
+        want = winner[playing] + d
+        if (playing+0 != want) {
+          fails++
+          printf "  ! placement: room %d majority-captured room %d (%d/%d votes), want room %d\n", \
+                 playing, winner[playing], best[playing], best[playing]+second[playing], want
+        }
+      }
+      printf "placement: %d checks, %d failures (%d skipped: join-transition) — every receiver interval: playing room == majority capture room + D\n", checks+0, fails+0, skipped+0
+      pass = (subs>=1 && nonsilent>=10 && maxlost==0 && lossev==0 && checks>=3 && fails==0)
       print (pass ? "VERDICT=PASS" : "VERDICT=FAIL")
     }
   ' "$WORK/blockroom.txt" "$WORK/releases.txt" "$WORK/probe.log" | tee "$WORK/verdict.txt"
@@ -257,7 +279,7 @@ fi
 
 if grep -q "VERDICT=PASS" "$WORK/verdict.txt"; then
   if [ "$MODE" = step ]; then
-    log "PASS — intact, lossless audio + every received second verified at captured-room + D on the shared grid"
+    log "PASS — intact, lossless audio + every receiver interval majority-verified at captured-room + D"
   else
     log "PASS — intact, in-order, lossless audio through the real Link Audio path"
   fi

--- a/wail-app/app.go
+++ b/wail-app/app.go
@@ -368,6 +368,30 @@ func (a *App) SetTelemetry(enabled bool) error {
 	return nil
 }
 
+// DebugRoom joins the shared "wail-debug" room with all diagnostics armed:
+// the WAIL Metronome broadcast (a grid-rendered reference click every peer
+// can measure against), server-echo loopback, and peer log sharing (the room
+// collates everyone's logs). Built for offset/latency hunts: have the other
+// peer press it too, then compare their content against their own metronome
+// (linkaudio-probe -offset-ref).
+func (a *App) DebugRoom(displayName string, linkAudioName *string) (*JoinResult, error) {
+	res, err := a.JoinRoom("wail-debug", nil, displayName, nil, nil, nil, nil, nil, nil, nil, nil, linkAudioName)
+	if err != nil {
+		return nil, err
+	}
+	if err := a.SetMetronomeBroadcast(true); err != nil {
+		log.Printf("[app] debug room: metronome broadcast failed: %v", err)
+	}
+	if err := a.SetLoopback(true); err != nil {
+		log.Printf("[app] debug room: loopback failed: %v", err)
+	}
+	if err := a.SetLogSharing(true); err != nil {
+		log.Printf("[app] debug room: log sharing failed: %v", err)
+	}
+	log.Printf("[app] debug room joined: metronome broadcast + loopback + log sharing armed")
+	return res, nil
+}
+
 // SetLogSharing toggles WebSocket log broadcasting to peers.
 func (a *App) SetLogSharing(enabled bool) error {
 	if a.wsLog != nil {

--- a/wail-app/audio_engine.go
+++ b/wail-app/audio_engine.go
@@ -81,6 +81,9 @@ type EngineHealth struct {
 	EmitSinkWriteRejected   uint64 `json:"emit_sink_write_rejected"`    // sink refused a chunk mid-stream (queue full / listener left) — hole in delivered audio
 	WireDecodeFailures      uint64 `json:"wire_decode_failures"`        // WAIF wire-decode errors
 	OpusDecodeFailures      uint64 `json:"opus_decode_failures"`        // Opus decode errors
+	// StreamOffsets is the debug-room per-stream phase-offset readout vs the
+	// room grid (internal/offset), computed on demand by Health.
+	StreamOffsets []StreamOffset `json:"stream_offsets,omitempty"`
 	// EmitCushionMs is the current effective emit feed-ahead (config, not a
 	// counter): it rides the snapshot so the UI can show/initialise the cushion
 	// control. Not a HEALTH_FIELDS row.

--- a/wail-app/audio_engine_real.go
+++ b/wail-app/audio_engine_real.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nicholasgasior/wail/wail-app/internal/interval"
 	"github.com/nicholasgasior/wail/wail-app/internal/lanloss"
 	"github.com/nicholasgasior/wail/wail-app/internal/metronome"
+	"github.com/nicholasgasior/wail/wail-app/internal/offset"
 	"github.com/nicholasgasior/wail/wail-app/internal/pace"
 	"github.com/nicholasgasior/wail/wail-app/internal/playout"
 )
@@ -259,6 +260,11 @@ type emitStream struct {
 	// index (ADR-0006 follow-up): a persistent nonzero verdict means the
 	// peer's audio plays that many intervals late/early, silently.
 	labelTrack emit.LabelOffsetTracker
+
+	// offsetTrk accumulates per-frame RMS at absolute room-frame positions
+	// (debug-room analysis: this stream's rhythmic phase offset vs the room
+	// grid, internal/offset). Created on first decoded frame.
+	offsetTrk *offset.Tracker
 
 	// Observability (ADR-0003 / pillar 8). Atomic so Health() on another
 	// goroutine reads them race-free: decodeFailures/framesConcealed are bumped
@@ -954,6 +960,32 @@ func (e *linkAudioEngine) HandleRemoteAudio(fromIdentity, displayName, streamNam
 		}
 		return
 	}
+	// Debug-room offset analysis: frame energy at its absolute room-frame
+	// position. Cheap (one channel's sum of squares per 20ms frame).
+	if st.offsetTrk == nil {
+		st.offsetTrk = offset.NewTracker(4000)
+	}
+	{
+		ch := int(f.Channels)
+		if ch < 1 {
+			ch = 1
+		}
+		var ss float64
+		nf := len(pcm) / ch
+		for i := 0; i < nf; i++ {
+			v := float64(pcm[i*ch])
+			ss += v * v
+		}
+		rms := 0.0
+		if nf > 0 {
+			rms = math.Sqrt(ss / float64(nf))
+		}
+		fpi := int64(FramesPerInterval(e.tempoBPM, e.cfg))
+		if fpi <= 0 {
+			fpi = 1
+		}
+		st.offsetTrk.Add(f.IntervalIndex*fpi+int64(f.FrameNumber), rms)
+	}
 	if !st.haveSeq || !seqLess(f.FrameSeq, st.expectSeq) {
 		st.haveSeq = true
 		st.expectSeq = f.FrameSeq + 1
@@ -1026,6 +1058,27 @@ func (e *linkAudioEngine) Health() EngineHealth {
 	}
 	h.WireDecodeFailures = e.wireDecodeFailures.Load()
 	h.EmitCushionMs = cushionMsFromFrames(e.cushionFrames)
+	// Debug-room stream offsets: each stream's measured rhythmic phase offset
+	// vs the room grid (internal/offset). Only computed for streams with
+	// enough buffered frames to judge; absent otherwise.
+	beatMs := 0.0
+	if e.tempoBPM > 0 {
+		beatMs = 60000 / e.tempoBPM
+	}
+	if beatMs > 0 {
+		for _, st := range e.emit {
+			if st.offsetTrk == nil || st.offsetTrk.Len() < 400 {
+				continue
+			}
+			if ms, ok := st.offsetTrk.Offset(20, beatMs); ok {
+				h.StreamOffsets = append(h.StreamOffsets, StreamOffset{
+					Name: affinity.FormatName(st.lastDisplayName, st.lastStreamName),
+					Ms:   ms,
+				})
+			}
+		}
+		sort.Slice(h.StreamOffsets, func(i, j int) bool { return h.StreamOffsets[i].Name < h.StreamOffsets[j].Name })
+	}
 	return h
 }
 

--- a/wail-app/cmd/linkaudio-probe/main.go
+++ b/wail-app/cmd/linkaudio-probe/main.go
@@ -18,6 +18,7 @@ import (
 	"math"
 	"os"
 	"os/signal"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -43,14 +44,22 @@ type chanState struct {
 	// BPI-lens beat the buffer begins at, floored to its interval). Only
 	// populated when -bpi is set; used by the tier2 interval-placement E2E.
 	gridFrames map[int64]int
+
+	// offset analysis (when -offset-ref is set): ring of per-buffer RMS
+	// envelopes for cross-correlation against the reference channel.
+	rmsRing  []float64
+	tempoBPM float64
 }
 
 func main() {
 	peerName := flag.String("name", "wail-probe", "Link Audio peer name for this probe")
 	match := flag.String("match", "", "only subscribe to channels whose \"peer · name\" contains this substring (case-insensitive); empty = all")
 	bpi := flag.Float64("bpi", 0, "if >0, also report the shared-grid interval index of received audio (beat mapped at this beats-per-interval lens; must match the room's BPI)")
+	offsetRef := flag.String("offset-ref", "", "if set, report per-channel onset phase offset in ms vs the channel whose name contains this substring (e.g. \"WAIL Metronome\")")
+	offsetDump := flag.String("offset-dump", "", "if set (and -offset-ref), write ref+channel RMS envelopes as CSVs to this directory on exit")
 	flag.Parse()
 	matchLower := strings.ToLower(*match)
+	offsetRefLower := strings.ToLower(*offsetRef)
 
 	l := abllink.New(120)
 	l.SetPeerName(*peerName)
@@ -59,7 +68,7 @@ func main() {
 	defer l.Close()
 
 	var ss *abllink.SessionState
-	if *bpi > 0 {
+	if *bpi > 0 || *offsetRef != "" {
 		ss = abllink.NewSessionState()
 	}
 
@@ -80,6 +89,9 @@ func main() {
 		select {
 		case <-sigCh:
 			log.Printf("stopping")
+			if *offsetDump != "" {
+				dumpEnvelopes(subs, *offsetDump)
+			}
 			for _, st := range subs {
 				st.src.Close()
 			}
@@ -156,11 +168,24 @@ func main() {
 						prev = s
 						first = false
 					}
+
+					// Offset analysis: keep the per-buffer RMS envelope ring
+					// for cross-correlation (see reportOffsets).
+					if *offsetRef != "" && buf.NumFrames > 0 {
+						st.tempoBPM = buf.TempoBPM
+						st.rmsRing = appendPhase(st.rmsRing, chanBufRMS(buf), 4096)
+					}
 				}
 			}
 
 			if !report {
 				continue
+			}
+
+			// Offset analysis report (every 15s): per-channel onset phase vs the
+			// reference channel's (e.g. the WAIL Metronome, grid-rendered).
+			if *offsetRef != "" && tick%(reportEvery*15) == 0 {
+				reportOffsets(subs, offsetRefLower)
 			}
 
 			for _, st := range subs {
@@ -194,4 +219,195 @@ func main() {
 			}
 		}
 	}
+}
+
+// --- Offset analysis helpers ---
+
+// chanBufRMS computes the RMS of one buffer's channel 0.
+func chanBufRMS(buf abllink.CaptureBuffer) float64 {
+	ch := buf.NumChannels
+	if ch < 1 {
+		ch = 1
+	}
+	if buf.NumFrames == 0 {
+		return 0
+	}
+	var s float64
+	for i := 0; i < buf.NumFrames; i++ {
+		idx := i * ch
+		if idx >= len(buf.Samples) {
+			break
+		}
+		v := float64(buf.Samples[idx])
+		s += v * v
+	}
+	return math.Sqrt(s / float64(buf.NumFrames))
+}
+
+// appendPhase appends v to a bounded ring.
+func appendPhase(hist []float64, v float64, max int) []float64 {
+	hist = append(hist, v)
+	if len(hist) > max {
+		hist = hist[len(hist)-max:]
+	}
+	return hist
+}
+
+func medianHist(h []float64) float64 {
+	if len(h) == 0 {
+		return 0
+	}
+	cp := make([]float64, len(h))
+	copy(cp, h)
+	sort.Float64s(cp)
+	return cp[len(cp)/2]
+}
+
+// reportOffsets cross-correlates each channel's RMS envelope against the
+// reference channel's (the grid-rendered metronome) and reports the peak lag
+// in milliseconds. Pattern-agnostic and robust: any periodic content (clicks,
+// patterns) locks to its phase offset; fixed DAW-chain latency shows directly
+// while grid/network effects cancel through the shared path.
+func reportOffsets(subs map[abllink.ChannelID]*chanState, refLower string) {
+	var ref *chanState
+	for _, st := range subs {
+		if strings.Contains(strings.ToLower(st.peer+" · "+st.name), refLower) {
+			ref = st
+			break
+		}
+	}
+	if ref == nil || len(ref.rmsRing) < 400 {
+		return
+	}
+	for _, st := range subs {
+		if st == ref || len(st.rmsRing) < 400 {
+			continue
+		}
+		lagMs, strength := xcorrPeak(ref.rmsRing, st.rmsRing)
+		top := xcorrTop(ref.rmsRing, st.rmsRing, 3)
+		log.Printf("[offset] %q · %q: %+.0f ms vs %q · %q (peak %.2f; top3 %v)",
+			st.peer, st.name, lagMs, ref.peer, ref.name, strength, top)
+	}
+}
+
+// xcorrTop returns the top-n (lagMs, strength) correlation peaks for
+// inspecting alias structure.
+func xcorrTop(a, b []float64, nTop int) [][2]float64 {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	if n > 2000 {
+		n = 2000
+	}
+	a = a[len(a)-n:]
+	b = b[len(b)-n:]
+	var ma, mb float64
+	for i := 0; i < n; i++ {
+		ma += a[i]
+		mb += b[i]
+	}
+	ma /= float64(n)
+	mb /= float64(n)
+	const bufMs = 128.0 / 48.0
+	maxLag := int(math.Round(250.0 / bufMs))
+	type peak struct{ s, lag float64 }
+	var peaks []peak
+	for lag := -maxLag; lag <= maxLag; lag++ {
+		var sum float64
+		for i := 0; i < n; i++ {
+			j := i + lag
+			if j < 0 || j >= n {
+				continue
+			}
+			sum += (a[i] - ma) * (b[j] - mb)
+		}
+		peaks = append(peaks, peak{sum, float64(lag)})
+	}
+	sort.Slice(peaks, func(i, j int) bool { return peaks[i].s > peaks[j].s })
+	out := make([][2]float64, 0, nTop)
+	for i := 0; i < nTop && i < len(peaks); i++ {
+		out = append(out, [2]float64{peaks[i].lag * bufMs, peaks[i].s})
+	}
+	return out
+}
+
+// xcorrPeak returns the lag (in ms) at which the cross-correlation of
+// envelopes a (reference) and b peaks, plus a rough normalized strength.
+// Positive lag = b is LATE relative to a. Envelopes are per received Link
+// Audio buffer (~128 frames @ 48kHz = 2.667ms steps).
+func xcorrPeak(a, b []float64) (float64, float64) {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	if n > 2000 {
+		n = 2000
+	}
+	a = a[len(a)-n:]
+	b = b[len(b)-n:]
+	var ma, mb float64
+	for i := 0; i < n; i++ {
+		ma += a[i]
+		mb += b[i]
+	}
+	ma /= float64(n)
+	mb /= float64(n)
+	const bufMs = 128.0 / 48.0
+	maxLag := int(math.Round(250.0 / bufMs))
+	best, bestLag, zero := 0.0, 0, 0.0
+	for lag := -maxLag; lag <= maxLag; lag++ {
+		var sum float64
+		for i := 0; i < n; i++ {
+			j := i + lag
+			if j < 0 || j >= n {
+				continue
+			}
+			sum += (a[i] - ma) * (b[j] - mb)
+		}
+		if lag == 0 {
+			zero = sum
+		}
+		if sum > best {
+			best, bestLag = sum, lag
+		}
+	}
+	strength := 0.0
+	if zero != 0 {
+		strength = best / math.Abs(zero)
+	}
+	return float64(bestLag) * bufMs, strength
+}
+
+// dumpEnvelopes writes each channel's RMS envelope ring to <dir>/<peer>-<name>.csv
+// (one value per line, ~2.6ms per step) for offline cross-correlation.
+func dumpEnvelopes(subs map[abllink.ChannelID]*chanState, dir string) {
+	for _, st := range subs {
+		if len(st.rmsRing) == 0 {
+			continue
+		}
+		name := fmt.Sprintf("%s/%s-%s.csv", dir, sanitizeName(st.peer), sanitizeName(st.name))
+		f, err := os.Create(name)
+		if err != nil {
+			log.Printf("[offset-dump] %v", err)
+			continue
+		}
+		for _, v := range st.rmsRing {
+			fmt.Fprintf(f, "%.1f\n", v)
+		}
+		f.Close()
+		log.Printf("[offset-dump] wrote %s (%d samples)", name, len(st.rmsRing))
+	}
+}
+
+func sanitizeName(s string) string {
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' {
+			out = append(out, r)
+		} else {
+			out = append(out, '_')
+		}
+	}
+	return string(out)
 }

--- a/wail-app/events.go
+++ b/wail-app/events.go
@@ -103,9 +103,20 @@ type StatusUpdate struct {
 	CaptureChannels []CaptureChannelInfo `json:"capture_channels,omitempty"`
 	// Grid alignment (ADR-0006): live readout for the debug panel. State is
 	// "aligned"/"aligning"/"drifted"/"off"; empty until the aligner is ready.
-	AlignState   string   `json:"align_state,omitempty"`
-	AlignErrorMs *float64 `json:"align_error_ms,omitempty"`
-	RelayRTTMs   *float64 `json:"relay_rtt_ms,omitempty"`
+	AlignState   string         `json:"align_state,omitempty"`
+	AlignErrorMs *float64       `json:"align_error_ms,omitempty"`
+	RelayRTTMs   *float64       `json:"relay_rtt_ms,omitempty"`
+	// StreamOffsets is the debug-room readout: per-stream rhythmic phase
+	// offset vs the room grid (internal/offset), empty until enough rhythmic
+	// content has arrived to judge.
+	StreamOffsets []StreamOffset `json:"stream_offsets,omitempty"`
+}
+
+// StreamOffset is one stream's measured rhythmic phase offset vs the room
+// grid in milliseconds (debug-room analysis; positive = content late).
+type StreamOffset struct {
+	Name string  `json:"name"`
+	Ms   float64 `json:"ms"`
 }
 
 type PeerNetworkInfo struct {

--- a/wail-app/frontend/index.html
+++ b/wail-app/frontend/index.html
@@ -88,6 +88,7 @@
         </details>
 
         <button type="submit" id="join-btn">Join Room</button>
+        <button type="button" id="debug-room-btn" class="debug-btn" title="Join the shared wail-debug room with the reference metronome, loopback, and peer log sharing armed">Debug Room</button>
       </form>
 
       <div id="join-error" class="error" style="display:none"></div>
@@ -258,6 +259,11 @@
         <div id="network-health" class="network-health">
           <span class="empty">No diagnostics yet</span>
         </div>
+      </section>
+
+      <section class="session-section" id="stream-offsets-section" style="display:none">
+        <h3 class="section-label">Stream offsets vs room grid (debug)</h3>
+        <div id="stream-offsets" class="network-health"></div>
       </section>
 
       <section class="session-section">

--- a/wail-app/frontend/main.js
+++ b/wail-app/frontend/main.js
@@ -754,6 +754,30 @@ joinForm.addEventListener('submit', async (e) => {
   }
 });
 
+// --- Debug Room ---
+// One button: join the shared wail-debug room with the reference metronome,
+// loopback, and peer log sharing armed (see App.DebugRoom).
+document.getElementById('debug-room-btn').addEventListener('click', async () => {
+  const btn = document.getElementById('debug-room-btn');
+  joinError.style.display = 'none';
+  btn.disabled = true;
+  btn.textContent = 'Connecting...';
+  try {
+    const result = await invoke('debug_room', {
+      displayName: getDisplayName(),
+      linkAudioName: getLinkAudioName(),
+    });
+    saveSettings();
+    showSession(result.room);
+    setupListeners();
+  } catch (err) {
+    showError(joinError, err);
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Debug Room';
+  }
+});
+
 // --- Disconnect ---
 disconnectBtn.addEventListener('click', async () => {
   try {
@@ -974,6 +998,28 @@ function renderHealth(health) {
   }).join('');
 }
 
+// Debug-room stream offsets (status.stream_offsets): each remote stream's
+// measured rhythmic phase offset vs the room grid. |offset| > 25ms is
+// highlighted — that stream's content is audibly off-grid.
+function renderStreamOffsets(update) {
+  const section = document.getElementById('stream-offsets-section');
+  const el = document.getElementById('stream-offsets');
+  if (!section || !el) return;
+  const offs = (update && update.stream_offsets) || [];
+  if (offs.length === 0) {
+    section.style.display = 'none';
+    el.innerHTML = '';
+    return;
+  }
+  section.style.display = '';
+  el.innerHTML = offs.map(o => {
+    const ms = Math.round(o.ms);
+    const cls = Math.abs(ms) > 25 ? 'health-bad' : '';
+    const sign = ms > 0 ? '+' : '';
+    return `<div class="health-row"><span>${o.name}</span><span class="${cls}">${sign}${ms} ms</span></div>`;
+  }).join('');
+}
+
 // Unified peers tree (Session tab): a "you" node carrying your sends —
 // enabled capture channels and in-app senders (test tone / WAV), names
 // click-to-rename — above the remote peer nodes with their channels nested
@@ -1138,6 +1184,7 @@ async function setupListeners() {
     });
     if (statusSnapshots.length > STATS_WINDOW_SIZE) statusSnapshots.shift();
     renderStatus(s);
+    renderStreamOffsets(s);
     seedClock(s);
   }));
 

--- a/wail-app/frontend/style.css
+++ b/wail-app/frontend/style.css
@@ -1211,3 +1211,17 @@ summary:hover {
   cursor: pointer;
 }
 
+
+.debug-btn {
+  width: 100%;
+  margin-top: 8px;
+  padding: 10px;
+  background: #3b2f5e;
+  color: #d8ccff;
+  border: 1px solid #6b5ca5;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+}
+.debug-btn:hover { background: #4a3d75; }
+.debug-btn:disabled { opacity: 0.6; cursor: default; }

--- a/wail-app/internal/offset/offset.go
+++ b/wail-app/internal/offset/offset.go
@@ -1,0 +1,117 @@
+// Package offset measures a stream's rhythmic phase offset against the room
+// grid from its labeled frames (the "debug room" analysis): segments of
+// energy in the frame-RMS series yield click onsets whose absolute room-frame
+// positions fold into a modal beat phase. A stream whose content sits on the
+// grid reports ~0; a peer performing late (e.g. monitoring through a latent
+// path) shows it directly in milliseconds, no DAW or envelope-matching needed.
+package offset
+
+import "math"
+
+// Frame is one labeled audio frame's energy at its absolute room-frame
+// position (intervalIndex*framesPerInterval + frameNumber).
+type Frame struct {
+	Abs int64
+	RMS float64
+}
+
+// Tracker accumulates a bounded history of frames for one stream.
+type Tracker struct {
+	frames []Frame
+	max    int
+}
+
+func NewTracker(maxFrames int) *Tracker {
+	if maxFrames <= 0 {
+		maxFrames = 4000
+	}
+	return &Tracker{max: maxFrames}
+}
+
+func (t *Tracker) Add(abs int64, rms float64) {
+	t.frames = append(t.frames, Frame{Abs: abs, RMS: rms})
+	if len(t.frames) > t.max {
+		t.frames = t.frames[len(t.frames)-t.max:]
+	}
+}
+
+// Len reports the buffered frame count (analysis needs a few hundred).
+func (t *Tracker) Len() int { return len(t.frames) }
+
+type segment struct{ start, end int64 }
+
+// segments finds energy bursts above max(20% of peak, floor) in abs space.
+// Gaps up to 2 frames are bridged (late/lost frames read as silence).
+func segments(frames []Frame, floor float64) []segment {
+	if len(frames) == 0 {
+		return nil
+	}
+	mx := 0.0
+	for _, f := range frames {
+		if f.RMS > mx {
+			mx = f.RMS
+		}
+	}
+	thr := mx * 0.2
+	if thr < floor {
+		thr = floor
+	}
+	var segs []segment
+	i := 0
+	for i < len(frames) {
+		if frames[i].RMS > thr {
+			start := frames[i].Abs
+			end := frames[i].Abs
+			j := i + 1
+			for j < len(frames) && (frames[j].RMS > thr || (j+1 < len(frames) && frames[j+1].RMS > thr && frames[j+1].Abs-frames[j].Abs <= 2)) {
+				end = frames[j].Abs
+				j++
+			}
+			segs = append(segs, segment{start, end})
+			i = j
+		} else {
+			i++
+		}
+	}
+	return segs
+}
+
+// Offset returns the stream's modal content phase relative to the beat grid,
+// in milliseconds: segment onsets are folded into beat phase and the circular
+// mode returned, wrapped to ±beat/2. beatMs is 60000/bpm; frameMs is the
+// duration of one frame (20ms in WAIL). ok is false with fewer than 4
+// segments (not enough rhythmic content to judge).
+func (t *Tracker) Offset(frameMs, beatMs float64) (float64, bool) {
+	segs := segments(t.frames, 300)
+	if len(segs) < 4 {
+		return 0, false
+	}
+	// Circular mode of onset phases in 24 bins per beat.
+	var bins [24]int
+	for _, s := range segs {
+		ph := math.Mod(s.phase(frameMs, beatMs), 1)
+		if ph < 0 {
+			ph++
+		}
+		b := int(ph * 24)
+		if b >= 24 {
+			b = 23
+		}
+		bins[b]++
+	}
+	best, bi := 0, 0
+	for i, c := range bins {
+		if c > best {
+			best, bi = c, i
+		}
+	}
+	ph := (float64(bi) + 0.5) / 24
+	if ph > 0.5 {
+		ph--
+	}
+	return ph * beatMs, true
+}
+
+func (s segment) phase(frameMs, beatMs float64) float64 {
+	return float64(s.start) * frameMs / beatMs
+}

--- a/wail-app/internal/offset/offset_test.go
+++ b/wail-app/internal/offset/offset_test.go
@@ -1,0 +1,96 @@
+package offset
+
+import (
+	"math"
+	"testing"
+)
+
+// clickSeries appends clicks (10ms = half a frame of full energy) at the
+// given abs frame positions on a silent background.
+func clickSeries(tr *Tracker, frameDurFrames int, positions []int64) {
+	maxAbs := int64(0)
+	for _, p := range positions {
+		if p > maxAbs {
+			maxAbs = p
+		}
+	}
+	energy := map[int64]float64{}
+	for _, p := range positions {
+		energy[p] = 9000
+	}
+	for abs := int64(0); abs <= maxAbs+10; abs++ {
+		tr.Add(abs, energy[abs])
+	}
+}
+
+func TestOffsetOnGridClicks(t *testing.T) {
+	// Clicks every beat (25 frames at 20ms, 120bpm = 500ms) at phase 0.
+	tr := NewTracker(0)
+	var pos []int64
+	for k := int64(0); k < 8; k++ {
+		pos = append(pos, k*25)
+	}
+	clickSeries(tr, 1, pos)
+	ms, ok := tr.Offset(20, 500)
+	if !ok {
+		t.Fatal("no offset for clear click series")
+	}
+	if math.Abs(ms) > 15 {
+		t.Fatalf("on-grid clicks measured %+.1f ms, want ~0", ms)
+	}
+}
+
+func TestOffsetLateClicks(t *testing.T) {
+	// Same series shifted +88ms (+4.4 frames at 20ms).
+	tr := NewTracker(0)
+	var pos []int64
+	for k := int64(0); k < 8; k++ {
+		pos = append(pos, 4+k*25) // +80ms
+	}
+	clickSeries(tr, 1, pos)
+	ms, ok := tr.Offset(20, 500)
+	if !ok {
+		t.Fatal("no offset for click series")
+	}
+	if ms < 60 || ms > 100 {
+		t.Fatalf("shifted clicks measured %+.1f ms, want ~+80", ms)
+	}
+}
+
+func TestOffsetSubdividedPattern(t *testing.T) {
+	// Clicks every HALF beat at +100ms: phases ~0.21 and ~0.71 — the modal
+	// phase must pick one cluster, not smear (both are "late" by 100ms;
+	// accepting either is correct for offset measurement). Beat = 480ms
+	// (24 frames) so the half-beat lands on whole frames.
+	tr := NewTracker(0)
+	var pos []int64
+	for k := int64(0); k < 12; k++ {
+		pos = append(pos, 5+k*12) // every 240ms starting at +100ms
+	}
+	clickSeries(tr, 1, pos)
+	ms, ok := tr.Offset(20, 480)
+	if !ok {
+		t.Fatal("no offset for subdivided pattern")
+	}
+	// 100ms (0.208 beat) or -140ms (0.708 wrapped) are both correct reads.
+	if !(math.Abs(ms-100) < 25 || math.Abs(ms+140) < 25) {
+		t.Fatalf("subdivided pattern measured %+.1f ms, want 100 or -140", ms)
+	}
+}
+
+func TestOffsetInsufficientContent(t *testing.T) {
+	tr := NewTracker(0)
+	tr.Add(0, 9000)
+	tr.Add(25, 9000)
+	if _, ok := tr.Offset(20, 500); ok {
+		t.Fatal("two clicks must not yield an offset")
+	}
+	// Silence must not yield an offset either.
+	tr2 := NewTracker(0)
+	for i := int64(0); i < 200; i++ {
+		tr2.Add(i, 0)
+	}
+	if _, ok := tr2.Offset(20, 500); ok {
+		t.Fatal("silence must not yield an offset")
+	}
+}

--- a/wail-app/ipc_source.go
+++ b/wail-app/ipc_source.go
@@ -73,6 +73,19 @@ func (s *ipcCaptureSource) Push(samples []int16, beginFrame uint64, channels int
 	s.ring = append(s.ring, blk)
 }
 
+// ipcStaleStampThresholdUs bounds how far a reconstructed stamp may lie in
+// the FUTURE before the anchor is re-armed. Stamps should sit at or behind
+// the pop instant (capture → IPC → drain); a stamp seconds ahead means the
+// anchor was armed on a stale re-sent block — wail_send.c preserves and
+// re-sends the send ring through a WAIL outage, so the first blocks after a
+// reconnect can be arbitrarily old. Extrapolating from such an anchor stamps
+// all subsequent audio by the outage duration (field finding: an 11-minute
+// outage put both peers' capture +82/+83 intervals ahead, frozen for the
+// session). 2s: far above any backlog, far below any plausible outage.
+const ipcStaleStampThresholdUs = 2_000_000
+
+// PopMapped drains the oldest block from the ring. ok is false when the ring is empty.
+// Call from a single drain goroutine.
 func (s *ipcCaptureSource) PopMapped(ss *abllink.SessionState, quantum float64) (captureBuffer, float64, bool, bool) {
 	s.mu.Lock()
 	if len(s.ring) == 0 {
@@ -94,6 +107,14 @@ func (s *ipcCaptureSource) PopMapped(ss *abllink.SessionState, quantum float64) 
 	stampMicros := s.anchorMicros
 	if blk.sampleRate > 0 {
 		stampMicros += int64(blk.beginFrame-s.anchorFrames) * 1_000_000 / int64(blk.sampleRate)
+	}
+	// Stale-ring guard (see ipcStaleStampThresholdUs): re-arm the anchor on
+	// the current block when the reconstructed stamp jumps implausibly far
+	// into the future.
+	if stampMicros-s.nowMicros() > ipcStaleStampThresholdUs {
+		s.anchorMicros = s.nowMicros()
+		s.anchorFrames = blk.beginFrame
+		stampMicros = s.anchorMicros
 	}
 	s.mu.Unlock()
 

--- a/wail-app/ipc_source_test.go
+++ b/wail-app/ipc_source_test.go
@@ -93,3 +93,52 @@ func TestRawPCMToInt16(t *testing.T) {
 		t.Fatalf("float32 conversion = %v, want %v", got, want)
 	}
 }
+
+func TestIPCCaptureSourceStaleRingReanchors(t *testing.T) {
+	lb := NewLinkBridge(120, 4)
+	ss := abllink.NewSessionState()
+	defer ss.Close()
+	lb.Link().CaptureAppSessionState(ss)
+
+	// The plugin's send ring sat blocked through an 11-minute WAIL outage
+	// (wail_send.c re-sends the stale slots on reconnect). The stale slots
+	// (begin_frame ≈ 0) flush first and arm the anchor...
+	var nowUs int64 = 100_000_000
+	src := &ipcCaptureSource{nowMicros: func() int64 { return nowUs }}
+	src.Push([]int16{0, 0}, 0, 2, 48000)     // stale slot 1 (11 min old)
+	src.Push([]int16{0, 0}, 48000, 2, 48000) // stale slot 2
+	if _, _, ok, _ := src.PopMapped(ss, 4.0); !ok {
+		t.Fatal("stale slot 1 must map")
+	}
+	_, beat2, ok2, _ := src.PopMapped(ss, 4.0)
+	if !ok2 {
+		t.Fatal("stale slot 2 must map")
+	}
+
+	// ...then the CURRENT block arrives, 31.7M frames (11 min) later. The
+	// anchor must re-arm on the implausible forward jump; extrapolating from
+	// the stale anchor would stamp this 660s in the future (+82 intervals —
+	// the field bug), frozen for the session.
+	nowUs += 10_000_000 // 10s of playback since the outage
+	src.Push([]int16{0, 0}, 31_700_000, 2, 48000)
+	_, beat, ok, _ := src.PopMapped(ss, 4.0)
+	if !ok {
+		t.Fatal("current block must map")
+	}
+	// Re-armed: the stamp advanced from the stale slot's 101s to 110s of
+	// real time (18 beats). Poisoned: it would jump ~1319 beats (660s).
+	if d := beat - beat2; math.Abs(d-18.0) > 1.0 {
+		t.Fatalf("stamp jump from stale ring = %.1f beats, want ~18 (re-armed) — poisoned anchor would give ~1319", d)
+	}
+
+	// And a small forward skew (≤ the threshold) must NOT re-arm: normal
+	// backlog/jitter keeps the established anchor.
+	src.Push([]int16{0, 0}, 31_700_000+48000, 2, 48000)
+	_, beat3, ok3, _ := src.PopMapped(ss, 4.0)
+	if !ok3 {
+		t.Fatal("follow-up block must map")
+	}
+	if d := beat3 - beat; math.Abs(d-2.0) > 1e-6 {
+		t.Fatalf("beat advance after re-arm = %f, want 2.0 (anchor kept)", d)
+	}
+}

--- a/wail-app/main.go
+++ b/wail-app/main.go
@@ -31,6 +31,7 @@ func main() {
 	wavFile := flag.String("wav", "", "WAV file to send (headless mode)")
 	testTone := flag.Bool("test-tone", false, "Send a synthetic test tone on stream 0 (headless mode; no DAW/WAV needed)")
 	loopback := flag.Bool("loopback", false, "Ask the relay to echo our own audio back; republished as a \"(loopback)\" Link Audio channel (headless mode)")
+	metronomeBroadcast := flag.Bool("metronome-broadcast", false, "Broadcast the WAIL Metronome click to the room as an audio stream (headless mode; debug reference)")
 	instance := flag.Int("instance", 0, "Instance number (separate data dir / identity)")
 	flag.Parse()
 
@@ -61,7 +62,7 @@ func main() {
 	log.Printf("App initialized — identity: %s", appBackend.identity)
 
 	if *headless {
-		runHeadless(appBackend, *room, *password, *bpmFlag, *name, *wavFile, *testTone, *loopback)
+		runHeadless(appBackend, *room, *password, *bpmFlag, *name, *wavFile, *testTone, *loopback, *metronomeBroadcast)
 		return
 	}
 
@@ -127,7 +128,7 @@ func main() {
 	}
 }
 
-func runHeadless(app *App, room, password string, bpm float64, name, wavFile string, testTone, loopback bool) {
+func runHeadless(app *App, room, password string, bpm float64, name, wavFile string, testTone, loopback, metronomeBroadcast bool) {
 	if room == "" {
 		log.Fatal("-room is required in headless mode")
 	}
@@ -173,6 +174,13 @@ func runHeadless(app *App, room, password string, bpm float64, name, wavFile str
 			log.Fatalf("Failed to enable loopback: %v", err)
 		}
 		log.Printf("Server-echo loopback enabled")
+	}
+
+	if metronomeBroadcast {
+		if err := app.SetMetronomeBroadcast(true); err != nil {
+			log.Fatalf("Failed to enable metronome broadcast: %v", err)
+		}
+		log.Printf("WAIL Metronome broadcast enabled")
 	}
 
 	// Block until signal

--- a/wail-app/session.go
+++ b/wail-app/session.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"math"
 	"os"
+	"reflect"
 	"sort"
 	"strconv"
 	"sync"
@@ -563,6 +564,17 @@ func sessionLoop(
 				sentStreamNames = nil // new peer: re-broadcast even if unchanged
 				syncStreamNames()
 
+			case "LogBroadcast":
+				// Peer log sharing: fold a peer's log line into our log (and the
+				// GUI panel) with their name, so one client collates the room.
+				name := ev.From
+				peers.WithPeer(ev.From, func(p *PeerState) {
+					if p.DisplayName != nil {
+						name = *p.DisplayName
+					}
+				})
+				log.Printf("[%s] %s", name, ev.Message)
+
 			case "PeerLeft":
 				var name string
 				peers.WithPeer(ev.PeerID, func(p *PeerState) {
@@ -1112,6 +1124,10 @@ func sessionLoop(
 				}
 			}
 
+			// Engine health snapshot (also carries the debug-room stream offsets).
+			// Fetched before the emit so the diff log follows in the same tick.
+			health := audioEngine.Health()
+
 			emitter.Emit("status:update", StatusUpdate{
 				BPM: state.BPM, Beat: state.Beat, Phase: state.Phase,
 				LinkPeers: state.NumPeers, Peers: peerInfos, Slots: slotInfos,
@@ -1121,6 +1137,7 @@ func sessionLoop(
 				AudioBytesSent: audioBytesSent, AudioBytesRecv: audioBytesRecv,
 				AudioDCOpen: dcOpen, PluginConnected: true,
 				AlignState: alignStateStr, AlignErrorMs: alignErrMs, RelayRTTMs: relayRttMs,
+				StreamOffsets: health.StreamOffsets,
 				Recording: recorder != nil,
 				RecordingSizeBytes: func() uint64 {
 					if recorder != nil {
@@ -1136,9 +1153,11 @@ func sessionLoop(
 			mesh.Broadcast(NewAudioStatus(dcOpen, audioIntervalsSent, audioIntervalsReceived, true, audioStatusSeq))
 
 			// Engine health: log any counter that moved (each increment is a
-			// likely-audible event), then ship the snapshot with the network event.
-			health := audioEngine.Health()
-			if health != lastHealth {
+			// likely-audible event). StreamOffsets is a slice — compare the
+			// snapshot with it zeroed out (offsets are informational only).
+			hcNow, hcPrev := health, lastHealth
+			hcNow.StreamOffsets, hcPrev.StreamOffsets = nil, nil
+			if !reflect.DeepEqual(hcNow, hcPrev) {
 				delta := func(logf func(string, ...any), what string, prev, now uint64) {
 					if now > prev {
 						logf("[audio] %s +%d (total %d)", what, now-prev, now)


### PR DESCRIPTION
## What

One-press diagnostic mode for the "peer feels N ms off" class of problem, plus an in-app, DAW-less way to measure it. Motivated by the 88 ms offset hunt (root-caused by a parallel fix to the recv-plugin cushion — this PR is the tooling that lets anyone measure that class of issue).

## Features

- **Debug Room button** (join screen): one press joins the shared `wail-debug` room and arms all diagnostics — the WAIL Metronome broadcast (grid-rendered reference click), server-echo loopback, and peer log sharing. Headless equivalent: `-metronome-broadcast`.
- **Peer log collation**: incoming `LogBroadcast` events now fold into the local log with the peer's name (they were silently dropped) — one client collates the whole room's logs.
- **In-app stream offsets** (the DAW-less part): new pure `internal/offset` module computes each remote stream's modal rhythmic phase offset vs the room grid from labeled WAIF frames — `interval_index` + `frame_number` give exact room-frame positions, so no envelope matching or reference channel is needed. The engine accumulates per-frame RMS at decode, `Health` surfaces offsets on demand, and the Debug tab shows a **Stream offsets** section with |offset| > 25 ms highlighted. A peer performing late because their monitoring path is latent shows it directly.
- **Probe**: `linkaudio-probe -offset-ref` (envelope cross-correlation vs a reference channel, best for same-period rhythmic content) and `-offset-dump` (per-channel RMS envelopes to CSV — the mode that pinned +88 ms in practice).

## Tests

- `internal/offset`: TDD — on-grid clicks (~0), +80 ms shifted clicks, half-beat subdivided pattern (no phase smearing), insufficient content
- Full suite (real + linkstub), vet, tier2 E2E (placement majority vote) — all green
