### PR TITLE
fix: prefix the Link Bridge plugins with WAIL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,12 +223,12 @@ jobs:
           # Bash runner; the missing-bundle guard below caught it loudly).
           src="build/plugins"
           if [ -d "build/plugins/Release" ]; then src="build/plugins/Release"; fi
-          for b in wail-send wail-recv linkbridge-send linkbridge-recv; do
+          for b in wail-send wail-recv wail-linkbridge-send wail-linkbridge-recv; do
             cp -R "${src}/${b}.clap" dist/lib/
           done
           # Fail loudly: a failed platform doesn't block the release by design,
           # so silent plugin-less installers ship unless staging itself errors.
-          for b in wail-send wail-recv linkbridge-send linkbridge-recv; do
+          for b in wail-send wail-recv wail-linkbridge-send wail-linkbridge-recv; do
             test -e "dist/lib/${b}.clap" || { echo "::error::missing staged bundle ${b}.clap"; exit 1; }
           done
 
@@ -336,7 +336,7 @@ jobs:
           mkdir -p dist/lib
           # Product bundles only — dev tools (transport-probe, linkbridge-spike) are
           # built but never shipped.
-          for b in wail-send wail-recv linkbridge-send linkbridge-recv; do
+          for b in wail-send wail-recv wail-linkbridge-send wail-linkbridge-recv; do
             cp -R "build/plugins/${b}.clap" dist/lib/
           done
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -102,7 +102,7 @@ function(add_linkbridge_plugin name)
       OUTPUT_NAME "${name}"
       MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in"
       MACOSX_BUNDLE_BUNDLE_NAME "${name}"
-      MACOSX_BUNDLE_GUI_IDENTIFIER "software.linkbridge.${name}"
+      MACOSX_BUNDLE_GUI_IDENTIFIER "software.wail.${name}"
       MACOSX_BUNDLE_BUNDLE_VERSION "0.1.0"
       MACOSX_BUNDLE_SHORT_VERSION_STRING "0.1.0")
   else()
@@ -111,8 +111,8 @@ function(add_linkbridge_plugin name)
 endfunction()
 
 add_linkbridge_plugin(linkbridge-spike linkbridge_spike.c) # dev spike (gate 1), not shipped
-add_linkbridge_plugin(linkbridge-send linkbridge_send.c)
-add_linkbridge_plugin(linkbridge-recv linkbridge_recv.c)
+add_linkbridge_plugin(wail-linkbridge-send linkbridge_send.c)
+add_linkbridge_plugin(wail-linkbridge-recv linkbridge_recv.c)
 
 # DAW-less integration tests (clap-trap host + IPC test double). Off by default:
 # enabling fetches clap-trap over the network at configure time.

--- a/plugins/linkbridge_recv.c
+++ b/plugins/linkbridge_recv.c
@@ -461,9 +461,9 @@ static const void *CLAP_ABI lbr_get_extension(const clap_plugin_t *p, const char
 static const char *lbr_features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_UTILITY, NULL};
 static const clap_plugin_descriptor_t lbr_desc = {
     .clap_version = CLAP_VERSION_INIT,
-    .id = "software.linkbridge.recv",
-    .name = "Link Bridge Recv",
-    .vendor = "Link Bridge",
+    .id = "software.wail.linkbridge.recv",
+    .name = "WAIL Link Bridge Recv",
+    .vendor = "WAIL",
     .url = "https://github.com/nicholasgasior/wail",
     .version = "0.1.0",
     .description = "Hear WAIL room streams as named Link Audio sub-chains (ADR-0007).",

--- a/plugins/linkbridge_send.c
+++ b/plugins/linkbridge_send.c
@@ -218,9 +218,9 @@ static void CLAP_ABI lbs_main_thread(const clap_plugin_t *p) {
 static const char *lbs_features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_UTILITY, NULL};
 static const clap_plugin_descriptor_t lbs_desc = {
     .clap_version = CLAP_VERSION_INIT,
-    .id = "software.linkbridge.send",
-    .name = "Link Bridge Send",
-    .vendor = "Link Bridge",
+    .id = "software.wail.linkbridge.send",
+    .name = "WAIL Link Bridge Send",
+    .vendor = "WAIL",
     .url = "https://github.com/nicholasgasior/wail",
     .version = "0.1.0",
     .description = "Publish this track as a Link Audio channel (ADR-0007).",

--- a/plugins/tests/CMakeLists.txt
+++ b/plugins/tests/CMakeLists.txt
@@ -34,10 +34,10 @@ function(add_wail_harness name)
     WAIL_SEND_CLAP_PATH="$<TARGET_FILE:wail-send>"
     WAIL_RECV_CLAP_PATH="$<TARGET_FILE:wail-recv>"
     WAIL_LINKBRIDGE_SPIKE_PATH="$<TARGET_FILE:linkbridge-spike>"
-    WAIL_LINKBRIDGE_SEND_PATH="$<TARGET_FILE:linkbridge-send>"
-    WAIL_LINKBRIDGE_RECV_PATH="$<TARGET_FILE:linkbridge-recv>"
+    WAIL_LINKBRIDGE_SEND_PATH="$<TARGET_FILE:wail-linkbridge-send>"
+    WAIL_LINKBRIDGE_RECV_PATH="$<TARGET_FILE:wail-linkbridge-recv>"
   )
-  add_dependencies(${name} wail-send wail-recv linkbridge-spike linkbridge-send linkbridge-recv)
+  add_dependencies(${name} wail-send wail-recv linkbridge-spike wail-linkbridge-send wail-linkbridge-recv)
 endfunction()
 
 add_wail_harness(wail-plugin-tests main.cpp test_send.cpp test_recv.cpp test_linkbridge.cpp)

--- a/plugins/tests/minidaw_main.cpp
+++ b/plugins/tests/minidaw_main.cpp
@@ -12,7 +12,7 @@
 // bridge filter, stamp alignment, output pipeline.
 //
 // Usage:
-//   minidaw recv --plugin <path-to-linkbridge-recv> [--seconds 20]
+//   minidaw recv --plugin <path-to-wail-linkbridge-recv> [--seconds 20]
 //            [--threshold-ms 5] [--name-contains Metronome] [--verbose]
 //
 // Exit 0 = PASS (|median onset offset| <= threshold), 1 = FAIL/timeout.
@@ -137,7 +137,7 @@ int main(int argc, char **argv) {
 
    wailtest::ClapInstance inst;
    std::string err;
-   if (!inst.load(args.plugin.c_str(), "software.linkbridge.recv", 0, kRate, kBlock, kBlock, &err)) {
+   if (!inst.load(args.plugin.c_str(), "software.wail.linkbridge.recv", 0, kRate, kBlock, kBlock, &err)) {
       fprintf(stderr, "load failed: %s\n", err.c_str());
       return 1;
    }

--- a/plugins/tests/test_linkbridge.cpp
+++ b/plugins/tests/test_linkbridge.cpp
@@ -87,7 +87,7 @@ TEST(linkbridge_spike_hosts_and_logs) {
 TEST(linkbridge_send_pubsub_roundtrip) {
    wailtest::ClapInstance inst;
    std::string err;
-   CHECK_MSG(inst.load(WAIL_LINKBRIDGE_SEND_PATH, "software.linkbridge.send", 0, 48000.0, 256, 256, &err),
+   CHECK_MSG(inst.load(WAIL_LINKBRIDGE_SEND_PATH, "software.wail.linkbridge.send", 0, 48000.0, 256, 256, &err),
              err.c_str());
    if (!inst.plugin) return;
 
@@ -193,7 +193,7 @@ TEST(linkbridge_send_pubsub_roundtrip) {
 TEST(linkbridge_recv_hears_only_room_published) {
    wailtest::ClapInstance inst;
    std::string err;
-   CHECK_MSG(inst.load(WAIL_LINKBRIDGE_RECV_PATH, "software.linkbridge.recv", 0, 48000.0, 256, 256, &err),
+   CHECK_MSG(inst.load(WAIL_LINKBRIDGE_RECV_PATH, "software.wail.linkbridge.recv", 0, 48000.0, 256, 256, &err),
              err.c_str());
    if (!inst.plugin) return;
 

--- a/scripts/minidaw-e2e.sh
+++ b/scripts/minidaw-e2e.sh
@@ -51,13 +51,13 @@ log "building relay + app + minidaw → $WORK"
 ( cd "$REPO_ROOT/signaling-server" && go build -o "$WORK/relay" . )
 ( cd "$REPO_ROOT/wail-app" && go build -o "$WORK/wail" . )
 cmake -S "$REPO_ROOT/plugins" -B "$REPO_ROOT/build/plugins" > /dev/null
-cmake --build "$REPO_ROOT/build/plugins" --target minidaw linkbridge-recv > /dev/null
+cmake --build "$REPO_ROOT/build/plugins" --target minidaw wail-linkbridge-recv > /dev/null
 
 MINIDAW="$REPO_ROOT/build/plugins/tests/minidaw"
-RECV_PLUGIN="$REPO_ROOT/build/plugins/linkbridge-recv.clap"
+RECV_PLUGIN="$REPO_ROOT/build/plugins/wail-linkbridge-recv.clap"
 # The CLAP bundle on macOS is a directory; the loader wants the binary inside.
 if [ -d "$RECV_PLUGIN" ]; then
-  RECV_PLUGIN="$RECV_PLUGIN/Contents/MacOS/linkbridge-recv"
+  RECV_PLUGIN="$RECV_PLUGIN/Contents/MacOS/wail-linkbridge-recv"
 fi
 
 log "starting local relay on :${PORT} (room $ROOM)"

--- a/scripts/wail-install-plugins.sh
+++ b/scripts/wail-install-plugins.sh
@@ -59,8 +59,8 @@ install_bundle() {
 
 install_bundle "${SRC_DIR}/wail-send.clap"
 install_bundle "${SRC_DIR}/wail-recv.clap"
-install_bundle "${SRC_DIR}/linkbridge-send.clap"
-install_bundle "${SRC_DIR}/linkbridge-recv.clap"
+install_bundle "${SRC_DIR}/wail-linkbridge-send.clap"
+install_bundle "${SRC_DIR}/wail-linkbridge-recv.clap"
 
 echo ""
 echo "Done. Rescan plugins in your DAW to pick up the changes."

--- a/wail-app/plugin_install.go
+++ b/wail-app/plugin_install.go
@@ -17,8 +17,8 @@ import (
 var pluginBundles = []string{
 	"wail-send.clap",
 	"wail-recv.clap",
-	"linkbridge-send.clap",
-	"linkbridge-recv.clap",
+	"wail-linkbridge-send.clap",
+	"wail-linkbridge-recv.clap",
 }
 
 // SystemPluginDir returns the per-user CLAP directory DAWs scan by default. The


### PR DESCRIPTION
## What

Brand the two new **Link Bridge** CLAP plugins (ADR-0007) as WAIL's across every identity surface, matching the existing `wail-send`/`wail-recv` plugins (vendor `WAIL`, id `software.wail.*`):

| Surface | Before | After |
|---|---|---|
| Display name (`.name`) | `Link Bridge Send/Recv` | `WAIL Link Bridge Send/Recv` |
| Vendor (`.vendor`) | `Link Bridge` | `WAIL` |
| CLAP id (`.id`) | `software.linkbridge.{send,recv}` | `software.wail.linkbridge.{send,recv}` |
| Build target / `.clap` bundle | `linkbridge-{send,recv}.clap` | `wail-linkbridge-{send,recv}.clap` |
| macOS bundle id base | `software.linkbridge.*` | `software.wail.*` (`add_wail_plugin` convention) |

## Why

The Link Bridge plugins shipped unbranded, so a DAW's plugin browser showed a "Link Bridge" vendor with generic names sitting alongside the WAIL-branded `wail-send`/`wail-recv`. This makes them consistently identifiable as WAIL's, following the same `WAIL-`/`software.wail.*` convention as the Link Audio peer name (#370) and the sibling plugins.

## Changes (10 files, in lockstep)

- `plugins/linkbridge_send.c`, `plugins/linkbridge_recv.c` — descriptor `.id` / `.name` / `.vendor`.
- `plugins/CMakeLists.txt` — build target names + macOS bundle id base.
- `plugins/tests/CMakeLists.txt`, `plugins/tests/test_linkbridge.cpp`, `plugins/tests/minidaw_main.cpp` — target-file vars + the id strings the tests load by.
- `.github/workflows/release.yml` — staging/guard loops.
- `scripts/wail-install-plugins.sh`, `scripts/minidaw-e2e.sh` — installed/loaded bundle paths.
- `wail-app/plugin_install.go` — the app's installed-bundle list.

## Compatibility note

⚠️ Changing the CLAP `.id` **breaks host/DAW project references to already-placed Link Bridge instances** — an existing session with a Link Bridge plugin won't auto-reconnect it after this rename. Acceptable while these plugins are new (ADR-0007), but worth calling out.

## Out of scope / left unchanged

- The dev-only `linkbridge-spike` and `transport-probe` plugins (built, never shipped).
- The internal `linkbridge-{send,recv}.log` diagnostic filenames.

## Verification

- `grep` confirms zero remaining `software.linkbridge.{send,recv}` id references, and every build/artifact reference now reads `wail-linkbridge-*`.
- `gofmt` clean on `plugin_install.go`.
- The C/CMake/CI changes aren't compiled here (no CLAP submodule + cgo/libopus in this environment) — validated by cross-reference consistency; CI will build the bundles.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYJQXcUsu4w927AhK8ZBoH)_