### PR TITLE
feat: Link Bridge spike — Link SDK inside a CLAP plugin (ADR-0007 gate 1)

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(wail_plugins C)
+project(wail_plugins C CXX) # CXX: the Link Bridge plugins embed the Link SDK (ADR-0007)
 
 # Thin CLAP bridge plugins (ADR-0005). No external deps beyond the vendored CLAP
 # headers, libpthread (POSIX) / ws2_32 (Windows), and the system sockets — the WAIL
@@ -50,6 +50,50 @@ endfunction()
 
 add_wail_plugin(wail-send wail_send.c)
 add_wail_plugin(wail-recv wail_recv.c)
+
+# Link Bridge plugins (ADR-0007): the Link SDK (C++17 + asio) compiled into the
+# CLAP bundle itself — each plugin instance is its own LAN Link peer. Mirrors
+# the include paths and platform defines of the app's cgo build (see
+# wail-app/internal/abllink/abllink.go). Windows/MinGW additionally needs the
+# `interface` param rename in the vendored Channels.hpp, same as the app build.
+set(LINK_SDK "${CMAKE_CURRENT_SOURCE_DIR}/../vendor/link")
+if(NOT EXISTS "${LINK_SDK}/extensions/abl_link/src/abl_link.cpp")
+  message(FATAL_ERROR "Link SDK not found at ${LINK_SDK}. Run: git submodule update --init --recursive vendor/link")
+endif()
+function(add_linkbridge_plugin name)
+  add_library(${name} MODULE ${ARGN})
+  target_include_directories(${name} PRIVATE
+    "${CLAP_INCLUDE}" "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${LINK_SDK}/extensions/abl_link/include"
+    "${LINK_SDK}/extensions/abl_link/src"
+    "${LINK_SDK}/include"
+    "${LINK_SDK}/modules/asio-standalone/asio/include")
+  target_compile_features(${name} PRIVATE cxx_std_17)
+  set_target_properties(${name} PROPERTIES CXX_VISIBILITY_PRESET hidden VISIBILITY_INLINES_HIDDEN ON)
+  target_link_libraries(${name} PRIVATE Threads::Threads)
+  if(WIN32)
+    target_compile_definitions(${name} PRIVATE LINK_PLATFORM_WINDOWS=1 NOMINMAX)
+    target_link_libraries(${name} PRIVATE ws2_32 winmm iphlpapi)
+    set_target_properties(${name} PROPERTIES PREFIX "" SUFFIX ".clap")
+  elseif(APPLE)
+    target_compile_definitions(${name} PRIVATE LINK_PLATFORM_MACOSX=1 LINK_PLATFORM_UNIX=1)
+    set_target_properties(${name} PROPERTIES
+      BUNDLE TRUE
+      BUNDLE_EXTENSION "clap"
+      OUTPUT_NAME "${name}"
+      MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in"
+      MACOSX_BUNDLE_BUNDLE_NAME "${name}"
+      MACOSX_BUNDLE_GUI_IDENTIFIER "software.linkbridge.${name}"
+      MACOSX_BUNDLE_BUNDLE_VERSION "0.1.0"
+      MACOSX_BUNDLE_SHORT_VERSION_STRING "0.1.0")
+  else()
+    target_compile_definitions(${name} PRIVATE LINK_PLATFORM_LINUX=1 LINK_PLATFORM_UNIX=1)
+    target_link_libraries(${name} PRIVATE m atomic)
+    set_target_properties(${name} PROPERTIES PREFIX "" SUFFIX ".clap")
+  endif()
+endfunction()
+
+add_linkbridge_plugin(linkbridge-spike linkbridge_spike.c linkbridge_link.cpp) # dev spike (gate 1), not shipped
 
 # DAW-less integration tests (clap-trap host + IPC test double). Off by default:
 # enabling fetches clap-trap over the network at configure time.

--- a/plugins/linkbridge_link.cpp
+++ b/plugins/linkbridge_link.cpp
@@ -1,0 +1,70 @@
+// linkbridge_link.cpp — Link SDK compilation unit + C API impl for the Link
+// Bridge plugins (ADR-0007). Mirrors the Go app's abllink/wrap.cpp: pulls in
+// the vendored abl_link C wrapper (which instantiates the header-only SDK) and
+// exposes the small C surface linkbridge_link.h declares.
+//
+// Windows/MinGW gets the same accommodations as the app's cgo build (NOMINMAX,
+// winsock2 before windows.h); the `interface` param collision in Link's
+// Channels.hpp is handled at build time like the app does (see DEVELOPMENT.md).
+#if defined(_WIN32)
+#define NOMINMAX
+#include <winsock2.h>
+#include <windows.h>
+#endif
+
+#include "abl_link.cpp"
+#include "linkbridge_link.h"
+
+struct lb_link {
+  abl_link h;
+};
+struct lb_state {
+  abl_link_session_state s;
+};
+
+lb_link *lb_create(double tempo) {
+  lb_link *l = new lb_link{};
+  l->h = abl_link_create(tempo);
+  return l;
+}
+
+void lb_destroy(lb_link *l) {
+  if (!l) return;
+  abl_link_destroy(l->h);
+  delete l;
+}
+
+void lb_enable(lb_link *l, bool on) { abl_link_enable(l->h, on); }
+
+uint64_t lb_num_peers(lb_link *l) { return abl_link_num_peers(l->h); }
+
+double lb_tempo(lb_link *l) {
+  abl_link_session_state ss = abl_link_create_session_state();
+  abl_link_capture_app_session_state(l->h, ss);
+  double t = abl_link_tempo(ss);
+  abl_link_destroy_session_state(ss);
+  return t;
+}
+
+lb_state *lb_capture(lb_link *l) {
+  lb_state *s = new lb_state{};
+  s->s = abl_link_create_session_state();
+  abl_link_capture_audio_session_state(l->h, s->s);
+  return s;
+}
+
+void lb_release(lb_state *s) {
+  if (!s) return;
+  abl_link_destroy_session_state(s->s);
+  delete s;
+}
+
+double lb_beat_at_time(lb_state *s, int64_t micros, double quantum) {
+  return abl_link_beat_at_time(s->s, micros, quantum);
+}
+
+int64_t lb_time_at_beat(lb_state *s, double beat, double quantum) {
+  return abl_link_time_at_beat(s->s, beat, quantum);
+}
+
+int64_t lb_clock_micros(lb_link *l) { return abl_link_clock_micros(l->h); }

--- a/plugins/linkbridge_link.h
+++ b/plugins/linkbridge_link.h
@@ -1,0 +1,39 @@
+// linkbridge_link.h — C-facing Link session API for the Link Bridge plugins
+// (ADR-0007). Each plugin instance owns one abl_link handle (one LAN peer):
+// session membership and timeline math only in the spike; Link Audio
+// sink/source wraps come with the Send/Recv halves.
+//
+// Threading: create/enable/disable/destroy from the plugin's main or activate
+// path (never the audio thread — they spawn/join Link's threads). The state
+// snapshot/query calls are realtime-safe (abl_link session-state capture is
+// lock-free by design).
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct lb_link lb_link;
+
+lb_link *lb_create(double tempo);
+void lb_destroy(lb_link *l);
+void lb_enable(lb_link *l, bool on);
+
+uint64_t lb_num_peers(lb_link *l);
+double lb_tempo(lb_link *l);
+
+// Session timeline (capture a snapshot, query, release — the abl_link pattern;
+// safe from process()).
+typedef struct lb_state lb_state;
+lb_state *lb_capture(lb_link *l);
+void lb_release(lb_state *s);
+double lb_beat_at_time(lb_state *s, int64_t micros, double quantum);
+int64_t lb_time_at_beat(lb_state *s, double beat, double quantum);
+int64_t lb_clock_micros(lb_link *l);
+
+#ifdef __cplusplus
+}
+#endif

--- a/plugins/linkbridge_spike.c
+++ b/plugins/linkbridge_spike.c
@@ -1,0 +1,168 @@
+// Link Bridge spike (ADR-0007, gate 1): proves the Link SDK links into a
+// .clap bundle and a plugin-hosted peer joins the LAN Link session. On
+// activate it creates and enables a Link peer; a ~1Hz heartbeat logs peer
+// count and session tempo to /tmp/linkbridge-spike.log. Success = peer count
+// climbs when another Link peer (WAIL app, Live, Bitwig Link) is on the LAN
+// and the session tempo matches.
+//
+// Dev spike, not a product plugin. Full vtable (Bitwig null-derefs empty
+// entries — see transport_probe.c).
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "clap/clap.h"
+#include "linkbridge_link.h"
+
+#define SPIKE_LOG "/tmp/linkbridge-spike.log"
+
+typedef struct {
+   clap_plugin_t      plugin;
+   const clap_host_t *host;
+   FILE              *log;
+   lb_link           *link;
+   uint64_t           last_peers;
+   double             last_tempo;
+   int                blocks;
+} spike;
+
+static void spike_log(spike *self, const char *fmt, ...) {
+   if (!self->log) return;
+   va_list ap;
+   va_start(ap, fmt);
+   vfprintf(self->log, fmt, ap);
+   va_end(ap);
+   fputc('\n', self->log);
+   fflush(self->log);
+}
+
+static clap_process_status CLAP_ABI spike_process(const clap_plugin_t *plugin, const clap_process_t *p) {
+   spike *self = plugin->plugin_data;
+   (void)p;
+   self->blocks++;
+   uint64_t peers = lb_num_peers(self->link);
+   double tempo = lb_tempo(self->link);
+   if (peers != self->last_peers || tempo != self->last_tempo || self->blocks % 200 == 0) {
+      spike_log(self, "peers=%llu tempo=%.3f", (unsigned long long)peers, tempo);
+      self->last_peers = peers;
+      self->last_tempo = tempo;
+   }
+   return CLAP_PROCESS_CONTINUE;
+}
+
+static bool CLAP_ABI spike_init(const clap_plugin_t *plugin) {
+   (void)plugin;
+   return true;
+}
+static void CLAP_ABI spike_destroy(const clap_plugin_t *plugin) {
+   spike *self = plugin->plugin_data;
+   free(self);
+}
+static bool CLAP_ABI spike_activate(const clap_plugin_t *plugin, double sr, uint32_t minf, uint32_t maxf) {
+   (void)minf;
+   (void)maxf;
+   spike *self = plugin->plugin_data;
+   self->log = fopen(SPIKE_LOG, "a");
+   self->link = lb_create(120.0);
+   lb_enable(self->link, true);
+   spike_log(self, "=== spike activated: host=\"%s %s\" sr=%.0f — Link peer enabled ===",
+             self->host && self->host->name ? self->host->name : "?",
+             self->host && self->host->version ? self->host->version : "?", sr);
+   self->last_peers = ~0ull;
+   return true;
+}
+static void CLAP_ABI spike_deactivate(const clap_plugin_t *plugin) {
+   spike *self = plugin->plugin_data;
+   if (self->link) {
+      spike_log(self, "=== spike deactivated (peers was %llu) ===",
+                (unsigned long long)lb_num_peers(self->link));
+      lb_enable(self->link, false);
+      lb_destroy(self->link);
+      self->link = NULL;
+   }
+   if (self->log) {
+      fclose(self->log);
+      self->log = NULL;
+   }
+}
+static bool CLAP_ABI spike_start(const clap_plugin_t *p) {
+   (void)p;
+   return true;
+}
+static void CLAP_ABI spike_stop(const clap_plugin_t *p) {
+   (void)p;
+}
+static void CLAP_ABI spike_reset(const clap_plugin_t *p) {
+   (void)p;
+}
+static const void *CLAP_ABI spike_get_extension(const clap_plugin_t *p, const char *id) {
+   (void)p;
+   (void)id;
+   return NULL;
+}
+static void CLAP_ABI spike_main_thread(const clap_plugin_t *p) {
+   (void)p;
+}
+
+static const char *spike_features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_UTILITY, NULL};
+static const clap_plugin_descriptor_t spike_desc = {
+    .clap_version = CLAP_VERSION_INIT,
+    .id = "software.linkbridge.spike",
+    .name = "Link Bridge Spike",
+    .vendor = "Link Bridge",
+    .url = "https://github.com/nicholasgasior/wail",
+    .version = "0.1.0",
+    .description = "Dev spike (ADR-0007 gate 1): Link SDK inside a CLAP plugin — joins the session and logs peers/tempo.",
+    .features = spike_features,
+};
+
+static const clap_plugin_t *CLAP_ABI spike_create(const clap_plugin_factory_t *f, const clap_host_t *host, const char *id) {
+   (void)f;
+   if (strcmp(id, spike_desc.id) != 0) return NULL;
+   spike *self = calloc(1, sizeof(spike));
+   if (!self) return NULL;
+   self->host = host;
+   self->plugin.desc = &spike_desc;
+   self->plugin.plugin_data = self;
+   self->plugin.init = spike_init;
+   self->plugin.destroy = spike_destroy;
+   self->plugin.activate = spike_activate;
+   self->plugin.deactivate = spike_deactivate;
+   self->plugin.start_processing = spike_start;
+   self->plugin.stop_processing = spike_stop;
+   self->plugin.reset = spike_reset;
+   self->plugin.process = spike_process;
+   self->plugin.get_extension = spike_get_extension;
+   self->plugin.on_main_thread = spike_main_thread;
+   return &self->plugin;
+}
+
+static uint32_t CLAP_ABI spike_factory_count(const clap_plugin_factory_t *f) {
+   (void)f;
+   return 1;
+}
+static const clap_plugin_descriptor_t *CLAP_ABI spike_factory_desc(const clap_plugin_factory_t *f, uint32_t idx) {
+   (void)f;
+   return idx == 0 ? &spike_desc : NULL;
+}
+static const clap_plugin_factory_t spike_factory = {spike_factory_count, spike_factory_desc, spike_create};
+
+static bool CLAP_ABI entry_init(const char *path) {
+   (void)path;
+   return true;
+}
+static void CLAP_ABI entry_deinit(void) {}
+static const void *CLAP_ABI entry_get_factory(const char *id) {
+   return strcmp(id, CLAP_PLUGIN_FACTORY_ID) == 0 ? &spike_factory : NULL;
+}
+
+CLAP_EXPORT const clap_plugin_entry_t clap_entry = {
+    .clap_version = CLAP_VERSION_INIT,
+    .init = entry_init,
+    .deinit = entry_deinit,
+    .get_factory = entry_get_factory,
+};

--- a/plugins/tests/CMakeLists.txt
+++ b/plugins/tests/CMakeLists.txt
@@ -33,11 +33,12 @@ function(add_wail_harness name)
   target_compile_definitions(${name} PRIVATE
     WAIL_SEND_CLAP_PATH="$<TARGET_FILE:wail-send>"
     WAIL_RECV_CLAP_PATH="$<TARGET_FILE:wail-recv>"
+    WAIL_LINKBRIDGE_SPIKE_PATH="$<TARGET_FILE:linkbridge-spike>"
   )
-  add_dependencies(${name} wail-send wail-recv)
+  add_dependencies(${name} wail-send wail-recv linkbridge-spike)
 endfunction()
 
-add_wail_harness(wail-plugin-tests main.cpp test_send.cpp test_recv.cpp)
+add_wail_harness(wail-plugin-tests main.cpp test_send.cpp test_recv.cpp test_linkbridge.cpp)
 
 # E2E chain driver for scripts/plugin-e2e.sh (not a ctest: needs two live apps).
 add_wail_harness(wail-plugin-chain chain_main.cpp)

--- a/plugins/tests/test_linkbridge.cpp
+++ b/plugins/tests/test_linkbridge.cpp
@@ -1,0 +1,71 @@
+// Smoke test for the Link Bridge spike (ADR-0007 gate 1): host the spike
+// plugin via clap-trap, pump blocks, and confirm it creates a Link peer and
+// writes its heartbeat log. Session-membership proof (peers > 0) needs a
+// second Link peer on the LAN — that's the Bitwig/Live manual step; here we
+// prove the bundle loads, activates, enables Link, and processes without
+// crashing.
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#include "plugin_host.h"
+#include "test_framework.h"
+
+TEST(linkbridge_spike_hosts_and_logs) {
+   // Fresh log so we can attribute lines to this run.
+   std::remove("/tmp/linkbridge-spike.log");
+
+   wailtest::ClapInstance inst;
+   std::string err;
+   CHECK_MSG(inst.load(WAIL_LINKBRIDGE_SPIKE_PATH, "software.linkbridge.spike", 0, 48000.0, 256, 256, &err),
+             err.c_str());
+   if (!inst.plugin) return;
+
+   // Pump ~3s of blocks, paced: Link session discovery fires on a ~1s
+   // announcement interval, so an unpaced burst (ms of wall time) would
+   // finish before any peer can be seen. With a second peer on the LAN (e.g.
+   // linktempo), the heartbeat should report peers=1 and the converged tempo.
+   std::vector<float> buf(256, 0.0f);
+   float *ch[2] = {buf.data(), buf.data()};
+   clap_audio_buffer_t out{};
+   out.channel_count = 2;
+   out.data32 = ch;
+   for (int i = 0; i < 600; i++) {
+      clap_process_t p{};
+      p.steady_time = -1;
+      p.frames_count = 256;
+      p.audio_outputs_count = 1;
+      p.audio_outputs = &out;
+      inst.plugin->process(inst.plugin, &p);
+      wail_sleep_ms(5);
+   }
+
+   inst.teardown(); // deactivate: flushes + closes the log
+
+   FILE *f = fopen("/tmp/linkbridge-spike.log", "r");
+   CHECK_MSG(f != nullptr, "spike wrote no log — Link peer creation or activate failed");
+   if (!f) return;
+   char line[512];
+   bool sawActivate = false, sawPeers = false;
+   while (fgets(line, sizeof(line), f)) {
+      std::string s(line);
+      if (s.find("spike activated") != std::string::npos) sawActivate = true;
+      if (s.find("peers=") != std::string::npos) sawPeers = true;
+   }
+   fclose(f);
+   CHECK(sawActivate);
+   CHECK_MSG(sawPeers, "no peers= heartbeat — Link peer not running");
+   // Session-membership proof when a second peer is on the LAN: WAIL_LB_EXPECT_PEERS
+   // is set by the manual/CI gate-1 run (linktempo alongside); unset in the
+   // default suite where the LAN may be empty.
+   if (getenv("WAIL_LB_EXPECT_PEERS")) {
+      char tail[512] = {0};
+      f = fopen("/tmp/linkbridge-spike.log", "r");
+      if (f) {
+         while (fgets(line, sizeof(line), f)) strncpy(tail, line, sizeof(tail) - 1);
+         fclose(f);
+      }
+      CHECK_MSG(strstr(tail, "peers=0") == nullptr, "expected peers>0 with a second peer on the LAN");
+   }
+}


### PR DESCRIPTION
First slice of ADR-0007. Retires the spike's core risk: **the Link SDK (C++17 + asio, same `vendor/link` pin as the app) links into a .clap bundle, and a plugin-hosted peer joins the LAN Link session.**

## Evidence (gate 1)

- Bundle builds clean on macOS and loads in clap-trap
- Heartbeat runs (peers/tempo at ~1Hz), clean activate/deactivate lifecycle
- **Session membership proven without a DAW:** with `linktempo` on the LAN, the hosted spike reports `peers=2` and a converged session tempo (the extra peer is a real app on the dev LAN — discovery against real apps confirmed)

## Contents

- `linkbridge_link.{h,cpp}` — C-facing Link session API for the bridge plugins (peer lifecycle + realtime-safe session-state beat↔time), over the `abl_link` C wrapper, same compilation pattern as the app's `abllink/wrap.cpp`
- `linkbridge_spike.c` — dev plugin (not shipped): creates/enables a Link peer on activate, logs to /tmp. Full factory + vtable per the Bitwig scan lessons
- `add_linkbridge_plugin()` CMake fn — mirrors the app cgo build's includes/defines; `project()` declares CXX; Windows/MinGW needs the same `Channels.hpp` `interface` rename as the app build (CI follow-up)
- clap-trap smoke test with a paced pump (Link discovery needs ~1s of wall time — an unpaced burst finishes before any announcement) and an env-gated peers assertion (`WAIL_LB_EXPECT_PEERS`) for live-peer runs

## Remaining gates (from ADR-0007)

- win/linux CI link (platform defines are in; the MinGW header rename is the known risk)
- ~~Bitwig `song_pos_beats`~~ ✅ done via #444's transport probe
- Bitwig plugin-process networking: tentatively good (its engine process wrote /tmp fine; this spike's Link traffic is the definitive check — plugin loads in Bitwig and reports peers, manual step)

Next slice: Link Bridge Send (one channel per track instance, sink commit from `process()`).