### PR TITLE
feat: make peer log sharing unconditional

### DIFF
--- a/wail-app/frontend/index.html
+++ b/wail-app/frontend/index.html
@@ -312,11 +312,6 @@
         </div>
 
         <div class="remember-row">
-          <input type="checkbox" id="settings-log-sharing">
-          <label for="settings-log-sharing" class="remember-label">Share my debug log with the room</label>
-        </div>
-
-        <div class="remember-row">
           <input type="checkbox" id="settings-remember" checked>
           <label for="settings-remember" class="remember-label">Remember settings</label>
         </div>

--- a/wail-app/frontend/main.js
+++ b/wail-app/frontend/main.js
@@ -21,7 +21,6 @@ const settingsForm = document.getElementById('settings-form');
 const settingsDisplayNameInput = document.getElementById('settings-display-name');
 const settingsLinkAudioNameInput = document.getElementById('settings-link-audio-name');
 const settingsTelemetryCheckbox = document.getElementById('settings-telemetry');
-const settingsLogSharingCheckbox = document.getElementById('settings-log-sharing');
 const settingsRememberCheckbox = document.getElementById('settings-remember');
 const chatInput = document.getElementById('chat-input');
 const chatSendBtn = document.getElementById('chat-send-btn');
@@ -287,7 +286,6 @@ const DISPLAY_NAME_KEY = 'wail-display-name';
 const LINK_AUDIO_NAME_KEY = 'wail-link-audio-name';
 const DEFAULT_LINK_AUDIO_NAME = 'WAIL';
 const TELEMETRY_KEY = 'wail-telemetry';
-const LOG_SHARING_KEY = 'wail-log-sharing';
 const REMEMBER_KEY = 'wail-remember';
 
 function getDisplayName() {
@@ -313,18 +311,6 @@ function getTelemetryEnabled() {
 
 function saveTelemetryEnabled(enabled) {
   localStorage.setItem(TELEMETRY_KEY, enabled ? 'true' : 'false');
-}
-
-function getLogSharingEnabled() {
-  // Default ON (unset key): a room that can see each other's logs debugs
-  // itself — one client (or the wail-logtail CLI) collates the whole room.
-  // An explicit opt-out persists.
-  const val = localStorage.getItem(LOG_SHARING_KEY);
-  return val !== 'false';
-}
-
-function saveLogSharingEnabled(enabled) {
-  localStorage.setItem(LOG_SHARING_KEY, enabled ? 'true' : 'false');
 }
 
 function getRememberEnabled() {
@@ -564,7 +550,6 @@ document.getElementById('browse-recording-dir').addEventListener('click', async 
 
 // Sync telemetry, log sharing, and remember-settings state on load
 invoke('set_telemetry', { enabled: getTelemetryEnabled() }).catch(() => {});
-invoke('set_log_sharing', { enabled: getLogSharingEnabled() }).catch(() => {});
 invoke('set_remember_enabled', { enabled: getRememberEnabled() }).catch(() => {});
 
 // Populate default recording dir on load
@@ -578,7 +563,6 @@ function openSettings() {
   settingsDisplayNameInput.value = getDisplayName();
   settingsLinkAudioNameInput.value = getLinkAudioName();
   settingsTelemetryCheckbox.checked = getTelemetryEnabled();
-  settingsLogSharingCheckbox.checked = getLogSharingEnabled();
   settingsRememberCheckbox.checked = getRememberEnabled();
   settingsPanel.style.display = 'flex';
 }
@@ -615,10 +599,6 @@ settingsForm.addEventListener('submit', (e) => {
   const telemetryEnabled = settingsTelemetryCheckbox.checked;
   saveTelemetryEnabled(telemetryEnabled);
   invoke('set_telemetry', { enabled: telemetryEnabled }).catch(() => {});
-  // Save log sharing setting
-  const logSharingEnabled = settingsLogSharingCheckbox.checked;
-  saveLogSharingEnabled(logSharingEnabled);
-  invoke('set_log_sharing', { enabled: logSharingEnabled }).catch(() => {});
   // Save remember setting
   const rememberEnabled = settingsRememberCheckbox.checked;
   saveRememberEnabled(rememberEnabled);

--- a/wail-app/main.go
+++ b/wail-app/main.go
@@ -32,7 +32,6 @@ func main() {
 	testTone := flag.Bool("test-tone", false, "Send a synthetic test tone on stream 0 (headless mode; no DAW/WAV needed)")
 	loopback := flag.Bool("loopback", false, "Ask the relay to echo our own audio back; republished as a \"(loopback)\" Link Audio channel (headless mode)")
 	metronomeBroadcast := flag.Bool("metronome-broadcast", false, "Broadcast the WAIL Metronome click to the room as an audio stream (headless mode; debug reference)")
-	logSharing := flag.Bool("log-sharing", false, "Share this instance's logs with room peers (headless mode; debug room arm)")
 	instance := flag.Int("instance", 0, "Instance number (separate data dir / identity)")
 	flag.Parse()
 
@@ -57,7 +56,11 @@ func main() {
 		appBackend.wsLog = wsLogWriter
 	}
 
-	if *logSharing && appBackend.wsLog != nil {
+	// Peer log sharing is unconditional: a room that can see each other's
+	// logs debugs itself — one client (or the wail-logtail CLI) collates the
+	// whole room. The writer still gates nothing when no session is joined
+	// (the pump only runs inside a session).
+	if appBackend.wsLog != nil {
 		appBackend.wsLog.SetEnabled(true)
 	}
 


### PR DESCRIPTION
Per your call: the checkbox goes, sharing is just what WAIL does. The pump only runs inside a session (idle instances broadcast nothing), headless shares too (CI traffic is trivial), `SetLogSharing` stays as backend API for a future opt-out. The day-old `-log-sharing` flag is removed (superseded by the unconditional arm).