### PR TITLE
chore: gofmt sweep across both Go modules

### DIFF
--- a/signaling-server/cmd/wail-logtail/main.go
+++ b/signaling-server/cmd/wail-logtail/main.go
@@ -59,15 +59,15 @@ var errStopped = fmt.Errorf("stopped")
 // {type:"sync", from, payload:<SyncMessage JSON>}; LogBroadcast rides in the
 // payload. peer_joined/peer_left are relay-originated, snake_case.
 type envelope struct {
-	Type        string          `json:"type"`
-	From        string          `json:"from,omitempty"`
-	PeerID      string          `json:"peer_id,omitempty"`
-	DisplayName *string         `json:"display_name,omitempty"`
-	Code        string          `json:"code,omitempty"`
-	Payload     json.RawMessage `json:"payload,omitempty"`
-	Level       string          `json:"level,omitempty"`
-	Message     string          `json:"message,omitempty"`
-	Peers       []string        `json:"peers,omitempty"`
+	Type        string            `json:"type"`
+	From        string            `json:"from,omitempty"`
+	PeerID      string            `json:"peer_id,omitempty"`
+	DisplayName *string           `json:"display_name,omitempty"`
+	Code        string            `json:"code,omitempty"`
+	Payload     json.RawMessage   `json:"payload,omitempty"`
+	Level       string            `json:"level,omitempty"`
+	Message     string            `json:"message,omitempty"`
+	Peers       []string          `json:"peers,omitempty"`
 	PeerNames   map[string]string `json:"peer_display_names,omitempty"`
 }
 

--- a/signaling-server/main.go
+++ b/signaling-server/main.go
@@ -39,12 +39,12 @@ const (
 	// The Link Audio engine sends a whole interval's WAIF frames in one burst at
 	// the boundary (~400 frames for 8s at 20ms; more at slow tempos), so the
 	// burst must absorb a full interval — steady-state is still ~50 frames/sec.
-	baseBinaryRate   = 100.0  // tokens/sec per stream
-	baseBinaryBurst  = 2500.0 // max tokens per stream
-	baseTextRate     = 100.0 // tokens/sec (not scaled by streams)
-	baseTextBurst    = 200.0 // max tokens
-	rateLimitWarnMax = 50    // violations before disconnect
-	maxStreamsPerPeer = 16   // cap stream_count for rate-limit scaling
+	baseBinaryRate    = 100.0  // tokens/sec per stream
+	baseBinaryBurst   = 2500.0 // max tokens per stream
+	baseTextRate      = 100.0  // tokens/sec (not scaled by streams)
+	baseTextBurst     = 200.0  // max tokens
+	rateLimitWarnMax  = 50     // violations before disconnect
+	maxStreamsPerPeer = 16     // cap stream_count for rate-limit scaling
 )
 
 // ---------------------------------------------------------------------------
@@ -165,20 +165,20 @@ type directionMetrics struct {
 type peerStatus struct {
 	dcOpen          bool
 	pluginConnected bool
-	lastPerPeer map[string]peerFrameReport
+	lastPerPeer     map[string]peerFrameReport
 }
 
 // session tracks aggregate metrics for a multi-peer session in a room.
 type session struct {
-	ID        string                              `json:"id"`
-	Room      string                              `json:"room"`
-	StartedAt time.Time                           `json:"started_at"`
-	EndedAt   *time.Time                          `json:"ended_at,omitempty"`
-	Phase     string                              `json:"phase"`
-	Peers     []string                            `json:"peers"`
-	Joining   map[string]*directionMetrics        `json:"joining"`
-	Playing   map[string]*directionMetrics        `json:"playing"`
-	peerState map[string]*peerStatus
+	ID                 string                       `json:"id"`
+	Room               string                       `json:"room"`
+	StartedAt          time.Time                    `json:"started_at"`
+	EndedAt            *time.Time                   `json:"ended_at,omitempty"`
+	Phase              string                       `json:"phase"`
+	Peers              []string                     `json:"peers"`
+	Joining            map[string]*directionMetrics `json:"joining"`
+	Playing            map[string]*directionMetrics `json:"playing"`
+	peerState          map[string]*peerStatus
 	peerDisplayNames   map[string]string // snapshotted at archive time
 	transitionSnapshot map[directionKey]peerFrameReport
 }
@@ -187,10 +187,10 @@ func newSession(roomName string, peers []string) *session {
 	id := fmt.Sprintf("%s-%d", roomName, time.Now().UnixMilli())
 	s := &session{
 		ID: id, Room: roomName, StartedAt: time.Now(), Phase: "joining",
-		Peers: peers,
-		Joining: make(map[string]*directionMetrics),
-		Playing: make(map[string]*directionMetrics),
-		peerState: make(map[string]*peerStatus),
+		Peers:              peers,
+		Joining:            make(map[string]*directionMetrics),
+		Playing:            make(map[string]*directionMetrics),
+		peerState:          make(map[string]*peerStatus),
 		transitionSnapshot: make(map[directionKey]peerFrameReport),
 	}
 	for _, p := range peers {
@@ -278,7 +278,9 @@ func (s *session) updateMetrics(reporter string, dcOpen, pluginConnected bool, p
 			s.Phase = "playing"
 			for _, peer := range s.Peers {
 				st := s.peerState[peer]
-				if st == nil { continue }
+				if st == nil {
+					continue
+				}
 				for remotePeer, report := range st.lastPerPeer {
 					s.transitionSnapshot[directionKey{from: remotePeer, to: peer}] = report
 				}
@@ -289,7 +291,9 @@ func (s *session) updateMetrics(reporter string, dcOpen, pluginConnected bool, p
 
 func (s *session) addPeer(peerID string) {
 	for _, p := range s.Peers {
-		if p == peerID { return }
+		if p == peerID {
+			return
+		}
 	}
 	s.Peers = append(s.Peers, peerID)
 	if _, ok := s.peerState[peerID]; !ok {
@@ -302,9 +306,9 @@ func (s *session) addPeer(peerID string) {
 // ---------------------------------------------------------------------------
 
 type room struct {
-	mu      sync.Mutex
-	conns   atomic.Pointer[[]connEntry]
-	connMap map[string]*conn
+	mu                sync.Mutex
+	conns             atomic.Pointer[[]connEntry]
+	connMap           map[string]*conn
 	activeSession     *session
 	completedSessions []*session
 
@@ -337,15 +341,17 @@ func (r *room) rebuildConns() {
 
 func (r *room) loadConns() []connEntry {
 	p := r.conns.Load()
-	if p == nil { return nil }
+	if p == nil {
+		return nil
+	}
 	return *p
 }
 
 // hub tracks all rooms.
 type hub struct {
-	mu    sync.RWMutex
-	rooms map[string]*room
-	db    *sql.DB
+	mu                sync.RWMutex
+	rooms             map[string]*room
+	db                *sql.DB
 	completedMu       sync.Mutex
 	completedSessions map[string][]*session
 }
@@ -356,9 +362,13 @@ type hub struct {
 
 func openDB() *sql.DB {
 	path := os.Getenv("DB_PATH")
-	if path == "" { path = "/data/wail.db" }
+	if path == "" {
+		path = "/data/wail.db"
+	}
 	db, err := sql.Open("sqlite", path+"?_journal_mode=WAL&_busy_timeout=5000")
-	if err != nil { log.Fatalf("open db: %v", err) }
+	if err != nil {
+		log.Fatalf("open db: %v", err)
+	}
 	for _, stmt := range []string{
 		`CREATE TABLE IF NOT EXISTS peers (
 			room TEXT NOT NULL, peer_id TEXT NOT NULL, display_name TEXT,
@@ -368,7 +378,9 @@ func openDB() *sql.DB {
 			room TEXT PRIMARY KEY, password_hash TEXT,
 			created_at INTEGER NOT NULL DEFAULT 0)`,
 	} {
-		if _, err := db.Exec(stmt); err != nil { log.Fatalf("migrate: %v", err) }
+		if _, err := db.Exec(stmt); err != nil {
+			log.Fatalf("migrate: %v", err)
+		}
 	}
 	cutoff := time.Now().Unix() - stalePeerSec
 	db.Exec("DELETE FROM peers WHERE last_seen < ?", cutoff)
@@ -396,11 +408,15 @@ func (h *hub) getOrCreateRoom(name string) *room {
 	h.mu.RLock()
 	r, ok := h.rooms[name]
 	h.mu.RUnlock()
-	if ok { return r }
+	if ok {
+		return r
+	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	r, ok = h.rooms[name]
-	if ok { return r }
+	if ok {
+		return r
+	}
 	r = newRoom()
 	h.rooms[name] = r
 	return r
@@ -417,11 +433,15 @@ func (h *hub) deleteRoom(name string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	r, ok := h.rooms[name]
-	if !ok { return }
+	if !ok {
+		return
+	}
 	r.mu.Lock()
 	empty := len(r.connMap) == 0
 	r.mu.Unlock()
-	if empty { delete(h.rooms, name) }
+	if empty {
+		delete(h.rooms, name)
+	}
 }
 
 func (h *hub) archiveSession(roomName string, s *session) {
@@ -442,8 +462,12 @@ func (h *hub) join(c *conn, msg clientMsg) (string, string, int) {
 	roomName := msg.Room
 	peerID := msg.PeerID
 	streamCount := msg.StreamCount
-	if streamCount < 1 { streamCount = 1 }
-	if streamCount > maxStreamsPerPeer { streamCount = maxStreamsPerPeer }
+	if streamCount < 1 {
+		streamCount = 1
+	}
+	if streamCount > maxStreamsPerPeer {
+		streamCount = maxStreamsPerPeer
+	}
 
 	if semverLess(msg.ClientVersion, minVersion) {
 		c.sendJSON(map[string]any{"type": "join_error", "code": "version_outdated", "min_version": minVersion})
@@ -473,12 +497,16 @@ func (h *hub) join(c *conn, msg clientMsg) (string, string, int) {
 
 	if !roomExists {
 		pwHash := ""
-		if msg.Password != "" { pwHash = hashPassword(msg.Password) }
+		if msg.Password != "" {
+			pwHash = hashPassword(msg.Password)
+		}
 		h.db.Exec("INSERT OR IGNORE INTO rooms (room, password_hash, created_at) VALUES (?, ?, ?)", roomName, pwHash, time.Now().Unix())
 	}
 
 	displayName := ""
-	if msg.DisplayName != nil { displayName = *msg.DisplayName }
+	if msg.DisplayName != nil {
+		displayName = *msg.DisplayName
+	}
 	h.db.Exec(`INSERT INTO peers (room, peer_id, display_name, stream_count, last_seen) VALUES (?, ?, ?, ?, ?)
 		ON CONFLICT(room, peer_id) DO UPDATE SET display_name=excluded.display_name, stream_count=excluded.stream_count, last_seen=excluded.last_seen`,
 		roomName, peerID, displayName, streamCount, time.Now().Unix())
@@ -524,7 +552,9 @@ func (h *hub) join(c *conn, msg clientMsg) (string, string, int) {
 			log.Printf("[metrics] peer %s joined active session %s (now %d peers)", peerID, s.ID, peerCountAfter)
 		} else {
 			allPeers := make([]string, 0, peerCountAfter)
-			for pid := range r.connMap { allPeers = append(allPeers, pid) }
+			for pid := range r.connMap {
+				allPeers = append(allPeers, pid)
+			}
 			s := newSession(roomName, allPeers)
 			r.activeSession = s
 			log.Printf("[metrics] session %s started with %d peers", s.ID, peerCountAfter)
@@ -537,7 +567,9 @@ func (h *hub) join(c *conn, msg clientMsg) (string, string, int) {
 		if id != peerID && rc.publicIP == c.publicIP {
 			lanPeerPresent = true
 			ipPrefix := c.publicIP
-			if len(ipPrefix) > 8 { ipPrefix = ipPrefix[:8] }
+			if len(ipPrefix) > 8 {
+				ipPrefix = ipPrefix[:8]
+			}
 			log.Printf("peer %s shares LAN with existing peer %s (IP prefix: %s...)", peerID, id, ipPrefix)
 			break
 		}
@@ -559,9 +591,13 @@ func (h *hub) join(c *conn, msg clientMsg) (string, string, int) {
 }
 
 func (h *hub) signal(room, peerID string, c *conn, msg clientMsg) {
-	if room == "" { return }
+	if room == "" {
+		return
+	}
 	r := h.getRoom(room)
-	if r == nil { return }
+	if r == nil {
+		return
+	}
 	for _, e := range r.loadConns() {
 		if e.peerID == msg.To {
 			e.c.sendJSON(map[string]any{"type": "signal", "to": msg.To, "from": peerID, "payload": msg.Payload})
@@ -571,14 +607,22 @@ func (h *hub) signal(room, peerID string, c *conn, msg clientMsg) {
 }
 
 func (h *hub) broadcastSync(room, peerID string, c *conn, msg clientMsg) {
-	if room == "" { return }
+	if room == "" {
+		return
+	}
 	r := h.getRoom(room)
-	if r == nil { return }
+	if r == nil {
+		return
+	}
 	raw, err := json.Marshal(map[string]any{"type": "sync", "from": peerID, "payload": msg.Payload})
-	if err != nil { return }
+	if err != nil {
+		return
+	}
 	wsMsg := wsMessage{websocket.TextMessage, raw}
 	for _, e := range r.loadConns() {
-		if e.peerID != peerID { e.c.sendWS(wsMsg) }
+		if e.peerID != peerID {
+			e.c.sendWS(wsMsg)
+		}
 	}
 	// The relay owns the room interval clock (ADR-0003): if this sync carried a
 	// tempo/config change, update the clock and broadcast the new anchor to all.
@@ -597,9 +641,13 @@ func (h *hub) broadcastSync(room, peerID string, c *conn, msg clientMsg) {
 }
 
 func (h *hub) syncTo(room, peerID string, c *conn, msg clientMsg) {
-	if room == "" { return }
+	if room == "" {
+		return
+	}
 	r := h.getRoom(room)
-	if r == nil { return }
+	if r == nil {
+		return
+	}
 	for _, e := range r.loadConns() {
 		if e.peerID == msg.To {
 			e.c.sendJSON(map[string]any{"type": "sync", "from": peerID, "payload": msg.Payload})
@@ -613,9 +661,13 @@ func (h *hub) syncTo(room, peerID string, c *conn, msg clientMsg) {
 // avoiding unsynchronized reads of c.room/c.peerID (which may be cleared by eviction/leave).
 // loopback additionally echoes the frame back to the sender (set_loopback opt-in).
 func (h *hub) broadcastAudioBinary(room, peerID string, c *conn, data []byte, loopback bool) {
-	if room == "" { return }
+	if room == "" {
+		return
+	}
 	r := h.getRoom(room)
-	if r == nil { return }
+	if r == nil {
+		return
+	}
 
 	// Label watchdog: peek the sender's interval label and heal frozen
 	// offsets (see labelwatch.go). Cheap: one header parse per frame.
@@ -635,42 +687,64 @@ func (h *hub) broadcastAudioBinary(room, peerID string, c *conn, data []byte, lo
 
 	wsMsg := wsMessage{websocket.BinaryMessage, frame}
 	for _, e := range r.loadConns() {
-		if e.peerID != peerID || loopback { e.c.sendWS(wsMsg) }
+		if e.peerID != peerID || loopback {
+			e.c.sendWS(wsMsg)
+		}
 	}
 }
 
 func (h *hub) broadcastLog(room, peerID string, c *conn, msg clientMsg) {
-	if room == "" { return }
+	if room == "" {
+		return
+	}
 	r := h.getRoom(room)
-	if r == nil { return }
+	if r == nil {
+		return
+	}
 	raw, err := json.Marshal(map[string]any{
 		"type": "log", "from": peerID, "level": msg.Level,
 		"target": msg.Target, "message": msg.Message, "timestamp_us": msg.TimestampUs,
 	})
-	if err != nil { return }
+	if err != nil {
+		return
+	}
 	wsMsg := wsMessage{websocket.TextMessage, raw}
 	for _, e := range r.loadConns() {
-		if e.peerID != peerID { e.c.sendWS(wsMsg) }
+		if e.peerID != peerID {
+			e.c.sendWS(wsMsg)
+		}
 	}
 }
 
 func (h *hub) metricsReport(room, peerID string, c *conn, msg clientMsg) {
-	if room == "" { return }
+	if room == "" {
+		return
+	}
 	r := h.getRoom(room)
-	if r == nil { return }
+	if r == nil {
+		return
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	s := r.activeSession
-	if s == nil { return }
+	if s == nil {
+		return
+	}
 	dcOpen := false
-	if msg.DcOpen != nil { dcOpen = *msg.DcOpen }
+	if msg.DcOpen != nil {
+		dcOpen = *msg.DcOpen
+	}
 	pluginConnected := false
-	if msg.PluginConnected != nil { pluginConnected = *msg.PluginConnected }
+	if msg.PluginConnected != nil {
+		pluginConnected = *msg.PluginConnected
+	}
 	s.updateMetrics(peerID, dcOpen, pluginConnected, msg.PerPeer)
 }
 
 func (h *hub) leave(room, peerID string, c *conn) {
-	if room == "" { return }
+	if room == "" {
+		return
+	}
 	r := h.getRoom(room)
 	if r != nil {
 		r.watch.forget(peerID)
@@ -767,10 +841,14 @@ func (c *conn) writePump() {
 				c.ws.WriteMessage(websocket.CloseMessage, []byte{})
 				return
 			}
-			if err := c.ws.WriteMessage(msg.msgType, msg.data); err != nil { return }
+			if err := c.ws.WriteMessage(msg.msgType, msg.data); err != nil {
+				return
+			}
 		case <-ticker.C:
 			c.ws.SetWriteDeadline(time.Now().Add(writeWait))
-			if err := c.ws.WriteMessage(websocket.PingMessage, nil); err != nil { return }
+			if err := c.ws.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
 		}
 	}
 }
@@ -805,7 +883,9 @@ func (c *conn) readPump(h *hub) {
 
 	for {
 		msgType, raw, err := c.ws.ReadMessage()
-		if err != nil { return }
+		if err != nil {
+			return
+		}
 
 		if msgType == websocket.BinaryMessage {
 			if binaryBucket != nil && !binaryBucket.allow() {
@@ -847,10 +927,14 @@ func (c *conn) readPump(h *hub) {
 		}
 
 		var msg clientMsg
-		if err := json.Unmarshal(raw, &msg); err != nil { continue }
+		if err := json.Unmarshal(raw, &msg); err != nil {
+			continue
+		}
 		switch msg.Type {
 		case "join":
-			if room != "" { h.leave(room, peerID, c) }
+			if room != "" {
+				h.leave(room, peerID, c)
+			}
 			var sc int
 			room, peerID, sc = h.join(c, msg)
 			loopback = false
@@ -889,18 +973,25 @@ func (c *conn) readPump(h *hub) {
 var upgrader = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
 
 func clientIP(r *http.Request) string {
-	if ip := r.Header.Get("Fly-Client-IP"); ip != "" { return ip }
+	if ip := r.Header.Get("Fly-Client-IP"); ip != "" {
+		return ip
+	}
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
 		return strings.TrimSpace(strings.Split(xff, ",")[0])
 	}
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil { return r.RemoteAddr }
+	if err != nil {
+		return r.RemoteAddr
+	}
 	return host
 }
 
 func handleWS(h *hub, w http.ResponseWriter, r *http.Request) {
 	ws, err := upgrader.Upgrade(w, r, nil)
-	if err != nil { log.Printf("upgrade: %v", err); return }
+	if err != nil {
+		log.Printf("upgrade: %v", err)
+		return
+	}
 	c := &conn{ws: ws, send: make(chan wsMessage, 256), publicIP: clientIP(r)}
 	go c.writePump()
 	c.readPump(h)
@@ -908,8 +999,10 @@ func handleWS(h *hub, w http.ResponseWriter, r *http.Request) {
 
 func handleRooms(h *hub, w http.ResponseWriter, r *http.Request) {
 	type roomInfo struct {
-		Room string `json:"room"`; CreatedAt int64 `json:"created_at"`
-		PeerCount int `json:"peer_count"`; DisplayNames []string `json:"display_names"`
+		Room         string   `json:"room"`
+		CreatedAt    int64    `json:"created_at"`
+		PeerCount    int      `json:"peer_count"`
+		DisplayNames []string `json:"display_names"`
 	}
 	h.mu.RLock()
 	roomNames := make([]string, 0, len(h.rooms))
@@ -925,36 +1018,48 @@ func handleRooms(h *hub, w http.ResponseWriter, r *http.Request) {
 		var pwHash sql.NullString
 		var createdAt int64
 		h.db.QueryRow("SELECT password_hash, created_at FROM rooms WHERE room = ?", roomName).Scan(&pwHash, &createdAt)
-		if pwHash.Valid && pwHash.String != "" { continue }
+		if pwHash.Valid && pwHash.String != "" {
+			continue
+		}
 		conns := roomSnaps[roomName]
 		names := []string{}
 		for _, e := range conns {
-			if e.displayName != "" { names = append(names, e.displayName) }
+			if e.displayName != "" {
+				names = append(names, e.displayName)
+			}
 		}
 		result = append(result, roomInfo{Room: roomName, CreatedAt: createdAt, PeerCount: len(conns), DisplayNames: names})
 	}
-	if result == nil { result = []roomInfo{} }
+	if result == nil {
+		result = []roomInfo{}
+	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"rooms": result})
 }
 
 type sessionJSON struct {
-	ID string `json:"id"`; Room string `json:"room"`; StartedAt string `json:"started_at"`
-	EndedAt *string `json:"ended_at,omitempty"`; Duration string `json:"duration"`
-	Phase string `json:"phase"`; Peers []string `json:"peers"`
-	PeerDisplayNames map[string]string `json:"peer_display_names,omitempty"`
-	Joining map[string]*directionMetrics `json:"joining"`
-	Playing map[string]*directionMetrics `json:"playing"`
+	ID               string                       `json:"id"`
+	Room             string                       `json:"room"`
+	StartedAt        string                       `json:"started_at"`
+	EndedAt          *string                      `json:"ended_at,omitempty"`
+	Duration         string                       `json:"duration"`
+	Phase            string                       `json:"phase"`
+	Peers            []string                     `json:"peers"`
+	PeerDisplayNames map[string]string            `json:"peer_display_names,omitempty"`
+	Joining          map[string]*directionMetrics `json:"joining"`
+	Playing          map[string]*directionMetrics `json:"playing"`
 }
 type metricsSnapshot struct {
-	Active []sessionJSON `json:"active"`; Completed []sessionJSON `json:"completed"`
+	Active    []sessionJSON `json:"active"`
+	Completed []sessionJSON `json:"completed"`
 }
 
 func sessionToJSON(s *session) sessionJSON {
 	sj := sessionJSON{ID: s.ID, Room: s.Room, StartedAt: s.StartedAt.UTC().Format(time.RFC3339),
 		Phase: s.Phase, Peers: s.Peers, Joining: s.Joining, Playing: s.Playing}
 	if s.EndedAt != nil {
-		t := s.EndedAt.UTC().Format(time.RFC3339); sj.EndedAt = &t
+		t := s.EndedAt.UTC().Format(time.RFC3339)
+		sj.EndedAt = &t
 		sj.Duration = s.EndedAt.Sub(s.StartedAt).Round(time.Second).String()
 	} else {
 		sj.Duration = time.Since(s.StartedAt).Round(time.Second).String()
@@ -964,7 +1069,9 @@ func sessionToJSON(s *session) sessionJSON {
 
 func (h *hub) lookupDisplayNames(sj *sessionJSON) {
 	r := h.getRoom(sj.Room)
-	if r == nil { return }
+	if r == nil {
+		return
+	}
 	names := make(map[string]string)
 	for _, e := range r.loadConns() {
 		if e.displayName != "" {
@@ -981,10 +1088,15 @@ func (h *hub) snapshotMetrics(roomFilter string) metricsSnapshot {
 	h.mu.RLock()
 	roomNames := make([]string, 0, len(h.rooms))
 	roomPtrs := make([]*room, 0, len(h.rooms))
-	for name, r := range h.rooms { roomNames = append(roomNames, name); roomPtrs = append(roomPtrs, r) }
+	for name, r := range h.rooms {
+		roomNames = append(roomNames, name)
+		roomPtrs = append(roomPtrs, r)
+	}
 	h.mu.RUnlock()
 	for i, name := range roomNames {
-		if roomFilter != "" && name != roomFilter { continue }
+		if roomFilter != "" && name != roomFilter {
+			continue
+		}
 		r := roomPtrs[i]
 		r.mu.Lock()
 		if s := r.activeSession; s != nil {
@@ -996,7 +1108,9 @@ func (h *hub) snapshotMetrics(roomFilter string) metricsSnapshot {
 	}
 	h.completedMu.Lock()
 	for rn, sessions := range h.completedSessions {
-		if roomFilter != "" && rn != roomFilter { continue }
+		if roomFilter != "" && rn != roomFilter {
+			continue
+		}
 		for _, s := range sessions {
 			sj := sessionToJSON(s)
 			if len(s.peerDisplayNames) > 0 {
@@ -1009,8 +1123,12 @@ func (h *hub) snapshotMetrics(roomFilter string) metricsSnapshot {
 	}
 	h.completedMu.Unlock()
 	sort.Slice(completed, func(i, j int) bool { return completed[i].StartedAt > completed[j].StartedAt })
-	if active == nil { active = []sessionJSON{} }
-	if completed == nil { completed = []sessionJSON{} }
+	if active == nil {
+		active = []sessionJSON{}
+	}
+	if completed == nil {
+		completed = []sessionJSON{}
+	}
 	return metricsSnapshot{Active: active, Completed: completed}
 }
 
@@ -1022,20 +1140,35 @@ func handleMetrics(h *hub, w http.ResponseWriter, r *http.Request) {
 
 func handleMetricsWS(h *hub, w http.ResponseWriter, r *http.Request) {
 	ws, err := upgrader.Upgrade(w, r, nil)
-	if err != nil { log.Printf("metrics ws upgrade: %v", err); return }
+	if err != nil {
+		log.Printf("metrics ws upgrade: %v", err)
+		return
+	}
 	defer ws.Close()
 	roomFilter := r.URL.Query().Get("room")
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
-	if err := ws.WriteJSON(h.snapshotMetrics(roomFilter)); err != nil { return }
+	if err := ws.WriteJSON(h.snapshotMetrics(roomFilter)); err != nil {
+		return
+	}
 	done := make(chan struct{})
-	go func() { defer close(done); for { if _, _, err := ws.ReadMessage(); err != nil { return } } }()
+	go func() {
+		defer close(done)
+		for {
+			if _, _, err := ws.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
 	for {
 		select {
-		case <-done: return
+		case <-done:
+			return
 		case <-ticker.C:
 			ws.SetWriteDeadline(time.Now().Add(writeWait))
-			if err := ws.WriteJSON(h.snapshotMetrics(roomFilter)); err != nil { return }
+			if err := ws.WriteJSON(h.snapshotMetrics(roomFilter)); err != nil {
+				return
+			}
 		}
 	}
 }
@@ -1122,8 +1255,12 @@ func semverLess(a, b string) bool {
 	var a1, a2, a3, b1, b2, b3 int
 	fmt.Sscanf(a, "%d.%d.%d", &a1, &a2, &a3)
 	fmt.Sscanf(b, "%d.%d.%d", &b1, &b2, &b3)
-	if a1 != b1 { return a1 < b1 }
-	if a2 != b2 { return a2 < b2 }
+	if a1 != b1 {
+		return a1 < b1
+	}
+	if a2 != b2 {
+		return a2 < b2
+	}
 	return a3 < b3
 }
 
@@ -1142,7 +1279,9 @@ func main() {
 	http.HandleFunc("/metrics/dashboard", func(w http.ResponseWriter, r *http.Request) { handleDashboard(w, r) })
 	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200); w.Write([]byte("ok")) })
 	port := os.Getenv("PORT")
-	if port == "" { port = "8080" }
+	if port == "" {
+		port = "8080"
+	}
 	log.Printf("WAIL signaling server listening on :%s", port)
 	log.Fatal(http.ListenAndServe(":"+port, nil))
 }

--- a/wail-app/align_bridge_test.go
+++ b/wail-app/align_bridge_test.go
@@ -14,14 +14,14 @@ type fakeLinkBridge struct {
 	det *TempoChangeDetector
 }
 
-func (f *fakeLinkBridge) Enable()                          {}
-func (f *fakeLinkBridge) Disable()                         {}
-func (f *fakeLinkBridge) SetTempo(bpm float64)             { f.bpm = bpm }
-func (f *fakeLinkBridge) ForceBeat(float64, *int64)        {}
-func (f *fakeLinkBridge) SnapGrid(int64)                   {}
-func (f *fakeLinkBridge) TimeAtBeat(float64) int64         { return 0 }
-func (f *fakeLinkBridge) State() LinkState                 { return LinkState{BPM: f.bpm} }
-func (f *fakeLinkBridge) Detector() *TempoChangeDetector   { return f.det }
+func (f *fakeLinkBridge) Enable()                        {}
+func (f *fakeLinkBridge) Disable()                       {}
+func (f *fakeLinkBridge) SetTempo(bpm float64)           { f.bpm = bpm }
+func (f *fakeLinkBridge) ForceBeat(float64, *int64)      {}
+func (f *fakeLinkBridge) SnapGrid(int64)                 {}
+func (f *fakeLinkBridge) TimeAtBeat(float64) int64       { return 0 }
+func (f *fakeLinkBridge) State() LinkState               { return LinkState{BPM: f.bpm} }
+func (f *fakeLinkBridge) Detector() *TempoChangeDetector { return f.det }
 func (f *fakeLinkBridge) SpawnPoller(context.Context) (chan<- LinkCommand, <-chan LinkEvent) {
 	return nil, nil
 }

--- a/wail-app/app.go
+++ b/wail-app/app.go
@@ -26,11 +26,11 @@ var signalingURL = func() string {
 
 // App is the Wails application backend. All exported methods are callable from the frontend.
 type App struct {
-	mu          sync.Mutex
-	session     *SessionHandle
-	emitter     EventEmitter
-	identity    string
-	streamNames map[uint16]string
+	mu           sync.Mutex
+	session      *SessionHandle
+	emitter      EventEmitter
+	identity     string
+	streamNames  map[uint16]string
 	dataDir      string
 	instance     int      // per-instance offset; sets the CLAP IPC port (9191 + instance)
 	pluginErrors []string // CLAP auto-install errors from startup, surfaced to the UI

--- a/wail-app/audio_engine_real.go
+++ b/wail-app/audio_engine_real.go
@@ -48,7 +48,7 @@ const (
 	discoveryInterval  = 1 * time.Second
 	emitChunkFrames    = engineInternalRate * 5 / 1000 // ~5ms per paced write
 
-// emitCushionMs is how far ahead of the playhead each sink is kept fed —
+	// emitCushionMs is how far ahead of the playhead each sink is kept fed —
 	// stall tolerance for the emit loop. It stamps audio into the future, which
 	// some Link Audio receivers stall on (the VOID DAW-bridge plugin chokes on
 	// any feed-ahead), so the default was briefly 0 — floored to one ~5ms write

--- a/wail-app/cmd/linktempo/main.go
+++ b/wail-app/cmd/linktempo/main.go
@@ -3,8 +3,9 @@
 // user turning the tempo knob would (a committed timeline — newest wins).
 //
 // Usage:
-//   linktempo -bpm 120 -script "10:122,20:124,30:120"   # t-seconds:bpm steps
-//   linktempo -bpm 122 -insist-ms 500                    # re-apply -bpm every 500ms
+//
+//	linktempo -bpm 120 -script "10:122,20:124,30:120"   # t-seconds:bpm steps
+//	linktempo -bpm 122 -insist-ms 500                    # re-apply -bpm every 500ms
 //
 // -insist-ms models a LAN peer that refuses to follow (an external session or
 // a DAW whose user keeps turning the knob back): after every script step (or

--- a/wail-app/events.go
+++ b/wail-app/events.go
@@ -103,9 +103,9 @@ type StatusUpdate struct {
 	CaptureChannels []CaptureChannelInfo `json:"capture_channels,omitempty"`
 	// Grid alignment (ADR-0006): live readout for the debug panel. State is
 	// "aligned"/"aligning"/"drifted"/"off"; empty until the aligner is ready.
-	AlignState   string         `json:"align_state,omitempty"`
-	AlignErrorMs *float64       `json:"align_error_ms,omitempty"`
-	RelayRTTMs   *float64       `json:"relay_rtt_ms,omitempty"`
+	AlignState   string   `json:"align_state,omitempty"`
+	AlignErrorMs *float64 `json:"align_error_ms,omitempty"`
+	RelayRTTMs   *float64 `json:"relay_rtt_ms,omitempty"`
 	// StreamOffsets is the debug-room readout: per-stream rhythmic phase
 	// offset vs the room grid (internal/offset), empty until enough rhythmic
 	// content has arrived to judge.

--- a/wail-app/internal/align/steerer_test.go
+++ b/wail-app/internal/align/steerer_test.go
@@ -222,7 +222,7 @@ func TestSlewNudgeDoesNotArmTempoGate(t *testing.T) {
 	// active same-sign δ maps to the same target, which can't prove a second
 	// nudge fired. The flip restarts persistence — the nudge lands on the
 	// second confirming tick.)
-	f.timeAtBeat = 13_985_000 // δ=−15ms → target 119.94 ≠ current slew target
+	f.timeAtBeat = 13_985_000          // δ=−15ms → target 119.94 ≠ current slew target
 	s.Tick(16, now.Add(8*time.Second)) // flip sighting
 	s.Tick(16, now.Add(9*time.Second)) // confirmed → retarget
 	if len(f.tempos) != 2 || !approxEq(f.tempos[1], 120*(1-interval.SlewMaxFraction)) {
@@ -274,9 +274,9 @@ func TestSlewHoldsOffWhenDraggedFromOwnTarget(t *testing.T) {
 	}
 	// The session sits at the slew's own target: keep steering (no gate).
 	f.state.BPM = lastTempo(f)
-	f.timeAtBeat = 13_985_000 // δ=−15ms → different nudge (opposite sign)
+	f.timeAtBeat = 13_985_000          // δ=−15ms → different nudge (opposite sign)
 	s.Tick(16, now.Add(8*time.Second)) // flip sighting
-	s.Tick(16, now.Add(9*time.Second))  // confirmed → retarget
+	s.Tick(16, now.Add(9*time.Second)) // confirmed → retarget
 	if len(f.tempos) != 2 {
 		t.Fatalf("slew gated itself at its own target: %v", f.tempos)
 	}
@@ -490,7 +490,7 @@ func TestSlewSettleStaysImmediate(t *testing.T) {
 	s.Tick(16, now.Add(6*time.Second))
 	s.Tick(16, now.Add(7*time.Second)) // active
 	f.state.BPM = lastTempo(f)
-	f.timeAtBeat = 14_000_000 // δ closed
+	f.timeAtBeat = 14_000_000          // δ closed
 	s.Tick(16, now.Add(8*time.Second)) // restore must not wait for persistence
 	if got := lastTempo(f); got != 120 {
 		t.Fatalf("settled tempo = %v, want 120 (immediate restore)", got)

--- a/wail-app/internal/capture/assembler.go
+++ b/wail-app/internal/capture/assembler.go
@@ -14,11 +14,11 @@ import (
 // read as silence and are surfaced separately via LAN-loss metrics). Index is
 // the *local* interval index; the caller labels it with the shared room index.
 type CompletedInterval struct {
-	Index        int64
-	Samples      []int16 // interleaved, Frames × Channels
-	Frames       int     // full interval length in frames
-	Channels     int
-	WrittenFrames int    // frames actually covered by received buffers (<= Frames)
+	Index         int64
+	Samples       []int16 // interleaved, Frames × Channels
+	Frames        int     // full interval length in frames
+	Channels      int
+	WrittenFrames int // frames actually covered by received buffers (<= Frames)
 }
 
 // Complete reports whether the whole interval was covered by received audio.
@@ -38,10 +38,10 @@ func (c *CompletedInterval) Complete() bool { return c.WrittenFrames >= c.Frames
 // (measured live 2026-07: ~5-frame gaps every 64000 samples plus a growing
 // ~100-frame pop at every interval boundary — audible clicks).
 type Assembler struct {
-	cfg        interval.Config
-	channels   int
-	sampleRate uint32
-	cur        *intervalBuf
+	cfg         interval.Config
+	channels    int
+	sampleRate  uint32
+	cur         *intervalBuf
 	droppedLate uint64
 
 	// Contiguous placement cursor (frames within cur) + anchoring state.

--- a/wail-app/link_types.go
+++ b/wail-app/link_types.go
@@ -11,7 +11,7 @@ const (
 	tempoChangeThreshold  = 0.01 // BPM
 	echoGuardDuration     = 150 * time.Millisecond
 	linkPollInterval      = 20 * time.Millisecond // 50 Hz
-	snapshotIntervalTicks = 10                     // ~200ms at 50Hz
+	snapshotIntervalTicks = 10                    // ~200ms at 50Hz
 	// tempoHoldDown is how long a detected local tempo change must hold
 	// before it is reported as user intent. Link session convergence nudges
 	// (join merges, phase re-lock — up to ±2%) are transient, lasting a few

--- a/wail-app/session.go
+++ b/wail-app/session.go
@@ -1160,7 +1160,7 @@ func sessionLoop(
 				AudioDCOpen: dcOpen, PluginConnected: true,
 				AlignState: alignStateStr, AlignErrorMs: alignErrMs, RelayRTTMs: relayRttMs,
 				StreamOffsets: health.StreamOffsets,
-				Recording: recorder != nil,
+				Recording:     recorder != nil,
 				RecordingSizeBytes: func() uint64 {
 					if recorder != nil {
 						return recorder.BytesWritten()

--- a/wail-app/signaling.go
+++ b/wail-app/signaling.go
@@ -72,9 +72,9 @@ type outgoingSync struct {
 
 // SignalingChannels holds the incoming channels from the signaling connection.
 type SignalingChannels struct {
-	IncomingCh chan SignalMessage                // control plane (PeerJoined, PeerLeft, etc.)
-	SyncCh     chan FromPeerSync                // sync messages from peers
-	AudioCh    chan FromPeerAudio               // binary audio from peers
+	IncomingCh chan SignalMessage // control plane (PeerJoined, PeerLeft, etc.)
+	SyncCh     chan FromPeerSync  // sync messages from peers
+	AudioCh    chan FromPeerAudio // binary audio from peers
 }
 
 // FromPeerSync wraps a sync message with the sender's peer ID.

--- a/wail-app/wslog.go
+++ b/wail-app/wslog.go
@@ -20,10 +20,10 @@ type WsLogEntry struct {
 // WsLogWriter captures log output and broadcasts to subscribers.
 // Implements io.Writer so it can be added to a MultiWriter chain.
 type WsLogWriter struct {
-	enabled    atomic.Bool
-	mu         sync.Mutex
+	enabled     atomic.Bool
+	mu          sync.Mutex
 	subscribers []chan WsLogEntry
-	epoch      time.Time
+	epoch       time.Time
 }
 
 // NewWsLogWriter creates a new WebSocket log writer.


### PR DESCRIPTION
## What

`gofmt -w` across both Go modules. 13 files were non-compliant on `main`; `gofmt -l wail-app signaling-server` is now empty.

No behaviour change — the diff is whitespace, dropped `;` statement separators, and one doc-comment blank line. Verified mechanically:

- `git diff -w --ignore-blank-lines` leaves only the token-level changes below
- `git diff --word-diff-regex='[^[:space:]]+'` reports **25** changed tokens, and every one is a trailing `;` that became a newline (`err);` → `err)`, `` `json:"room"`; `` → `` `json:"room"` ``), plus a single `//` that gofmt's Go 1.19+ doc-comment rule inserts before the indented usage block in `cmd/linktempo/main.go`.

## The one judgment call

Most of the churn is one file. `signaling-server/main.go` was written in a compact single-line style — **60** bodies like:

```go
if p == nil { return }
if path == "" { path = "/data/wail.db" }
```

gofmt expands each to three lines, which is ~200 of the 287 inserted lines. That style was deliberate and gofmt cannot preserve it, so the choice is "gofmt-clean repo" or "keep the compact style and stay permanently non-compliant". I went with clean, but say the word and I'll drop that file from the sweep.

The rest is struct-field and const-block alignment that drifted when fields were added by hand.

## Verification

- `wail-app`: `go build ./...`, `go test -count=1 ./...` — pass (all 13 packages)
- `wail-app`: `go build -tags linkstub -o /dev/null .`, `go test -count=1 -tags linkstub ./...` — pass
- `signaling-server`: `go build ./...`, `go vet ./...`, `go test -count=1 ./...` — pass
- `gofmt -l wail-app signaling-server` — empty

### `scripts/tier2-e2e.sh` is flaky on `main` — not caused by this PR

I could not get a clean tier2 signal because the harness is a coin flip on this machine **independently of this change**. Same box, back to back:

| Tree | Runs | Result |
|---|---|---|
| `main` @ `4ca7ff1` (untouched) | 4 | **2 PASS, 2 FAIL** |
| this branch | 3 | **1 PASS, 2 FAIL** |

Audio integrity is fine in every run, pass or fail (`subscribed=1`, `maxLost=0`, `lossEvents=0`, non-silent 38/40s). Two failure modes, both on plain `main` too:

1. **Placement one interval late** — e.g. `room 4 majority-captured room 2 (2/3 votes), want room 3`, i.e. effective D=2 rather than D=1. Base run 3 hit this on 7 of 7 checks.
2. **Zero checks performed** — the harness collects 0 placement checks and fails for lack of evidence.

Since this PR provably changes no tokens, it cannot move interval placement. Flagging separately: either the harness's ground-truth binning is timing-fragile, or there's a real intermittent one-interval playout regression on `main` worth its own investigation. Happy to dig in — it's the more interesting bug of the two.

---
_Whitespace by gofmt, commit message by a language model of modest ambition._
