### PR TITLE
fix: hash room passwords with bcrypt instead of raw SHA-256

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -101,7 +101,7 @@ All signaling happens over a single WebSocket connection per client. Messages ar
 
 On `join`, the server:
 1. Checks `client_version >= minVersion`. Older clients get `join_error` with code `version_outdated`.
-2. Checks/creates the room, verifies password (SHA-256 hash comparison).
+2. Checks/creates the room, verifies the password against the stored bcrypt hash (cost 12). Rooms still holding a pre-bcrypt unsalted SHA-256 digest are accepted and re-hashed in place on the first successful join.
 3. Checks room capacity: 32 total stream slots. Full rooms get `join_error` with code `room_full`.
 4. Upserts peer into `peers` table.
 5. Sends `peer_joined` to all existing peers in the room (instant push).

--- a/signaling-server/Dockerfile
+++ b/signaling-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.24-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/signaling-server/go.mod
+++ b/signaling-server/go.mod
@@ -1,9 +1,10 @@
 module github.com/nicholasgasior/wail-signaling
 
-go 1.22
+go 1.24.0
 
 require (
 	github.com/gorilla/websocket v1.5.3
+	golang.org/x/crypto v0.47.0
 	modernc.org/sqlite v1.29.6
 )
 
@@ -14,7 +15,7 @@ require (
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	golang.org/x/sys v0.16.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
 	modernc.org/gc/v3 v3.0.0-20240107210532-573471604cb6 // indirect
 	modernc.org/libc v1.41.0 // indirect
 	modernc.org/mathutil v1.6.0 // indirect

--- a/signaling-server/go.sum
+++ b/signaling-server/go.sum
@@ -18,11 +18,13 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
+golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
 golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
 golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
-golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
+golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/tools v0.17.0 h1:FvmRgNOcs3kOa+T20R1uhfP9F6HgG2mfxDv1vrx1Htc=
 golang.org/x/tools v0.17.0/go.mod h1:xsh6VxdV005rRVaS6SSAf9oiAqljS7UZUacMZ8Bnsps=
 modernc.org/fileutil v1.3.0 h1:gQ5SIzK3H9kdfai/5x41oQiKValumqNTDXMvKo62HvE=

--- a/signaling-server/main.go
+++ b/signaling-server/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bytes"
 	"crypto/sha256"
+	"crypto/subtle"
 	"database/sql"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -18,6 +20,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"golang.org/x/crypto/bcrypt"
 	_ "modernc.org/sqlite"
 )
 
@@ -388,9 +391,48 @@ func openDB() *sql.DB {
 	return db
 }
 
-func hashPassword(pw string) string {
-	h := sha256.Sum256([]byte(pw))
-	return hex.EncodeToString(h[:])
+// bcryptCost is deliberately above the library default: joins are rare, so
+// ~250ms per attempt costs a musician nothing and makes offline cracking of a
+// leaked rooms table expensive.
+const bcryptCost = 12
+
+// bcryptInput folds passwords past bcrypt's 72-byte input limit through
+// SHA-256 so long ones are neither rejected nor silently truncated. The
+// base64 encoding keeps the result free of NUL bytes.
+func bcryptInput(pw string) []byte {
+	if len(pw) <= 72 {
+		return []byte(pw)
+	}
+	sum := sha256.Sum256([]byte(pw))
+	return []byte(base64.RawStdEncoding.EncodeToString(sum[:]))
+}
+
+func hashPassword(pw string) (string, error) {
+	h, err := bcrypt.GenerateFromPassword(bcryptInput(pw), bcryptCost)
+	if err != nil {
+		return "", err
+	}
+	return string(h), nil
+}
+
+// isLegacySHA256Hash reports whether stored is a pre-bcrypt unsalted SHA-256
+// digest, i.e. a bare 64-char hex string.
+func isLegacySHA256Hash(stored string) bool {
+	if len(stored) != hex.EncodedLen(sha256.Size) {
+		return false
+	}
+	_, err := hex.DecodeString(stored)
+	return err == nil
+}
+
+// checkPassword verifies pw against a stored room hash. legacy reports that
+// the stored digest is an old SHA-256 one and should be upgraded to bcrypt.
+func checkPassword(stored, pw string) (ok, legacy bool) {
+	if isLegacySHA256Hash(stored) {
+		sum := sha256.Sum256([]byte(pw))
+		return subtle.ConstantTimeCompare([]byte(hex.EncodeToString(sum[:])), []byte(stored)) == 1, true
+	}
+	return bcrypt.CompareHashAndPassword([]byte(stored), bcryptInput(pw)) == nil, false
 }
 
 // ---------------------------------------------------------------------------
@@ -444,6 +486,23 @@ func (h *hub) deleteRoom(name string) {
 	}
 }
 
+// upgradeRoomHash re-hashes a room's legacy SHA-256 password with bcrypt after
+// a successful join. The oldHash guard keeps a concurrent join from clobbering
+// an upgrade that already landed.
+func (h *hub) upgradeRoomHash(roomName, oldHash, pw string) {
+	newHash, err := hashPassword(pw)
+	if err != nil {
+		log.Printf("upgrade password hash for room %s: %v", roomName, err)
+		return
+	}
+	if _, err := h.db.Exec("UPDATE rooms SET password_hash = ? WHERE room = ? AND password_hash = ?",
+		newHash, roomName, oldHash); err != nil {
+		log.Printf("upgrade password hash for room %s: %v", roomName, err)
+		return
+	}
+	log.Printf("upgraded room %s password hash to bcrypt", roomName)
+}
+
 func (h *hub) archiveSession(roomName string, s *session) {
 	h.completedMu.Lock()
 	defer h.completedMu.Unlock()
@@ -481,9 +540,13 @@ func (h *hub) join(c *conn, msg clientMsg) (string, string, int) {
 		roomExists = true
 	}
 	if roomExists && storedHash.Valid && storedHash.String != "" {
-		if hashPassword(msg.Password) != storedHash.String {
+		ok, legacy := checkPassword(storedHash.String, msg.Password)
+		if !ok {
 			c.sendJSON(map[string]any{"type": "join_error", "code": "unauthorized"})
 			return "", "", 0
+		}
+		if legacy {
+			h.upgradeRoomHash(roomName, storedHash.String, msg.Password)
 		}
 	}
 
@@ -498,7 +561,12 @@ func (h *hub) join(c *conn, msg clientMsg) (string, string, int) {
 	if !roomExists {
 		pwHash := ""
 		if msg.Password != "" {
-			pwHash = hashPassword(msg.Password)
+			var err error
+			if pwHash, err = hashPassword(msg.Password); err != nil {
+				log.Printf("hash password for room %s: %v", roomName, err)
+				c.sendJSON(map[string]any{"type": "join_error", "code": "server_error"})
+				return "", "", 0
+			}
 		}
 		h.db.Exec("INSERT OR IGNORE INTO rooms (room, password_hash, created_at) VALUES (?, ?, ?)", roomName, pwHash, time.Now().Unix())
 	}

--- a/signaling-server/main_test.go
+++ b/signaling-server/main_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"golang.org/x/crypto/bcrypt"
 	_ "modernc.org/sqlite"
 )
 
@@ -446,5 +449,158 @@ func TestLoopbackResetsOnRejoin(t *testing.T) {
 	}
 	if _, _, ok := readBinaryFrame(t, ws, 500*time.Millisecond); ok {
 		t.Fatal("unexpected echo after rejoin — loopback should reset")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Room password hashing tests
+// ---------------------------------------------------------------------------
+
+func TestHashPasswordIsSaltedBcrypt(t *testing.T) {
+	a, err := hashPassword("hunter2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := hashPassword("hunter2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Fatal("two hashes of the same password are identical — hash is not salted")
+	}
+	if !strings.HasPrefix(a, "$2a$") {
+		t.Fatalf("expected a bcrypt hash, got %q", a)
+	}
+	cost, err := bcrypt.Cost([]byte(a))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cost < 12 {
+		t.Fatalf("bcrypt cost %d is below the minimum of 12", cost)
+	}
+}
+
+func TestCheckPasswordBcrypt(t *testing.T) {
+	stored, err := hashPassword("hunter2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok, legacy := checkPassword(stored, "hunter2"); !ok || legacy {
+		t.Fatalf("correct password: ok=%v legacy=%v, want true/false", ok, legacy)
+	}
+	if ok, _ := checkPassword(stored, "hunter3"); ok {
+		t.Fatal("wrong password accepted")
+	}
+	if ok, _ := checkPassword(stored, ""); ok {
+		t.Fatal("empty password accepted")
+	}
+}
+
+// Passwords beyond bcrypt's 72-byte input limit must still round-trip rather
+// than being silently truncated or rejected.
+func TestCheckPasswordLongerThanBcryptLimit(t *testing.T) {
+	long := strings.Repeat("a", 100)
+	stored, err := hashPassword(long)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok, _ := checkPassword(stored, long); !ok {
+		t.Fatal("long password rejected by its own hash")
+	}
+	// Differs only past byte 72 — a truncating implementation would accept it.
+	if ok, _ := checkPassword(stored, strings.Repeat("a", 99)+"b"); ok {
+		t.Fatal("password differing past byte 72 accepted — input is being truncated")
+	}
+}
+
+func TestCheckPasswordLegacySHA256(t *testing.T) {
+	sum := sha256.Sum256([]byte("hunter2"))
+	stored := hex.EncodeToString(sum[:])
+	ok, legacy := checkPassword(stored, "hunter2")
+	if !ok || !legacy {
+		t.Fatalf("legacy hash: ok=%v legacy=%v, want true/true", ok, legacy)
+	}
+	if ok, _ := checkPassword(stored, "hunter3"); ok {
+		t.Fatal("wrong password accepted against legacy hash")
+	}
+}
+
+func joinWithPassword(t *testing.T, ws *websocket.Conn, room, peerID, password string) map[string]any {
+	t.Helper()
+	msg := map[string]any{
+		"type":           "join",
+		"room":           room,
+		"peer_id":        peerID,
+		"password":       password,
+		"stream_count":   1,
+		"client_version": "99.0.0",
+	}
+	if err := ws.WriteJSON(msg); err != nil {
+		t.Fatal(err)
+	}
+	var resp map[string]any
+	ws.SetReadDeadline(time.Now().Add(10 * time.Second))
+	if err := ws.ReadJSON(&resp); err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func roomHash(t *testing.T, h *hub, room string) string {
+	t.Helper()
+	var stored sql.NullString
+	if err := h.db.QueryRow("SELECT password_hash FROM rooms WHERE room = ?", room).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	return stored.String
+}
+
+func TestJoinStoresBcryptHash(t *testing.T) {
+	h, srv := testServer(t)
+	if resp := joinWithPassword(t, dialWS(t, srv), "pw-room", "creator", "hunter2"); resp["type"] != "join_ok" {
+		t.Fatalf("expected join_ok, got %v", resp)
+	}
+
+	stored := roomHash(t, h, "pw-room")
+	if !strings.HasPrefix(stored, "$2") {
+		t.Fatalf("expected a bcrypt hash in the rooms table, got %q", stored)
+	}
+
+	if resp := joinWithPassword(t, dialWS(t, srv), "pw-room", "guest", "hunter2"); resp["type"] != "join_ok" {
+		t.Fatalf("correct password rejected: %v", resp)
+	}
+	resp := joinWithPassword(t, dialWS(t, srv), "pw-room", "intruder", "wrong")
+	if resp["type"] != "join_error" || resp["code"] != "unauthorized" {
+		t.Fatalf("expected unauthorized, got %v", resp)
+	}
+}
+
+// Rooms created before the bcrypt migration keep working, and their stored
+// digest is upgraded in place on the first successful join.
+func TestJoinUpgradesLegacyHash(t *testing.T) {
+	h, srv := testServer(t)
+	sum := sha256.Sum256([]byte("hunter2"))
+	legacy := hex.EncodeToString(sum[:])
+	if _, err := h.db.Exec("INSERT INTO rooms (room, password_hash, created_at) VALUES (?, ?, ?)",
+		"legacy-room", legacy, time.Now().Unix()); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp := joinWithPassword(t, dialWS(t, srv), "legacy-room", "intruder", "wrong"); resp["code"] != "unauthorized" {
+		t.Fatalf("expected unauthorized, got %v", resp)
+	}
+	if got := roomHash(t, h, "legacy-room"); got != legacy {
+		t.Fatal("failed join rewrote the stored hash")
+	}
+
+	if resp := joinWithPassword(t, dialWS(t, srv), "legacy-room", "member", "hunter2"); resp["type"] != "join_ok" {
+		t.Fatalf("legacy password rejected: %v", resp)
+	}
+	upgraded := roomHash(t, h, "legacy-room")
+	if !strings.HasPrefix(upgraded, "$2") {
+		t.Fatalf("expected the legacy hash to be upgraded to bcrypt, got %q", upgraded)
+	}
+	if resp := joinWithPassword(t, dialWS(t, srv), "legacy-room", "member2", "hunter2"); resp["type"] != "join_ok" {
+		t.Fatalf("join failed after upgrade: %v", resp)
 	}
 }


### PR DESCRIPTION
Closes #273.

Room passwords were stored as unsalted SHA-256 digests (`signaling-server/main.go`), so anyone who got hold of the rooms table could reverse common passwords with a rainbow table.

## What changed

- `hashPassword` now uses `golang.org/x/crypto/bcrypt` at cost 12 (~250ms per attempt — irrelevant on a join, expensive for an offline attacker).
- Passwords longer than bcrypt's 72-byte input limit are folded through SHA-256 and base64-encoded first, so they're neither rejected nor silently truncated. There's a test that a password differing only past byte 72 is rejected.
- `checkPassword` recognises a stored 64-char hex string as a legacy digest and verifies it with a constant-time compare.

## Migration

No password resets. A room still holding a legacy SHA-256 hash is accepted on join and re-hashed to bcrypt in place, guarded on the old value so a concurrent join can't clobber an upgrade that already landed. The `/rooms` public-list filter is unaffected — it only checks for a non-empty hash.

Also bumped the server Dockerfile to `golang:1.24-alpine`, since x/crypto requires a Go 1.24 directive in `go.mod`. CI already builds the server with the toolchain from `wail-app/go.mod` (1.26.1).

## Tests

- 6 new tests in `main_test.go`: salting, cost floor, correct/wrong/empty password, >72-byte round trip, legacy verification, and two integration tests over a real websocket join — one asserting new rooms land a `$2` hash, one asserting a seeded legacy room authenticates, upgrades in place, and still authenticates afterwards.
- `signaling-server`: `go test ./...` green.
- `wail-app`: `go test ./...` and `go test -tags linkstub ./...` green.
- `./scripts/tier2-e2e.sh`: `VERDICT=PASS`.

Claude Code hashed the passwords and is quietly relieved nobody asked it to invent the algorithm