### PR TITLE
feat: Link Bridge Send — publish a DAW track as a Link Audio channel (ADR-0007)

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -61,23 +61,37 @@ set(LINK_SDK "${CMAKE_CURRENT_SOURCE_DIR}/../vendor/link")
 if(NOT EXISTS "${LINK_SDK}/extensions/abl_link/src/abl_link.cpp")
   message(FATAL_ERROR "Link SDK not found at ${LINK_SDK}. Run: git submodule update --init --recursive vendor/link")
 endif()
+# linkbridge-link: the C-facing Link session/audio API (linkbridge_link.h),
+# shared by the bridge plugins AND the test harness (which subscribes to the
+# send plugin's channel in-process). Link SDK/platform link deps are PUBLIC so
+# consumers inherit them.
+add_library(linkbridge-link STATIC linkbridge_link.cpp linkbridge_link.h)
+target_include_directories(linkbridge-link PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}" PRIVATE
+  "${LINK_SDK}/extensions/abl_link/include"
+  "${LINK_SDK}/extensions/abl_link/src"
+  "${LINK_SDK}/include"
+  "${LINK_SDK}/modules/asio-standalone/asio/include")
+target_compile_features(linkbridge-link PUBLIC cxx_std_17)
+set_target_properties(linkbridge-link PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_link_libraries(linkbridge-link PUBLIC Threads::Threads)
+if(WIN32)
+  target_compile_definitions(linkbridge-link PRIVATE LINK_PLATFORM_WINDOWS=1 NOMINMAX)
+  target_link_libraries(linkbridge-link PUBLIC ws2_32 winmm iphlpapi)
+elseif(APPLE)
+  target_compile_definitions(linkbridge-link PRIVATE LINK_PLATFORM_MACOSX=1 LINK_PLATFORM_UNIX=1)
+else()
+  target_compile_definitions(linkbridge-link PRIVATE LINK_PLATFORM_LINUX=1 LINK_PLATFORM_UNIX=1)
+  target_link_libraries(linkbridge-link PUBLIC m atomic)
+endif()
+
 function(add_linkbridge_plugin name)
   add_library(${name} MODULE ${ARGN})
-  target_include_directories(${name} PRIVATE
-    "${CLAP_INCLUDE}" "${CMAKE_CURRENT_SOURCE_DIR}"
-    "${LINK_SDK}/extensions/abl_link/include"
-    "${LINK_SDK}/extensions/abl_link/src"
-    "${LINK_SDK}/include"
-    "${LINK_SDK}/modules/asio-standalone/asio/include")
-  target_compile_features(${name} PRIVATE cxx_std_17)
+  target_include_directories(${name} PRIVATE "${CLAP_INCLUDE}" "${CMAKE_CURRENT_SOURCE_DIR}")
   set_target_properties(${name} PROPERTIES CXX_VISIBILITY_PRESET hidden VISIBILITY_INLINES_HIDDEN ON)
-  target_link_libraries(${name} PRIVATE Threads::Threads)
+  target_link_libraries(${name} PRIVATE linkbridge-link)
   if(WIN32)
-    target_compile_definitions(${name} PRIVATE LINK_PLATFORM_WINDOWS=1 NOMINMAX)
-    target_link_libraries(${name} PRIVATE ws2_32 winmm iphlpapi)
     set_target_properties(${name} PROPERTIES PREFIX "" SUFFIX ".clap")
   elseif(APPLE)
-    target_compile_definitions(${name} PRIVATE LINK_PLATFORM_MACOSX=1 LINK_PLATFORM_UNIX=1)
     set_target_properties(${name} PROPERTIES
       BUNDLE TRUE
       BUNDLE_EXTENSION "clap"
@@ -88,13 +102,12 @@ function(add_linkbridge_plugin name)
       MACOSX_BUNDLE_BUNDLE_VERSION "0.1.0"
       MACOSX_BUNDLE_SHORT_VERSION_STRING "0.1.0")
   else()
-    target_compile_definitions(${name} PRIVATE LINK_PLATFORM_LINUX=1 LINK_PLATFORM_UNIX=1)
-    target_link_libraries(${name} PRIVATE m atomic)
     set_target_properties(${name} PROPERTIES PREFIX "" SUFFIX ".clap")
   endif()
 endfunction()
 
-add_linkbridge_plugin(linkbridge-spike linkbridge_spike.c linkbridge_link.cpp) # dev spike (gate 1), not shipped
+add_linkbridge_plugin(linkbridge-spike linkbridge_spike.c) # dev spike (gate 1), not shipped
+add_linkbridge_plugin(linkbridge-send linkbridge_send.c)
 
 # DAW-less integration tests (clap-trap host + IPC test double). Off by default:
 # enabling fetches clap-trap over the network at configure time.

--- a/plugins/linkbridge_link.cpp
+++ b/plugins/linkbridge_link.cpp
@@ -15,6 +15,11 @@
 #include "abl_link.cpp"
 #include "linkbridge_link.h"
 
+#include <atomic>
+#include <cmath>
+#include <cstring>
+#include <vector>
+
 struct lb_link {
   abl_link h;
 };
@@ -35,6 +40,8 @@ void lb_destroy(lb_link *l) {
 }
 
 void lb_enable(lb_link *l, bool on) { abl_link_enable(l->h, on); }
+
+void lb_enable_audio(lb_link *l, bool on) { abl_link_audio_enable_link_audio(l->h, on); }
 
 uint64_t lb_num_peers(lb_link *l) { return abl_link_num_peers(l->h); }
 
@@ -68,3 +75,178 @@ int64_t lb_time_at_beat(lb_state *s, double beat, double quantum) {
 }
 
 int64_t lb_clock_micros(lb_link *l) { return abl_link_clock_micros(l->h); }
+
+// --- sink ---
+
+struct lb_sink {
+  abl_link_audio_sink h;
+};
+
+lb_sink *lb_sink_create(lb_link *l, const char *name, size_t max_samples) {
+  lb_sink *s = new lb_sink{};
+  s->h = abl_link_audio_sink_create(l->h, name, max_samples);
+  return s;
+}
+
+void lb_sink_destroy(lb_sink *s) {
+  if (!s) return;
+  abl_link_audio_sink_destroy(s->h);
+  delete s;
+}
+
+void lb_sink_set_name(lb_sink *s, const char *name) {
+  abl_link_audio_sink_set_name(s->h, name);
+}
+
+static int16_t lb_f2i16(float x) {
+  if (x > 1.0f) x = 1.0f;
+  if (x < -1.0f) x = -1.0f;
+  long v = lrintf(x * 32767.0f);
+  if (v > 32767) v = 32767;
+  if (v < -32768) v = -32768;
+  return (int16_t)v;
+}
+
+bool lb_sink_commit(lb_sink *s, lb_state *st, double beats_at_begin, double quantum,
+                    const float *l, const float *r, size_t num_frames, uint32_t sample_rate) {
+  abl_link_audio_sink_buffer_handle h = abl_link_audio_sink_retain_buffer(s->h);
+  if (!abl_link_audio_sink_buffer_is_valid(&h)) {
+    abl_link_audio_sink_buffer_release(&h);
+    return false;
+  }
+  size_t nf = num_frames;
+  if (nf * 2 > h.max_num_samples) nf = h.max_num_samples / 2;
+  for (size_t i = 0; i < nf; i++) {
+    float lv = l ? l[i] : 0.0f;
+    float rv = r ? r[i] : lv;
+    h.samples[2 * i] = lb_f2i16(lv);
+    h.samples[2 * i + 1] = lb_f2i16(rv);
+  }
+  return abl_link_audio_sink_buffer_commit(&h, st->s, beats_at_begin, quantum, nf, 2, sample_rate);
+}
+
+// --- channels + source ---
+
+size_t lb_channels(lb_link *l, lb_channel_info *out, size_t max) {
+  if (max > LB_MAX_CHANNELS) max = LB_MAX_CHANNELS;
+  abl_link_audio_channel_list list = abl_link_audio_get_channels(l->h);
+  size_t n = 0;
+  for (size_t i = 0; i < list.count && n < max; i++) {
+    const abl_link_audio_channel &c = list.channels[i];
+    uint64_t id;
+    memcpy(&id, c.id.bytes, 8);
+    out[n].id_u64 = id;
+    snprintf(out[n].name, sizeof(out[n].name), "%s", c.name ? c.name : "");
+    snprintf(out[n].peer_name, sizeof(out[n].peer_name), "%s", c.peer_name ? c.peer_name : "");
+    n++;
+  }
+  abl_link_audio_free_channel_list(list);
+  return n;
+}
+
+namespace {
+
+// SPSC ring of received buffers: the SDK callback (Link-managed thread)
+// produces, lb_source_pop consumes. Data ring of frames + a parallel chunk
+// ring with per-buffer info, exactly the ADR-0002 capture-ring shape.
+constexpr uint32_t kRingFrames = 1 << 17; // ~1.36s stereo @48k
+constexpr uint32_t kRingChunks = 512;
+
+struct lb_chunk {
+  uint32_t frame_start;
+  size_t num_frames;
+  size_t num_channels;
+  uint32_t sample_rate;
+  uint64_t count;
+  double session_beat_time;
+  double tempo;
+};
+
+} // namespace
+
+struct lb_source {
+  abl_link_audio_source h;
+  std::atomic<uint32_t> data_head{0}, data_tail{0}; // frame counters
+  std::atomic<uint32_t> chunk_head{0}, chunk_tail{0};
+  std::vector<int16_t> data = std::vector<int16_t>(kRingFrames * 2);
+  lb_chunk chunks[kRingChunks];
+  std::vector<int16_t> pop_buf;
+  std::atomic<uint64_t> dropped{0};
+};
+
+static void lb_source_cb(const abl_link_audio_source_buffer *buf, void *context) {
+  lb_source *s = static_cast<lb_source *>(context);
+  uint32_t tail = s->data_tail.load(std::memory_order_relaxed);
+  uint32_t head = s->data_head.load(std::memory_order_acquire);
+  uint32_t space = kRingFrames - (tail - head);
+  size_t nf = buf->info.num_frames;
+  if (nf > space) {
+    s->dropped.fetch_add(nf, std::memory_order_relaxed);
+    return;
+  }
+  uint32_t ct = s->chunk_tail.load(std::memory_order_relaxed);
+  uint32_t ch = s->chunk_head.load(std::memory_order_acquire);
+  if (ct - ch == kRingChunks) {
+    s->dropped.fetch_add(nf, std::memory_order_relaxed);
+    return;
+  }
+  for (size_t i = 0; i < nf; i++) {
+    uint32_t idx = (tail + i) % kRingFrames;
+    int16_t lv, rv;
+    if (buf->info.num_channels > 1) {
+      lv = buf->samples[2 * i];
+      rv = buf->samples[2 * i + 1];
+    } else {
+      lv = rv = buf->samples[i];
+    }
+    s->data[2 * idx] = lv;
+    s->data[2 * idx + 1] = rv;
+  }
+  lb_chunk &c = s->chunks[ct % kRingChunks];
+  c.frame_start = tail;
+  c.num_frames = nf;
+  c.num_channels = buf->info.num_channels;
+  c.sample_rate = buf->info.sample_rate;
+  c.count = buf->info.count;
+  c.session_beat_time = buf->info.session_beat_time;
+  c.tempo = buf->info.tempo;
+  s->data_tail.store(tail + (uint32_t)nf, std::memory_order_release);
+  s->chunk_tail.store(ct + 1, std::memory_order_release);
+}
+
+lb_source *lb_source_create(lb_link *l, uint64_t channel_id_u64) {
+  lb_source *s = new lb_source{};
+  abl_link_audio_channel_id id;
+  memcpy(id.bytes, &channel_id_u64, 8);
+  s->h = abl_link_audio_source_create(l->h, id, lb_source_cb, s);
+  return s;
+}
+
+void lb_source_destroy(lb_source *s) {
+  if (!s) return;
+  abl_link_audio_source_destroy(s->h);
+  delete s;
+}
+
+bool lb_source_pop(lb_source *s, lb_source_buffer *out) {
+  uint32_t ch = s->chunk_head.load(std::memory_order_relaxed);
+  uint32_t ct = s->chunk_tail.load(std::memory_order_acquire);
+  if (ch == ct) return false;
+  const lb_chunk &c = s->chunks[ch % kRingChunks];
+  s->pop_buf.resize(c.num_frames * 2);
+  for (size_t i = 0; i < c.num_frames; i++) {
+    uint32_t idx = (c.frame_start + i) % kRingFrames;
+    s->pop_buf[2 * i] = s->data[2 * idx];
+    s->pop_buf[2 * i + 1] = s->data[2 * idx + 1];
+  }
+  s->chunk_head.store(ch + 1, std::memory_order_release);
+  s->data_head.store(c.frame_start + (uint32_t)c.num_frames, std::memory_order_release);
+  out->samples = s->pop_buf.data();
+  out->num_frames = c.num_frames;
+  out->num_channels = c.num_channels;
+  out->sample_rate = c.sample_rate;
+  out->count = c.count;
+  out->session_beat_time = c.session_beat_time;
+  out->tempo = c.tempo;
+  return true;
+}

--- a/plugins/linkbridge_link.h
+++ b/plugins/linkbridge_link.h
@@ -21,6 +21,9 @@ typedef struct lb_link lb_link;
 lb_link *lb_create(double tempo);
 void lb_destroy(lb_link *l);
 void lb_enable(lb_link *l, bool on);
+// Link Audio is a separate enable on top of the base session — without it the
+// peer syncs (visible in peer counts) but neither announces nor hears channels.
+void lb_enable_audio(lb_link *l, bool on);
 
 uint64_t lb_num_peers(lb_link *l);
 double lb_tempo(lb_link *l);
@@ -33,6 +36,46 @@ void lb_release(lb_state *s);
 double lb_beat_at_time(lb_state *s, int64_t micros, double quantum);
 int64_t lb_time_at_beat(lb_state *s, double beat, double quantum);
 int64_t lb_clock_micros(lb_link *l);
+
+// --- Link Audio sink (publishing; Send plugin) ---
+// Commit is realtime-safe (the SDK's retain/commit is designed for the audio
+// thread). Create/destroy/set_name are main-thread calls.
+typedef struct lb_sink lb_sink;
+lb_sink *lb_sink_create(lb_link *l, const char *name, size_t max_samples);
+void lb_sink_destroy(lb_sink *s);
+void lb_sink_set_name(lb_sink *s, const char *name);
+// Commit one stereo block of float32 (converted to int16, clamped). l may be
+// NULL (silence); r may be NULL (duplicates l). Returns false when no source
+// subscribes or the queue is momentarily full (try next block, not an error).
+bool lb_sink_commit(lb_sink *s, lb_state *st, double beats_at_begin, double quantum,
+                    const float *l, const float *r, size_t num_frames, uint32_t sample_rate);
+
+// --- Link Audio channels + source (subscribing; tests now, Recv later) ---
+// Discovery is main-thread only (not realtime-safe).
+#define LB_MAX_CHANNELS 64
+typedef struct {
+   uint64_t id_u64;                    // channel id, packed (8 bytes)
+   char     name[128];
+   char     peer_name[128];
+} lb_channel_info;
+size_t lb_channels(lb_link *l, lb_channel_info *out, size_t max);
+
+// A source runs the SDK callback (Link-managed thread) into a lock-free SPSC
+// ring — the ADR-0002 pattern, pure C/C++ all the way. Pop from any one
+// non-Link thread (test driver, or the Recv plugin's process()).
+typedef struct lb_source lb_source;
+lb_source *lb_source_create(lb_link *l, uint64_t channel_id_u64);
+void lb_source_destroy(lb_source *s);
+typedef struct {
+   const int16_t *samples; // interleaved; valid until the next lb_source_pop
+   size_t        num_frames;
+   size_t        num_channels;
+   uint32_t      sample_rate;
+   uint64_t      count;             // publisher's buffer counter (gap detection)
+   double        session_beat_time; // buffer begin on the session timeline
+   double        tempo;
+} lb_source_buffer;
+bool lb_source_pop(lb_source *s, lb_source_buffer *out);
 
 #ifdef __cplusplus
 }

--- a/plugins/linkbridge_send.c
+++ b/plugins/linkbridge_send.c
@@ -1,0 +1,270 @@
+// Link Bridge Send (ADR-0007) — publishes the DAW track this instance sits on
+// as a Link Audio channel. One channel per instance, named from the host's
+// track-info (no "WAIL · " prefix — the prefix marks room-published channels;
+// this is a raw LAN channel any Link Audio app can hear, including the WAIL
+// app's capture).
+//
+// Audio path (process()): passthrough, then commit the input block to the
+// Link Audio sink, stamped with the session beat at commit time. Link Audio
+// is 48kHz-only: at any other host rate the instance passes audio through
+// but publishes nothing, and says so loudly (log + port name). Realtime
+// discipline: process() only calls the SDK's realtime-safe retain/commit
+// (plus float→int16 conversion); peer/sink lifecycle lives on the activate
+// path. Full factory + vtable (Bitwig scan discipline).
+
+#include <stdarg.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "clap/clap.h"
+#include "linkbridge_link.h"
+
+#define LB_SEND_LOG "/tmp/linkbridge-send.log"
+#define LB_QUANTUM 4.0 // phase lens for buffer stamps (beats; beat values are absolute)
+
+typedef struct {
+   clap_plugin_t      plugin;
+   const clap_host_t *host;
+
+   lb_link *link;
+   lb_sink *sink;
+   bool     rate_ok; // host runs at 48k
+
+   // Track name: written on the main thread (activate / track_info.changed),
+   // read on the same thread for sink naming — sink_set_name is main-thread
+   // anyway, so no cross-thread handoff is needed.
+   char track_name[CLAP_NAME_SIZE];
+
+   FILE *log;
+   bool  logged_commit;
+} lb_send;
+
+static void lbs_log(lb_send *self, const char *fmt, ...) {
+   if (!self->log) return;
+   va_list ap;
+   va_start(ap, fmt);
+   vfprintf(self->log, fmt, ap);
+   va_end(ap);
+   fputc('\n', self->log);
+   fflush(self->log);
+}
+
+// refresh_track_name queries clap.track-info for this instance's track and
+// renames the sink channel to match. [main thread]
+static void refresh_track_name(lb_send *self) {
+   const clap_host_track_info_t *ti = self->host->get_extension(self->host, CLAP_EXT_TRACK_INFO);
+   if (!ti || !ti->get)
+      ti = self->host->get_extension(self->host, CLAP_EXT_TRACK_INFO_COMPAT);
+   if (!ti || !ti->get)
+      return;
+   clap_track_info_t info;
+   memset(&info, 0, sizeof(info));
+   if (!ti->get(self->host, &info))
+      return;
+   if (!(info.flags & CLAP_TRACK_INFO_HAS_TRACK_NAME) || info.name[0] == '\0')
+      return;
+   if (strncmp(self->track_name, info.name, CLAP_NAME_SIZE - 1) == 0)
+      return;
+   snprintf(self->track_name, sizeof(self->track_name), "%s", info.name);
+   if (self->sink) {
+      lb_sink_set_name(self->sink, self->track_name);
+      lbs_log(self, "channel renamed to \"%s\"", self->track_name);
+   }
+}
+
+static clap_process_status CLAP_ABI lbs_process(const clap_plugin_t *plugin, const clap_process_t *p) {
+   lb_send *self = plugin->plugin_data;
+   uint32_t n = p->frames_count;
+
+   // Passthrough: input 0 → output 0 (inline insert stays audible).
+   if (p->audio_inputs_count > 0 && p->audio_outputs_count > 0) {
+      const clap_audio_buffer_t *in = &p->audio_inputs[0];
+      clap_audio_buffer_t *out = &p->audio_outputs[0];
+      for (uint32_t ch = 0; ch < out->channel_count && ch < in->channel_count; ch++)
+         if (out->data32[ch] && in->data32[ch] && out->data32[ch] != in->data32[ch])
+            memcpy(out->data32[ch], in->data32[ch], n * sizeof(float));
+   }
+
+   if (!self->sink || !self->rate_ok || p->audio_inputs_count == 0)
+      return CLAP_PROCESS_CONTINUE;
+
+   const clap_audio_buffer_t *in = &p->audio_inputs[0];
+   if (!in->data32 || !in->data32[0])
+      return CLAP_PROCESS_CONTINUE;
+
+   // Stamp the block with the session beat at commit time (the constant
+   // output-path offset caveat of the recv path applies equally here —
+   // field-measurable, one number; tradeoffs.md).
+   lb_state *st = lb_capture(self->link);
+   double beat = lb_beat_at_time(st, lb_clock_micros(self->link), LB_QUANTUM);
+   bool ok = lb_sink_commit(self->sink, st, beat, LB_QUANTUM,
+                            in->data32[0], in->channel_count > 1 ? in->data32[1] : NULL, n, 48000);
+   lb_release(st);
+   if (!self->logged_commit) {
+      self->logged_commit = true;
+      lbs_log(self, "first commit: %s (frames=%u)", ok ? "ok" : "WITHHELD (no source subscribed?)", n);
+   }
+   return CLAP_PROCESS_CONTINUE;
+}
+
+static bool CLAP_ABI lbs_init(const clap_plugin_t *plugin) {
+   (void)plugin;
+   return true;
+}
+static void CLAP_ABI lbs_destroy(const clap_plugin_t *plugin) {
+   lb_send *self = plugin->plugin_data;
+   free(self);
+}
+static bool CLAP_ABI lbs_activate(const clap_plugin_t *plugin, double sr, uint32_t minf, uint32_t maxf) {
+   (void)minf;
+   (void)maxf;
+   lb_send *self = plugin->plugin_data;
+   self->log = fopen(LB_SEND_LOG, "a");
+   self->rate_ok = (sr == 48000.0);
+   self->link = lb_create(120.0);
+   lb_enable(self->link, true);
+   lb_enable_audio(self->link, true);
+   refresh_track_name(self);
+   const char *name = self->track_name[0] ? self->track_name : "Link Bridge Send";
+   if (self->rate_ok) {
+      self->sink = lb_sink_create(self->link, name, 16384);
+      lbs_log(self, "=== send activated: host=\"%s %s\" sr=%.0f channel=\"%s\" ===",
+              self->host && self->host->name ? self->host->name : "?",
+              self->host && self->host->version ? self->host->version : "?", sr, name);
+   } else {
+      lbs_log(self, "!!! send activated at sr=%.0f — Link Audio is 48kHz-only; "
+                    "this instance passes audio but publishes NOTHING "
+                    "(host=\"%s %s\")", sr,
+              self->host && self->host->name ? self->host->name : "?",
+              self->host && self->host->version ? self->host->version : "?");
+   }
+   return true;
+}
+static void CLAP_ABI lbs_deactivate(const clap_plugin_t *plugin) {
+   lb_send *self = plugin->plugin_data;
+   if (self->sink) {
+      lb_sink_destroy(self->sink);
+      self->sink = NULL;
+   }
+   if (self->link) {
+      lb_enable(self->link, false);
+      lb_destroy(self->link);
+      self->link = NULL;
+   }
+   if (self->log) {
+      fprintf(self->log, "=== send deactivated ===\n");
+      fclose(self->log);
+      self->log = NULL;
+   }
+}
+static bool CLAP_ABI lbs_start(const clap_plugin_t *p) {
+   (void)p;
+   return true;
+}
+static void CLAP_ABI lbs_stop(const clap_plugin_t *p) {
+   (void)p;
+}
+static void CLAP_ABI lbs_reset(const clap_plugin_t *p) {
+   (void)p;
+}
+
+// --- audio ports: 1 stereo in (main) + 1 stereo out (passthrough) ---
+
+static uint32_t CLAP_ABI lbs_ap_count(const clap_plugin_t *p, bool is_input) {
+   (void)p;
+   (void)is_input;
+   return 1;
+}
+static bool CLAP_ABI lbs_ap_get(const clap_plugin_t *p, uint32_t idx, bool is_input, clap_audio_port_info_t *info) {
+   (void)p;
+   if (idx != 0) return false;
+   info->id = 0;
+   snprintf(info->name, sizeof(info->name), "%s", is_input ? "Input" : "Output");
+   info->flags = CLAP_AUDIO_PORT_IS_MAIN;
+   info->channel_count = 2;
+   info->port_type = CLAP_PORT_STEREO;
+   info->in_place_pair = CLAP_INVALID_ID;
+   return true;
+}
+static const clap_plugin_audio_ports_t lbs_audio_ports = {lbs_ap_count, lbs_ap_get};
+
+// --- track-info: rename the channel when the track renames ---
+
+static void CLAP_ABI lbs_track_info_changed(const clap_plugin_t *plugin) {
+   refresh_track_name(plugin->plugin_data);
+}
+static const clap_plugin_track_info_t lbs_track_info = {lbs_track_info_changed};
+
+static const void *CLAP_ABI lbs_get_extension(const clap_plugin_t *p, const char *id) {
+   (void)p;
+   if (!strcmp(id, CLAP_EXT_AUDIO_PORTS)) return &lbs_audio_ports;
+   if (!strcmp(id, CLAP_EXT_TRACK_INFO)) return &lbs_track_info;
+   if (!strcmp(id, CLAP_EXT_TRACK_INFO_COMPAT)) return &lbs_track_info;
+   return NULL;
+}
+static void CLAP_ABI lbs_main_thread(const clap_plugin_t *p) {
+   (void)p;
+}
+
+static const char *lbs_features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_UTILITY, NULL};
+static const clap_plugin_descriptor_t lbs_desc = {
+    .clap_version = CLAP_VERSION_INIT,
+    .id = "software.linkbridge.send",
+    .name = "Link Bridge Send",
+    .vendor = "Link Bridge",
+    .url = "https://github.com/nicholasgasior/wail",
+    .version = "0.1.0",
+    .description = "Publish this track as a Link Audio channel (ADR-0007).",
+    .features = lbs_features,
+};
+
+static const clap_plugin_t *CLAP_ABI lbs_create(const clap_plugin_factory_t *f, const clap_host_t *host, const char *id) {
+   (void)f;
+   if (strcmp(id, lbs_desc.id) != 0) return NULL;
+   lb_send *self = calloc(1, sizeof(lb_send));
+   if (!self) return NULL;
+   self->host = host;
+   self->plugin.desc = &lbs_desc;
+   self->plugin.plugin_data = self;
+   self->plugin.init = lbs_init;
+   self->plugin.destroy = lbs_destroy;
+   self->plugin.activate = lbs_activate;
+   self->plugin.deactivate = lbs_deactivate;
+   self->plugin.start_processing = lbs_start;
+   self->plugin.stop_processing = lbs_stop;
+   self->plugin.reset = lbs_reset;
+   self->plugin.process = lbs_process;
+   self->plugin.get_extension = lbs_get_extension;
+   self->plugin.on_main_thread = lbs_main_thread;
+   return &self->plugin;
+}
+
+static uint32_t CLAP_ABI lbs_factory_count(const clap_plugin_factory_t *f) {
+   (void)f;
+   return 1;
+}
+static const clap_plugin_descriptor_t *CLAP_ABI lbs_factory_desc(const clap_plugin_factory_t *f, uint32_t idx) {
+   (void)f;
+   return idx == 0 ? &lbs_desc : NULL;
+}
+static const clap_plugin_factory_t lbs_factory = {lbs_factory_count, lbs_factory_desc, lbs_create};
+
+static bool CLAP_ABI entry_init(const char *path) {
+   (void)path;
+   return true;
+}
+static void CLAP_ABI entry_deinit(void) {}
+static const void *CLAP_ABI entry_get_factory(const char *id) {
+   return strcmp(id, CLAP_PLUGIN_FACTORY_ID) == 0 ? &lbs_factory : NULL;
+}
+
+CLAP_EXPORT const clap_plugin_entry_t clap_entry = {
+    .clap_version = CLAP_VERSION_INIT,
+    .init = entry_init,
+    .deinit = entry_deinit,
+    .get_factory = entry_get_factory,
+};

--- a/plugins/linkbridge_spike.c
+++ b/plugins/linkbridge_spike.c
@@ -69,6 +69,7 @@ static bool CLAP_ABI spike_activate(const clap_plugin_t *plugin, double sr, uint
    self->log = fopen(SPIKE_LOG, "a");
    self->link = lb_create(120.0);
    lb_enable(self->link, true);
+   lb_enable_audio(self->link, true);
    spike_log(self, "=== spike activated: host=\"%s %s\" sr=%.0f — Link peer enabled ===",
              self->host && self->host->name ? self->host->name : "?",
              self->host && self->host->version ? self->host->version : "?", sr);

--- a/plugins/tests/CMakeLists.txt
+++ b/plugins/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ FetchContent_MakeAvailable(clap-trap)
 function(add_wail_harness name)
   add_executable(${name} ${ARGN})
   target_include_directories(${name} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/..") # wail_ipc.h
-  target_link_libraries(${name} PRIVATE clap-trap Threads::Threads)
+  target_link_libraries(${name} PRIVATE clap-trap Threads::Threads linkbridge-link)
   target_compile_features(${name} PRIVATE cxx_std_20)
   if(WIN32)
     target_link_libraries(${name} PRIVATE ws2_32)
@@ -34,8 +34,9 @@ function(add_wail_harness name)
     WAIL_SEND_CLAP_PATH="$<TARGET_FILE:wail-send>"
     WAIL_RECV_CLAP_PATH="$<TARGET_FILE:wail-recv>"
     WAIL_LINKBRIDGE_SPIKE_PATH="$<TARGET_FILE:linkbridge-spike>"
+    WAIL_LINKBRIDGE_SEND_PATH="$<TARGET_FILE:linkbridge-send>"
   )
-  add_dependencies(${name} wail-send wail-recv linkbridge-spike)
+  add_dependencies(${name} wail-send wail-recv linkbridge-spike linkbridge-send)
 endfunction()
 
 add_wail_harness(wail-plugin-tests main.cpp test_send.cpp test_recv.cpp test_linkbridge.cpp)

--- a/plugins/tests/test_linkbridge.cpp
+++ b/plugins/tests/test_linkbridge.cpp
@@ -5,10 +5,12 @@
 // prove the bundle loads, activates, enables Link, and processes without
 // crashing.
 
+#include <cmath>
 #include <cstdio>
 #include <cstring>
 #include <string>
 
+#include "linkbridge_link.h"
 #include "plugin_host.h"
 #include "test_framework.h"
 
@@ -68,4 +70,109 @@ TEST(linkbridge_spike_hosts_and_logs) {
       }
       CHECK_MSG(strstr(tail, "peers=0") == nullptr, "expected peers>0 with a second peer on the LAN");
    }
+}
+
+// Pub/sub roundtrip (Link Bridge Send): host the send plugin via clap-trap,
+// feed a 440Hz sine, and a second Link peer in this process subscribes to the
+// published channel and measures what arrives — the whole Link Audio send
+// path, no DAW, no WAIL app.
+TEST(linkbridge_send_pubsub_roundtrip) {
+   wailtest::ClapInstance inst;
+   std::string err;
+   CHECK_MSG(inst.load(WAIL_LINKBRIDGE_SEND_PATH, "software.linkbridge.send", 0, 48000.0, 256, 256, &err),
+             err.c_str());
+   if (!inst.plugin) return;
+
+   // Subscriber side: our own Link peer in the test process.
+   lb_link *sub = lb_create(120.0);
+   lb_enable(sub, true);
+   lb_enable_audio(sub, true);
+
+   const uint32_t kBlock = 256;
+   std::vector<float> inL(kBlock), inR(kBlock), outL(kBlock), outR(kBlock);
+   float *inCh[2] = {inL.data(), inR.data()};
+   float *outCh[2] = {outL.data(), outR.data()};
+   clap_audio_buffer_t inBuf{}, outBuf{};
+   inBuf.channel_count = 2;
+   inBuf.data32 = inCh;
+   outBuf.channel_count = 2;
+   outBuf.data32 = outCh;
+
+   auto pump = [&]() {
+      static uint64_t frame = 0;
+      for (uint32_t i = 0; i < kBlock; i++) {
+         float v = 0.5f * sinf(2.0f * 3.14159265f * 440.0f * (float)(frame + i) / 48000.0f);
+         inL[i] = v;
+         inR[i] = v;
+      }
+      frame += kBlock;
+      clap_process_t p{};
+      p.steady_time = -1;
+      p.frames_count = kBlock;
+      p.audio_inputs_count = 1;
+      p.audio_inputs = &inBuf;
+      p.audio_outputs_count = 1;
+      p.audio_outputs = &outBuf;
+      inst.plugin->process(inst.plugin, &p);
+   };
+
+   // Wait for the channel to appear, pumping the plugin meanwhile.
+   uint64_t chanId = 0;
+   {
+      auto t0 = std::chrono::steady_clock::now();
+      while (!chanId && std::chrono::steady_clock::now() - t0 < std::chrono::seconds(10)) {
+         pump();
+         lb_channel_info chans[LB_MAX_CHANNELS];
+         size_t n = lb_channels(sub, chans, LB_MAX_CHANNELS);
+         for (size_t i = 0; i < n; i++)
+            if (std::string(chans[i].name).find("Link Bridge Send") != std::string::npos)
+               chanId = chans[i].id_u64;
+         wail_sleep_ms(20);
+      }
+   }
+   CHECK_MSG(chanId != 0, "Link Bridge Send channel never appeared on the LAN");
+   if (!chanId) {
+      inst.teardown();
+      lb_destroy(sub);
+      return;
+   }
+
+   lb_source *src = lb_source_create(sub, chanId);
+
+   // Collect ~1.5s of audio.
+   std::vector<int16_t> got;
+   {
+      auto t0 = std::chrono::steady_clock::now();
+      lb_source_buffer b;
+      while (got.size() < 48000 * 3 / 2 &&
+             std::chrono::steady_clock::now() - t0 < std::chrono::seconds(10)) {
+         pump();
+         while (lb_source_pop(src, &b))
+            got.insert(got.end(), b.samples, b.samples + b.num_frames * 2);
+         wail_sleep_ms(5);
+      }
+   }
+   CHECK_MSG(got.size() >= 48000,
+             "received too little audio (" + std::to_string(got.size()) + " frames-pairs)");
+
+   // Measure: RMS and zero-crossing frequency on the left channel.
+   if (got.size() >= 48000) {
+      double sq = 0;
+      int crossings = 0;
+      size_t frames = got.size() / 2;
+      for (size_t i = 0; i < frames; i++) {
+         double l = got[2 * i] / 32768.0;
+         sq += l * l;
+         if (i > 0 && ((got[2 * i - 2] < 0) != (got[2 * i] < 0))) crossings++;
+      }
+      double rms = sqrt(sq / frames);
+      double seconds = (double)frames / 48000.0;
+      double freq = crossings / 2.0 / seconds;
+      CHECK_MSG(rms > 0.1, "received audio too quiet (rms=" + std::to_string(rms) + ") — send path broken");
+      CHECK_MSG(freq > 380 && freq < 500, "frequency off: got " + std::to_string(freq) + " Hz, want ~440");
+   }
+
+   lb_source_destroy(src);
+   inst.teardown();
+   lb_destroy(sub);
 }


### PR DESCRIPTION
Second slice of ADR-0007 (after the spike, #448): the **Send** plugin. Insert on a track → that track becomes a Link Audio channel any Link Audio app can hear — including the WAIL app's capture (rooms work with zero app changes) and Live 12.3 natively.

## Decisions implemented (from the ADR)

- **One channel per instance**, named from the host's track-info, renames following the track
- **No `WAIL · ` prefix** — the prefix marks room-published channels; this is a raw LAN channel
- **48k-only, fail loud** — other host rates pass audio through but publish nothing, logged
- Stamps blocks with the session beat at commit time (the known constant output-path caveat, same class as the recv path — field-measurable, in tradeoffs already)
- Realtime discipline: `process()` only calls the SDK's realtime-safe retain/commit; lifecycle on activate

## Wrapper grows the audio API (shared with the Recv slice)

`linkbridge_link` now has: **sink** (realtime-safe commit with float→int16), **source** (SDK callback → SPSC ring — the ADR-0002 pattern, already the shape Recv will consume), and **channel discovery**. Built as a static lib so tests link it in-process.

## The bug that cost an hour, worth the price

**Link Audio has its own enable flag** (`abl_link_audio_enable_link_audio`), separate from the base session. Without it the peer syncs and appears in peer counts — but neither announces nor hears channels. Diagnosed via the external probe seeing peers-but-no-channels; fixed in the wrapper, spike, and tests. This is now the first thing to check on any future 'channels don't appear' report.

## Test

`linkbridge_send_pubsub_roundtrip`: clap-trap-hosted Send publishes a 440Hz sine; a second Link peer **in the test process** discovers the channel, subscribes, and the received audio passes RMS + zero-crossing frequency checks. No DAW, no WAIL app. Full ctest suite green (16 tests).

Next slice: Link Bridge Recv — 16-port device, `WAIL · `-filtered, stamp-aligned renderer (anchor + deadband, ported from the IPC work, plus the transport-phase mode from #446).