### PR TITLE
fix: select the Windows plugin staging dir explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,12 +216,15 @@ jobs:
           cmake --build build/plugins --config Release
           mkdir -p dist/lib
           # Product bundles only — dev tools (transport-probe, linkbridge-spike) are
-          # built but never shipped. MSVC's multi-config generator places bundles
-          # under build/plugins/Release/ (single-config puts them in build/plugins/)
-          # — locate, don't hardcode (v3.14.3/v3.15.0 shipped plugin-less Windows
-          # installers on the hardcoded path).
+          # built but never shipped. MSVC's multi-config generator places the .clap
+          # DLLs under build/plugins/Release/ (single-config puts them in
+          # build/plugins/) — pick explicitly; we pass --config Release, so the two
+          # layouts are deterministic (find -maxdepth missed the DLLs on the Git
+          # Bash runner; the missing-bundle guard below caught it loudly).
+          src="build/plugins"
+          if [ -d "build/plugins/Release" ]; then src="build/plugins/Release"; fi
           for b in wail-send wail-recv linkbridge-send linkbridge-recv; do
-            find build/plugins -maxdepth 2 -name "${b}.clap" -exec cp -R {} dist/lib/ \;
+            cp -R "${src}/${b}.clap" dist/lib/
           done
           # Fail loudly: a failed platform doesn't block the release by design,
           # so silent plugin-less installers ship unless staging itself errors.


### PR DESCRIPTION
Follow-up to #462: `find -maxdepth` missed the built DLLs on the Git Bash runner (quirk undiagnosed — the new missing-bundle guard caught it loudly, which is exactly its job; no broken installer shipped). The two layouts are fully deterministic since we pass `--config Release`, so select `build/plugins/Release` when present, else the flat dir.