### PR TITLE
fix: stage Windows CLAP plugins from the multi-config build path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,9 +216,17 @@ jobs:
           cmake --build build/plugins --config Release
           mkdir -p dist/lib
           # Product bundles only — dev tools (transport-probe, linkbridge-spike) are
-          # built but never shipped.
+          # built but never shipped. MSVC's multi-config generator places bundles
+          # under build/plugins/Release/ (single-config puts them in build/plugins/)
+          # — locate, don't hardcode (v3.14.3/v3.15.0 shipped plugin-less Windows
+          # installers on the hardcoded path).
           for b in wail-send wail-recv linkbridge-send linkbridge-recv; do
-            cp -R "build/plugins/${b}.clap" dist/lib/
+            find build/plugins -maxdepth 2 -name "${b}.clap" -exec cp -R {} dist/lib/ \;
+          done
+          # Fail loudly: a failed platform doesn't block the release by design,
+          # so silent plugin-less installers ship unless staging itself errors.
+          for b in wail-send wail-recv linkbridge-send linkbridge-recv; do
+            test -d "dist/lib/${b}.clap" || { echo "::error::missing staged bundle ${b}.clap"; exit 1; }
           done
 
       - uses: actions/upload-artifact@v7


### PR DESCRIPTION
The **v3.14.3 and v3.15.0 Windows installers shipped without the CLAP plugins** — MSVC's multi-config generator puts bundles in `build/plugins/Release/`, the staging `cp` hardcoded `build/plugins/`, and the release's don't-block-on-platform-failure policy let it ship silently twice. Found while preparing v3.15.0 for the field test; Geren's Windows install needs this before the plugins exist for him.

- `find` (generator-agnostic) replaces the hardcoded path
- Staging now hard-errors if any of the 4 product bundles is missing — recurrence = visible platform failure, never a silent plugin-less installer

Linux was unaffected (single-config generator, flat output dir). Merging cuts v3.15.1 with the first complete Windows installer.