### PR TITLE
fix: stop counting join-time setup as sink underruns

### DIFF
--- a/signaling-server/cmd/wail-logtail/main.go
+++ b/signaling-server/cmd/wail-logtail/main.go
@@ -67,6 +67,8 @@ type envelope struct {
 	Payload     json.RawMessage `json:"payload,omitempty"`
 	Level       string          `json:"level,omitempty"`
 	Message     string          `json:"message,omitempty"`
+	Peers       []string        `json:"peers,omitempty"`
+	PeerNames   map[string]string `json:"peer_display_names,omitempty"`
 }
 
 type logPayload struct {
@@ -153,6 +155,15 @@ func tail(server, room, password, name, version string, events bool, sig chan os
 				fmt.Printf("%s [%s/%s] %s\n", ts, p.From, level, p.Message)
 			} else if events {
 				fmt.Printf("%s [event] sync %s: %s\n", ts, p.Type, strings.TrimSpace(string(m.Payload)))
+			}
+		case "join_ok":
+			// Print who's already here — join events only fire for later arrivals.
+			for _, p := range m.Peers {
+				name := m.PeerNames[p]
+				if name == "" {
+					name = p
+				}
+				fmt.Printf("%s [room] · %s already in room\n", ts, name)
 			}
 		case "peer_joined":
 			fmt.Printf("%s [room] + %s joined\n", ts, display(m))

--- a/wail-app/audio_engine.go
+++ b/wail-app/audio_engine.go
@@ -28,6 +28,10 @@ type AudioEngine interface {
 	// regardless of when in the interval it runs, unlike SetRoomAnchor's
 	// sample align; overrides it whenever grid alignment is active.
 	AlignRoomLabel(roomIndex, localIndex int64)
+	// OnGridSnap re-anchors emit feeders after an entry-conformance grid
+	// snap: the snap moved the playhead, not the audio — the jumped frames
+	// skip silently, never counting as underruns.
+	OnGridSnap(deltaUs int64)
 	// RoomIndex maps a local interval index to the shared room index via the
 	// labeler aligned by SetRoomAnchor; ok is false until an anchor has arrived.
 	// The session uses it for boundary logging and to tag in-app-sender frames,

--- a/wail-app/audio_engine_real.go
+++ b/wail-app/audio_engine_real.go
@@ -457,6 +457,22 @@ func (e *linkAudioEngine) RoomIndex(localIndex int64) (int64, bool) {
 // computed localIndex from the anchor's boundary time on an aligned grid, so
 // this never suffers the sample-align/snap off-by-one). Logs only on change —
 // re-running entry conformance is idempotent.
+// OnGridSnap re-anchors every emit feeder after an entry-conformance grid
+// snap (ADR-0006): the snap moved the playhead, not the audio — the jumped
+// frames skip silently, never counting as underruns (the join-time ~500k
+// "underrun frames" were exactly this setup event misattributed as loss).
+func (e *linkAudioEngine) OnGridSnap(deltaUs int64) {
+	if deltaUs <= 0 {
+		return // backward jump: the playhead pauses; nothing to skip
+	}
+	frames := int(deltaUs) * engineInternalRate / 1e6
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, st := range e.emit {
+		st.feeder.SkipFrames(frames)
+	}
+}
+
 func (e *linkAudioEngine) AlignRoomLabel(roomIndex, localIndex int64) {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/wail-app/audio_engine_stub.go
+++ b/wail-app/audio_engine_stub.go
@@ -16,6 +16,7 @@ func (s *stubAudioEngine) Stop()                                                
 func (s *stubAudioEngine) HandleRemoteAudio(_, _, _ string, _ []byte)            {}
 func (s *stubAudioEngine) SetRoomAnchor(_ int64, _ float64, _ uint32, _ float64) {}
 func (s *stubAudioEngine) AlignRoomLabel(_, _ int64)                             {}
+func (s *stubAudioEngine) OnGridSnap(_ int64)                                    {}
 func (s *stubAudioEngine) RoomIndex(_ int64) (int64, bool)                       { return 0, false }
 func (s *stubAudioEngine) CaptureChannels() []CaptureChannelInfo                 { return nil }
 func (s *stubAudioEngine) SetCaptureEnabled(_ string, _ bool)                    {}

--- a/wail-app/internal/align/steerer.go
+++ b/wail-app/internal/align/steerer.go
@@ -75,6 +75,10 @@ type Steerer struct {
 	// engine's AlignRoomLabel): the local interval ending at the anchor's
 	// boundary corresponds to the anchor's index, exact on an aligned grid.
 	alignRoomLabel func(roomIndex, localIndex int64)
+	// onSnapGrid fires after an entry-conformance snap so the audio engine
+	// can re-anchor its emit feeders: the snap moved the playhead, not the
+	// audio — the jumped frames must skip silently, never count as underruns.
+	onSnapGrid func(deltaUs int64)
 
 	aligner          *interval.GridAligner
 	enabled          bool
@@ -95,7 +99,7 @@ type Steerer struct {
 // reports alignment state changes ("aligned"/"aligning"/"drifted"/"off");
 // logf narrates steering decisions; alignRoomLabel applies the by-construction
 // labeler alignment to the audio engine. All three funcs may be nil.
-func NewSteerer(link LinkGrid, initialBPM float64, emit func(state string, errMs float64), logf func(format string, args ...any), alignRoomLabel func(roomIndex, localIndex int64)) *Steerer {
+func NewSteerer(link LinkGrid, initialBPM float64, emit func(state string, errMs float64), logf func(format string, args ...any), alignRoomLabel func(roomIndex, localIndex int64), onSnapGrid ...func(deltaUs int64)) *Steerer {
 	if emit == nil {
 		emit = func(string, float64) {}
 	}
@@ -105,11 +109,16 @@ func NewSteerer(link LinkGrid, initialBPM float64, emit func(state string, errMs
 	if alignRoomLabel == nil {
 		alignRoomLabel = func(int64, int64) {}
 	}
+	snap := func(int64) {}
+	if len(onSnapGrid) > 0 && onSnapGrid[0] != nil {
+		snap = onSnapGrid[0]
+	}
 	return &Steerer{
 		link:           link,
 		emit:           emit,
 		logf:           logf,
 		alignRoomLabel: alignRoomLabel,
+		onSnapGrid:     snap,
 		aligner:        interval.NewGridAligner(),
 		enabled:        true,
 		entryPending:   true,
@@ -328,6 +337,7 @@ func (s *Steerer) tryEntry(bpi float64, now time.Time) {
 	s.entryPending = false
 	if snapNeeded(delta) {
 		s.link.SnapGrid(delta)
+		s.onSnapGrid(delta)
 		s.lastSnapAt = now
 		s.logf("[align] entry: snapped grid %+.1f ms onto the room grid", float64(delta)/1000)
 	} else {

--- a/wail-app/internal/align/steerer_test.go
+++ b/wail-app/internal/align/steerer_test.go
@@ -94,6 +94,23 @@ func TestEntrySnapFiresWhenLate(t *testing.T) {
 	}
 }
 
+// TestEntrySnapNotifiesEngine: the entry snap must notify the audio engine
+// (the onSnapGrid hook) so emit feeders re-anchor silently — the snap moves
+// the playhead, not the audio.
+func TestEntrySnapNotifiesEngine(t *testing.T) {
+	now := time.Now()
+	s, f, _ := newSteerer(14_100_000) // 100ms late → snap
+	var snaps []int64
+	s.onSnapGrid = func(deltaUs int64) { snaps = append(snaps, deltaUs) }
+	observe(s, now)
+	if len(f.snaps) != 1 {
+		t.Fatalf("precondition: snaps = %v, want 1", f.snaps)
+	}
+	if len(snaps) != 1 || snaps[0] != 100_000 {
+		t.Fatalf("onSnapGrid calls = %v, want [100000]", snaps)
+	}
+}
+
 func TestEntryNoopWhenAligned(t *testing.T) {
 	now := time.Now()
 	s, f, emits := newSteerer(14_000_000) // exactly on the room grid

--- a/wail-app/internal/emit/feeder.go
+++ b/wail-app/internal/emit/feeder.go
@@ -83,6 +83,22 @@ func (f *Feeder) Promote(idx int64, makeNext func() (*PacedReader, int64, int)) 
 // Current returns the playing interval's reader (nil before SetCurrent).
 func (f *Feeder) Current() *PacedReader { return f.cur }
 
+// SkipFrames re-anchors the readers after an entry-conformance grid snap
+// (ADR-0006): the snap moved the playhead, not the audio — the jumped frames
+// are dead work (stale stamps), so skip them WITHOUT counting underruns. The
+// engine calls it via OnGridSnap with the snap's delta in frames.
+func (f *Feeder) SkipFrames(frames int) {
+	if frames <= 0 {
+		return
+	}
+	if f.cur != nil {
+		f.cur.Skip(f.cur.Cursor() + frames)
+	}
+	if f.next != nil {
+		f.next.Skip(f.next.Cursor() + frames)
+	}
+}
+
 // Underruns returns cumulative underrun events and skipped frames — the feed
 // fell behind the playhead past the cushion: audio was late to the sink and
 // the shortfall played as silence (the honest audible-dropout metric).
@@ -133,19 +149,20 @@ func (f *Feeder) Advance(nowBeat float64, emit func(samples []int16, beatAtBegin
 	f.fill(f.next, f.nextStart+overPlay, f.nextStart+over, emit)
 }
 
-// fill brings one reader's cursor up to targetFrame, first skipping (and
-// counting) any shortfall behind playFrame — stale-stamped chunks would be
-// dropped by receivers, so emitting them is dead work. A fresh reader's first
-// tick is inherently ~one tick behind its start beat (boundaries are detected
-// on the tick after the beat), so a small shortfall at cursor 0 skips silently
-// instead of tainting the underrun counter.
+// fill brings one reader's cursor up to targetFrame, first skipping any
+// shortfall behind playFrame — stale-stamped chunks would be dropped by
+// receivers, so emitting them is dead work. Only MID-STREAM shortfall counts
+// as an underrun: a fresh reader's catch-up (cursor 0) is always setup —
+// join warmup (the first interval can't play before N+D) or the entry snap's
+// grid jump — and the skipped frames were never playable audio (the ~500k
+// join-time "underruns" field report). The skip itself always happens.
 func (f *Feeder) fill(r *PacedReader, playFrame, targetFrame int, emit func([]int16, float64)) {
 	if playFrame > r.Cursor() && r.Cursor() < r.TotalFrames() {
 		skipTo := playFrame
 		if skipTo > r.TotalFrames() {
 			skipTo = r.TotalFrames()
 		}
-		if r.Cursor() > 0 || skipTo > 2*f.chunkFrames {
+		if r.Cursor() > 0 {
 			f.underrunEvents++
 			f.underrunFrames += uint64(skipTo - r.Cursor())
 		}

--- a/wail-app/internal/emit/feeder_test.go
+++ b/wail-app/internal/emit/feeder_test.go
@@ -166,6 +166,30 @@ func TestFeederStallPastCushionCountsUnderrunAndSkips(t *testing.T) {
 	}
 }
 
+// TestFeederSkipFramesReanchorsSilently: a grid snap moves the PLAYHEAD, not
+// the audio — SkipFrames re-anchors the readers without counting, and the
+// next Advance emits from the re-anchored position.
+func TestFeederSkipFramesReanchorsSilently(t *testing.T) {
+	var out []emitted
+	f, r := newTestFeeder(0, stampedSource(fTotal, 0))
+	f.Advance(0, collector(&out)) // cursor 50
+	f.SkipFrames(100)             // the entry snap jumped the grid 100 frames
+	if ev, fr := f.Underruns(); ev != 0 || fr != 0 {
+		t.Fatalf("SkipFrames counted: %d events/%d frames, want 0/0", ev, fr)
+	}
+	if r.Cursor() != 150 {
+		t.Fatalf("cursor = %d, want 150 (re-anchored)", r.Cursor())
+	}
+	out = nil
+	f.Advance(0.15, collector(&out)) // playhead 150 == cursor → no underrun
+	if ev, _ := f.Underruns(); ev != 0 {
+		t.Fatalf("underrun after re-anchor: %d events", ev)
+	}
+	if out[0].first != 150 {
+		t.Fatalf("post-re-anchor chunk starts at frame %d, want 150", out[0].first)
+	}
+}
+
 func TestFeederPlayheadExactlyAtCursorNoUnderrun(t *testing.T) {
 	var out []emitted
 	f, _ := newTestFeeder(0, stampedSource(fTotal, 0))
@@ -287,12 +311,20 @@ func TestFeederFreshReaderFirstTickLagIsNotAnUnderrun(t *testing.T) {
 	if ev, _ := f.Underruns(); ev != 0 {
 		t.Fatalf("first-tick lag counted as underrun (%d events)", ev)
 	}
-	// A genuinely late start (beyond 2 chunks) still counts.
+	// A big fresh-reader catch-up is setup, not loss — join warmup (the
+	// first interval can't play before N+D) or the entry snap's grid jump.
+	// In steady state SetCurrent only runs for a stream's first interval
+	// (promote covers the rest), so big cursor-0 skips are setup by
+	// construction (the ~500k join-time "underruns" field report). The skip
+	// still happens; it just never counts.
 	var out2 []emitted
 	f2, _ := newTestFeeder(0, stampedSource(fTotal, 0))
-	f2.Advance(0.05, collector(&out2)) // 50 frames in at cursor 0
-	if ev, _ := f2.Underruns(); ev != 1 {
-		t.Fatalf("late start past tolerance should count, got %d events", ev)
+	f2.Advance(0.5, collector(&out2)) // playhead 500 frames in, cursor 0
+	if ev, _ := f2.Underruns(); ev != 0 {
+		t.Fatalf("fresh-reader catch-up counted as underrun (%d events)", ev)
+	}
+	if out2[0].first != 500 {
+		t.Fatalf("first chunk starts at frame %d, want 500 (skip still happens)", out2[0].first)
 	}
 }
 

--- a/wail-app/session.go
+++ b/wail-app/session.go
@@ -223,7 +223,7 @@ func sessionLoop(
 	// all alignment state lives in internal/align.
 	steer := align.NewSteerer(alignBridge{link}, bpm, func(state string, errMs float64) {
 		emitter.Emit("align:state", AlignStateEvent{State: state, ErrorMs: errMs})
-	}, logInfo, audioEngine.AlignRoomLabel)
+	}, logInfo, audioEngine.AlignRoomLabel, audioEngine.OnGridSnap)
 
 	// Receivers label our republished channels with these names (StreamNames
 	// sync): enabled capture channels default to their discovered channel name,


### PR DESCRIPTION
Your "~500k underrun frames at join — can we ignore them?" was right to look suspicious: the number was real but meaningless. Two setup events were being misattributed as loss:

1. **Fresh-reader catch-up at cursor 0** — in steady state `SetCurrent` only runs for a stream's *first* interval (promote covers the rest), so big cursor-0 skips are setup by construction: join warmup (audio can't play before N+D) or the entry snap. The old ">2 chunks counts" tolerance predated that understanding and misfired on every join. The skip still happens (stale stamps are dead work); only **mid-stream shortfall counts** — the honest dropout metric.
2. **The entry snap itself** — now wired `Steerer.onSnapGrid → AudioEngine.OnGridSnap → Feeder.SkipFrames`: the snap moves the playhead, not the audio, so jumped frames re-anchor silently.

Also aboard:  prints the existing peer list on attach (built during ss3 — joining a live room no longer looks empty).

After this, the underrun counter means one thing only: real loss.