### PR TITLE
fix: accept files in the Windows plugin staging guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,7 +226,7 @@ jobs:
           # Fail loudly: a failed platform doesn't block the release by design,
           # so silent plugin-less installers ship unless staging itself errors.
           for b in wail-send wail-recv linkbridge-send linkbridge-recv; do
-            test -d "dist/lib/${b}.clap" || { echo "::error::missing staged bundle ${b}.clap"; exit 1; }
+            test -e "dist/lib/${b}.clap" || { echo "::error::missing staged bundle ${b}.clap"; exit 1; }
           done
 
       - uses: actions/upload-artifact@v7


### PR DESCRIPTION
Third time's the autopsy: the guard I added in #462 used `test -d`, but on Windows a `.clap` is a DLL **file**, not a bundle directory — so the guard failed even when staging was correct (the `find` version had in fact copied them). `test -e` accepts both layouts (single-file .clap on Windows/Linux, bundle dir on macOS). The original v3.15.0 bug remained only the flat-vs-`Release/` path, fixed in #464.