### PR TITLE
fix: install the Link Bridge plugins on Homebrew

### DIFF
--- a/homebrew/wail.rb
+++ b/homebrew/wail.rb
@@ -44,14 +44,18 @@ class Wail < Formula
     end
     bin.install "wail-app/wail"
 
-    # Build the CLAP plugins (thin PCM bridge for non-Link-Audio DAWs, ADR-0005) and
-    # stage them under lib/. Homebrew can't write into the user's plugin folder, so
-    # `wail-install-plugins` (below) copies them there on demand.
+    # Build the CLAP plugins (thin PCM bridge for non-Link-Audio DAWs, ADR-0005, plus
+    # the Link Bridge pair, ADR-0007) and stage them under lib/. Homebrew can't write
+    # into the user's plugin folder, so `wail-install-plugins` (below) copies them
+    # there on demand.
     system "cmake", "-S", "plugins", "-B", "build/plugins", "-DCMAKE_BUILD_TYPE=Release"
     system "cmake", "--build", "build/plugins"
     # Product bundles only: dev tools (transport-probe, linkbridge-spike) build
-    # alongside but must not be installed.
-    lib.install Dir["build/plugins/{wail-send,wail-recv,linkbridge-send,linkbridge-recv}.clap"]
+    # alongside but must not be installed. Named explicitly rather than brace-globbed
+    # — a glob silently drops renamed bundles instead of failing the build.
+    %w[wail-send wail-recv wail-linkbridge-send wail-linkbridge-recv].each do |bundle|
+      lib.install "build/plugins/#{bundle}.clap"
+    end
     bin.install "scripts/wail-install-plugins.sh" => "wail-install-plugins"
   end
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -16,6 +16,16 @@ or `WAIL_IPC_ADDR`).
 Both implement `clap.state` (Stream Index persists in project files for send; recv
 saves a version marker), so hosts can save projects/presets containing them.
 
+Alongside them are the **Link Bridge** plugins (ADR-0007), for DAWs that are native
+Link *sync* peers but lack Link Audio (Live pre-12.3, Bitwig-class hosts). These speak
+Link Audio directly instead of IPC — each instance joins the LAN Link session as its
+own audio-only peer, so the app needs no changes:
+
+- **`wail-linkbridge-send`** — publishes the track as a Link Audio channel named from
+  the DAW track name.
+- **`wail-linkbridge-recv`** — 16 stereo ports subscribed to the room-published
+  `WAIL · {peer} · {stream}` channels, auto-named as peers arrive.
+
 ## Build
 
 Requires a C11 compiler, CMake ≥ 3.15, and the vendored CLAP headers:
@@ -27,7 +37,10 @@ cmake --build build/plugins
 ctest --test-dir build/plugins --output-on-failure   # clap.state roundtrip tests
 ```
 
-Outputs `wail-send.clap` and `wail-recv.clap` in the build dir:
+Outputs the four product bundles in the build dir — `wail-send.clap`,
+`wail-recv.clap`, `wail-linkbridge-send.clap`, `wail-linkbridge-recv.clap` (the
+`transport-probe` and `linkbridge-spike` targets build alongside but are dev tools and
+are never shipped):
 - **macOS** — a `.clap` bundle (`Contents/MacOS/<name>` + `Info.plist`).
 - **Linux / Windows** — a single `.clap` shared object / DLL.
 

--- a/wail-app/plugin_install_test.go
+++ b/wail-app/plugin_install_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -31,6 +33,45 @@ func clapDestDir(t *testing.T) string {
 	default:
 		t.Skipf("unsupported test platform: %s", runtime.GOOS)
 		return ""
+	}
+}
+
+// staleLinkBridgeName matches an unprefixed linkbridge-send/-recv bundle name —
+// the pre-rename spelling. The leading class rejects "wail-linkbridge-send" and
+// the underscore source filenames (linkbridge_send.c).
+var staleLinkBridgeName = regexp.MustCompile(`(?m)(^|[^-\w])linkbridge-(send|recv)`)
+
+// The bundle list is duplicated across the build, the two installers, and the
+// release workflow. A rename that misses one of them ships silently: the Homebrew
+// formula's brace glob dropped both renamed Link Bridge bundles and still
+// succeeded, so macOS users got two of four plugins with no error anywhere.
+func TestPluginBundleListsInSync(t *testing.T) {
+	files := []string{
+		"homebrew/wail.rb",
+		"scripts/wail-install-plugins.sh",
+		"plugins/CMakeLists.txt",
+		".github/workflows/release.yml",
+	}
+	for _, rel := range files {
+		t.Run(rel, func(t *testing.T) {
+			// ".." is the repo root; absent when the module is extracted alone.
+			data, err := os.ReadFile(filepath.Join("..", rel))
+			if err != nil {
+				t.Skipf("not in a repo checkout: %v", err)
+			}
+			body := string(data)
+			for _, bundle := range pluginBundles {
+				// CMake targets and the workflow's shell loop name bundles without
+				// the extension, so match on the base name.
+				name := strings.TrimSuffix(bundle, ".clap")
+				if !strings.Contains(body, name) {
+					t.Errorf("%s does not mention bundle %q", rel, name)
+				}
+			}
+			if m := staleLinkBridgeName.FindString(body); m != "" {
+				t.Errorf("%s uses the pre-rename bundle name %q; expected the wail- prefix", rel, strings.TrimSpace(m))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## The report

A Homebrew install, then `wail-install-plugins`:

```
Installed: ~/Library/Audio/Plug-Ins/CLAP/wail-send.clap
Installed: ~/Library/Audio/Plug-Ins/CLAP/wail-recv.clap
warning: /opt/homebrew/lib/wail-linkbridge-send.clap not found, skipping.
warning: /opt/homebrew/lib/wail-linkbridge-recv.clap not found, skipping.
```

## Root cause — one stale line

The Link Bridge rename (`linkbridge-{send,recv}` → `wail-linkbridge-{send,recv}`) updated ten files and missed `homebrew/wail.rb`:

```ruby
lib.install Dir["build/plugins/{wail-send,wail-recv,linkbridge-send,linkbridge-recv}.clap"]
```

`Dir[]` drops non-matching brace alternatives without complaint, so `lib.install` succeeded with 2 of 4 bundles. CMake builds all four unconditionally — they were staged into `build/plugins/` and thrown away.

Three things made it invisible rather than loud:

- **macOS ships only via Homebrew.** There is no macOS job in `release.yml`, so the formula is the sole macOS delivery path and the only one with no CI coverage. Windows/Linux stage the correct names, and Windows even has a `test -e` guard the formula lacked.
- **The app's auto-installer is silent too.** `plugin_install.go` `continue`s past a missing bundle with nothing added to `errs` — first-launch auto-install skipped both Link Bridge plugins with no log line and no UI hint. Only the shell script said anything.
- **The bundle list lives in five places** with no cross-check, which is how a rename went half-applied in the first place.

## Changes

- **`homebrew/wail.rb`** — install by explicit name instead of a brace glob, so the next rename **fails the build** rather than shipping fewer plugins. Refreshed the neighbouring comment, which described only the ADR-0005 PCM bridge and predated the Link Bridge pair it now installs.
- **`wail-app/plugin_install_test.go`** — `TestPluginBundleListsInSync` checks `pluginBundles` against the formula, the install script, `plugins/CMakeLists.txt`, and `release.yml`; it also asserts the pre-rename spelling appears nowhere, so drift is caught in either direction. Skips cleanly outside a repo checkout. New pattern for this repo (first test to read repo-root files) — justified by the formula otherwise having zero automated coverage.
- **`plugins/README.md`** — documented the Link Bridge pair and corrected the build-outputs list, which named only two of the four product bundles.

## Verification

- `ruby -c homebrew/wail.rb` — parses.
- Built the plugins and ran `wail-install-plugins.sh` against the build dir: **four `Installed:` lines, zero warnings.**
- Negative check: with the formula reverted, the new test fails on both arms — the two missing names *and* the stale spelling. With the fix, green.
- `go test ./...` and `go test -tags linkstub ./...` (wail-app), `go test ./...` (signaling-server), `ctest` (plugins) — all pass. `go build -tags linkstub` clean.

## One caveat, and it is not this PR

`scripts/tier2-e2e.sh` reports FAIL — but it **also fails on a clean tree with these changes stashed**, with a different signature each run (one run collected zero placement checks; the clean-tree run reported rooms 4 and 5 captured one interval early). Audio integrity is healthy in every run: `subscribed=1`, `maxLost=0`, `lossEvents=0`, ~38/40s non-silent. This matches the known flakiness already flagged on #480 and is orthogonal to a Ruby formula, a test, and a markdown file — but it means tier2 is currently red on `main` and worth its own investigation.

Claude Code did the typing, blame it accordingly.