### PR TITLE
fix: ship the Link Bridge plugins in installers and release packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,8 +215,11 @@ jobs:
           cmake -S plugins -B build/plugins
           cmake --build build/plugins --config Release
           mkdir -p dist/lib
-          find build/plugins -maxdepth 2 -name '*.clap' -exec cp -R {} dist/lib/ \;
-          test -e dist/lib/wail-send.clap && test -e dist/lib/wail-recv.clap
+          # Product bundles only — dev tools (transport-probe, linkbridge-spike) are
+          # built but never shipped.
+          for b in wail-send wail-recv linkbridge-send linkbridge-recv; do
+            cp -R "build/plugins/${b}.clap" dist/lib/
+          done
 
       - uses: actions/upload-artifact@v7
         with:
@@ -320,8 +323,11 @@ jobs:
           cmake -S plugins -B build/plugins -DCMAKE_BUILD_TYPE=Release
           cmake --build build/plugins
           mkdir -p dist/lib
-          find build/plugins -maxdepth 2 -name '*.clap' -exec cp -R {} dist/lib/ \;
-          test -e dist/lib/wail-send.clap && test -e dist/lib/wail-recv.clap
+          # Product bundles only — dev tools (transport-probe, linkbridge-spike) are
+          # built but never shipped.
+          for b in wail-send wail-recv linkbridge-send linkbridge-recv; do
+            cp -R "build/plugins/${b}.clap" dist/lib/
+          done
 
       - uses: actions/upload-artifact@v7
         with:

--- a/homebrew/wail.rb
+++ b/homebrew/wail.rb
@@ -49,7 +49,9 @@ class Wail < Formula
     # `wail-install-plugins` (below) copies them there on demand.
     system "cmake", "-S", "plugins", "-B", "build/plugins", "-DCMAKE_BUILD_TYPE=Release"
     system "cmake", "--build", "build/plugins"
-    lib.install Dir["build/plugins/*.clap"]
+    # Product bundles only: dev tools (transport-probe, linkbridge-spike) build
+    # alongside but must not be installed.
+    lib.install Dir["build/plugins/{wail-send,wail-recv,linkbridge-send,linkbridge-recv}.clap"]
     bin.install "scripts/wail-install-plugins.sh" => "wail-install-plugins"
   end
 

--- a/scripts/wail-install-plugins.sh
+++ b/scripts/wail-install-plugins.sh
@@ -25,7 +25,8 @@ else
 fi
 
 # Accept both a Homebrew-style prefix (bundles under lib/) and a raw build dir
-# (bundles at the top level).
+# (bundles at the top level). Product bundles only — dev tools
+# (transport-probe, linkbridge-spike) are never installed.
 if [ -e "${PREFIX}/lib/wail-send.clap" ]; then
     SRC_DIR="${PREFIX}/lib"
 else
@@ -58,6 +59,8 @@ install_bundle() {
 
 install_bundle "${SRC_DIR}/wail-send.clap"
 install_bundle "${SRC_DIR}/wail-recv.clap"
+install_bundle "${SRC_DIR}/linkbridge-send.clap"
+install_bundle "${SRC_DIR}/linkbridge-recv.clap"
 
 echo ""
 echo "Done. Rescan plugins in your DAW to pick up the changes."

--- a/wail-app/plugin_install.go
+++ b/wail-app/plugin_install.go
@@ -11,10 +11,14 @@ import (
 )
 
 // pluginBundles are the CLAP plugins WAIL ships and auto-installs on first launch
-// (ADR-0005). CLAP-only: VST3/AU are a future clap-wrapper target, not shipped here.
+// (ADR-0005 PCM bridge + ADR-0007 Link Bridge). CLAP-only: VST3/AU are a future
+// clap-wrapper target, not shipped here. Dev tools (transport-probe,
+// linkbridge-spike) are built but deliberately NOT shipped or installed.
 var pluginBundles = []string{
 	"wail-send.clap",
 	"wail-recv.clap",
+	"linkbridge-send.clap",
+	"linkbridge-recv.clap",
 }
 
 // SystemPluginDir returns the per-user CLAP directory DAWs scan by default. The


### PR DESCRIPTION
The Link Bridge pair built and tested but never reached users — four packaging gaps, one user-visible symptom ("homebrew didn't install the new plugins"):

| Place | Bug |
|---|---|
| `plugin_install.go` | bundle list hardcoded to the ADR-0005 pair — first-launch auto-install never copied them |
| `wail-install-plugins.sh` | installed only wail-send/recv |
| `homebrew/wail.rb` | `Dir[*.clap]` grabbed **everything** — including dev tools |
| `release.yml` (both jobs) | staged all `*.clap` — `transport-probe` and `linkbridge-spike` (both marked "not shipped") would have shipped |

## Fix

- All four surfaces now handle exactly the four product bundles: `wail-send`, `wail-recv`, `linkbridge-send`, `linkbridge-recv`
- Dev tools explicitly excluded everywhere (they build alongside but never ship)
- release.yml stages an explicit list and fails loudly if a bundle is missing (replacing the silent `find` glob)

## Verified

`wail-install-plugins.sh` against a local build installs all four bundles (it just put them on the dev machine); plugin install tests pass; full Go suite green.

Note: this means the release *after* v3.14.0 is the first one that actually contains the Link Bridge plugins — worth mentioning in whatever channel you tell Geren.