### PR TITLE
feat: share logs with the room by default

### DIFF
--- a/wail-app/frontend/main.js
+++ b/wail-app/frontend/main.js
@@ -316,8 +316,11 @@ function saveTelemetryEnabled(enabled) {
 }
 
 function getLogSharingEnabled() {
+  // Default ON (unset key): a room that can see each other's logs debugs
+  // itself — one client (or the wail-logtail CLI) collates the whole room.
+  // An explicit opt-out persists.
   const val = localStorage.getItem(LOG_SHARING_KEY);
-  return val === 'true';
+  return val !== 'false';
 }
 
 function saveLogSharingEnabled(enabled) {


### PR DESCRIPTION
The peer log pipeline (#459) only helps when it's on — and ss3 showed what it buys: a live two-machine diagnosis over the relay with zero log-paste gymnastics. Default the setting to on (unset preference → on; explicit opt-out persists). Headless stays opt-in via `-log-sharing` so CI/harness rooms stay quiet.