### PR TITLE
feat: peer log sharing pump + wail-logtail CLI + -log-sharing headless flag

### DIFF
--- a/signaling-server/cmd/wail-logtail/main.go
+++ b/signaling-server/cmd/wail-logtail/main.go
@@ -1,0 +1,179 @@
+// wail-logtail tails a WAIL room's shared logs over the relay: joins the room
+// as a quiet observer (stream_count 0) and prints LogBroadcast messages and
+// peer join/leave events as they arrive. Peers emit logs when peer log sharing
+// is armed (the debug room, or the app's -log-sharing flag).
+//
+// Usage:
+//
+//	wail-logtail -server wss://wail-relay.fly.dev -room wail-debug
+//	wail-logtail -server ws://localhost:8897 -room test-room -password secret -events
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func main() {
+	server := flag.String("server", "wss://wail-relay.fly.dev", "relay WebSocket URL")
+	room := flag.String("room", "wail-debug", "room to observe")
+	password := flag.String("password", "", "room password (if any)")
+	name := flag.String("name", "logtail", "display name shown to room peers")
+	version := flag.String("version", "3.14.3", "client_version sent at join (must meet relay min_version)")
+	events := flag.Bool("events", false, "also print non-log sync message types")
+	flag.Parse()
+
+	if *room == "" {
+		log.Fatal("-room is required")
+	}
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+
+	for {
+		err := tail(*server, *room, *password, *name, *version, *events, sig)
+		if err == errStopped {
+			return
+		}
+		log.Printf("[logtail] disconnected: %v — reconnecting in 2s", err)
+		select {
+		case <-sig:
+			return
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+var errStopped = fmt.Errorf("stopped")
+
+// envelope is the relay wire shape: client sync messages are wrapped as
+// {type:"sync", from, payload:<SyncMessage JSON>}; LogBroadcast rides in the
+// payload. peer_joined/peer_left are relay-originated, snake_case.
+type envelope struct {
+	Type        string          `json:"type"`
+	From        string          `json:"from,omitempty"`
+	PeerID      string          `json:"peer_id,omitempty"`
+	DisplayName *string         `json:"display_name,omitempty"`
+	Code        string          `json:"code,omitempty"`
+	Payload     json.RawMessage `json:"payload,omitempty"`
+	Level       string          `json:"level,omitempty"`
+	Message     string          `json:"message,omitempty"`
+}
+
+type logPayload struct {
+	Type    string `json:"type"`
+	From    string `json:"from,omitempty"`
+	Level   string `json:"level,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+func tail(server, room, password, name, version string, events bool, sig chan os.Signal) error {
+	// The relay serves WebSocket joins at /ws; append it if the URL has no path.
+	u := server
+	if !strings.Contains(strings.TrimPrefix(strings.TrimPrefix(u, "wss://"), "ws://"), "/") {
+		u = strings.TrimSuffix(u, "/") + "/ws"
+	}
+	c, _, err := websocket.DefaultDialer.Dial(u, nil)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	join := map[string]any{
+		"type":           "join",
+		"room":           room,
+		"peer_id":        fmt.Sprintf("logtail-%d", time.Now().UnixNano()),
+		"password":       password,
+		"stream_count":   0,
+		"display_name":   "[" + name + "]",
+		"client_version": version,
+	}
+	if err := c.WriteJSON(join); err != nil {
+		return fmt.Errorf("join write: %w", err)
+	}
+	fmt.Printf("[logtail] joined %q on %s — tailing (Ctrl-C to stop)\n", room, server)
+
+	stop := make(chan struct{})
+	go func() {
+		<-sig
+		_ = c.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+		close(stop)
+	}()
+
+	for {
+		select {
+		case <-stop:
+			return errStopped
+		default:
+		}
+		mt, data, err := c.ReadMessage()
+		if err != nil {
+			select {
+			case <-stop:
+				return errStopped
+			default:
+				return err
+			}
+		}
+		if mt == websocket.BinaryMessage {
+			continue // audio frames: not our business
+		}
+		var m envelope
+		if err := json.Unmarshal(data, &m); err != nil {
+			continue
+		}
+		ts := time.Now().Format("15:04:05")
+		switch m.Type {
+		case "log":
+			level := m.Level
+			if level == "" {
+				level = "info"
+			}
+			fmt.Printf("%s [%s/%s] %s\n", ts, m.From, level, m.Message)
+		case "sync":
+			var p logPayload
+			if err := json.Unmarshal(m.Payload, &p); err != nil {
+				continue
+			}
+			if p.Type == "LogBroadcast" {
+				level := p.Level
+				if level == "" {
+					level = "info"
+				}
+				fmt.Printf("%s [%s/%s] %s\n", ts, p.From, level, p.Message)
+			} else if events {
+				fmt.Printf("%s [event] sync %s: %s\n", ts, p.Type, strings.TrimSpace(string(m.Payload)))
+			}
+		case "peer_joined":
+			fmt.Printf("%s [room] + %s joined\n", ts, display(m))
+		case "peer_left":
+			fmt.Printf("%s [room] − %s left\n", ts, display(m))
+		case "join_error":
+			return fmt.Errorf("join refused: %s", m.Code)
+		default:
+			if events && m.Type != "" && !strings.HasPrefix(m.Type, "interval") {
+				fmt.Printf("%s [event] %s: %s\n", ts, m.Type, strings.TrimSpace(string(data)))
+			}
+		}
+	}
+}
+
+func display(m envelope) string {
+	if m.DisplayName != nil && *m.DisplayName != "" {
+		return *m.DisplayName
+	}
+	if m.PeerID != "" {
+		return m.PeerID
+	}
+	return "?"
+}

--- a/wail-app/app.go
+++ b/wail-app/app.go
@@ -206,6 +206,7 @@ func (a *App) JoinRoom(
 		Recording:      recording,
 		StreamCount:    actualStreamCount,
 		IPCPort:        uint16(9191 + a.instance),
+		LogSource:      a.logSource(),
 		CaptureRestore: a.captureEnabled,
 		OnCaptureEnabledChanged: func(keys []CaptureChannelKey) {
 			a.mu.Lock()
@@ -390,6 +391,15 @@ func (a *App) DebugRoom(displayName string, linkAudioName *string) (*JoinResult,
 	}
 	log.Printf("[app] debug room joined: metronome broadcast + loopback + log sharing armed")
 	return res, nil
+}
+
+// logSource returns the session's log entry source when the writer exists
+// (nil otherwise) — the session pumps it to the room as LogBroadcast.
+func (a *App) logSource() <-chan WsLogEntry {
+	if a.wsLog == nil {
+		return nil
+	}
+	return a.wsLog.Subscribe()
 }
 
 // SetLogSharing toggles WebSocket log broadcasting to peers.

--- a/wail-app/main.go
+++ b/wail-app/main.go
@@ -32,6 +32,7 @@ func main() {
 	testTone := flag.Bool("test-tone", false, "Send a synthetic test tone on stream 0 (headless mode; no DAW/WAV needed)")
 	loopback := flag.Bool("loopback", false, "Ask the relay to echo our own audio back; republished as a \"(loopback)\" Link Audio channel (headless mode)")
 	metronomeBroadcast := flag.Bool("metronome-broadcast", false, "Broadcast the WAIL Metronome click to the room as an audio stream (headless mode; debug reference)")
+	logSharing := flag.Bool("log-sharing", false, "Share this instance's logs with room peers (headless mode; debug room arm)")
 	instance := flag.Int("instance", 0, "Instance number (separate data dir / identity)")
 	flag.Parse()
 
@@ -54,6 +55,10 @@ func main() {
 		log.SetOutput(combined)
 		appBackend.fileLog = fileWriter
 		appBackend.wsLog = wsLogWriter
+	}
+
+	if *logSharing && appBackend.wsLog != nil {
+		appBackend.wsLog.SetEnabled(true)
 	}
 
 	// After log setup so the status line reaches wail.log, not just stdout.

--- a/wail-app/session.go
+++ b/wail-app/session.go
@@ -44,6 +44,10 @@ type SessionConfig struct {
 	// IPCPort is the loopback-TCP port the CLAP plugin bridge listens on
 	// (ADR-0005); 9191 + app instance. 0 means the default instance's 9191.
 	IPCPort uint16
+	// LogSource, when set, is pumped to the room as LogBroadcast messages
+	// (peer log sharing, #440). Entries flow only when the writer is armed
+	// (debug room / -log-sharing / GUI toggle).
+	LogSource <-chan WsLogEntry
 }
 
 // SessionCommand represents commands from the UI to the session.
@@ -144,6 +148,21 @@ func sessionLoop(
 
 	// Connect to signaling server
 	mesh, syncRx, audioRx, err := connectMesh(ctx, config, peerID)
+	if err == nil && config.LogSource != nil {
+		go func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case entry, ok := <-config.LogSource:
+					if !ok {
+						return
+					}
+					mesh.SendLog(entry.Level, entry.Target, entry.Message, entry.TimestampUs)
+				}
+			}
+		}()
+	}
 	if err != nil {
 		return fmt.Errorf("signaling connect: %w", err)
 	}


### PR DESCRIPTION
Root-caused while building the relay log-tailing idea: **#440's peer log collation had a silent gap — the send half was never written.** `WsLogWriter` captured entries and `SetLogSharing` armed them, but `PeerMesh.SendLog` had zero callers, so no peer's logs ever reached the room. **This is also why the debug room button appeared to do nothing**: it armed everything correctly, but collation had nothing to collate.

## Changes

- **The pump** (`SessionConfig.LogSource`): the session pumps subscribed `WsLogEntry`s to the mesh as `LogBroadcast`, gated by the writer's armed flag — entries flow only when sharing is on (debug room, GUI toggle, or the new flag)
- **`-log-sharing` headless flag**: the debug-room arm that had no headless equivalent; also wires into pair-debug-style harnesses
- **`wail-logtail`** (`signaling-server/cmd`): the CLI you asked for — a quiet room observer (joins with `stream_count: 0`, auto `/ws` suffix, reconnect) that prints `LogBroadcast` messages and peer join/leave live

Wire notes for the future reader: logs ride a dedicated top-level `"log"` message type (not sync payload), relay-originated peer events are snake_case, joins are served at `/ws`.

## Verified end-to-end

Local relay + headless app (`-log-sharing`) + `wail-logtail` → the app's full log stream arrives live, peer-tagged. Both modules' suites green.

Now usable against prod: `wail-logtail -room wail-debug` — and I can watch your next jam from here.