### PR TITLE
fix: close the retirement gaps a review of #492 turned up

### DIFF
--- a/plugins/wail_recv.c
+++ b/plugins/wail_recv.c
@@ -297,6 +297,21 @@ static const char *display_name(const char *chan, char *buf, size_t cap) {
    return buf;
 }
 
+// free_slot releases a slot's subscription and clears its port label. Ordering
+// matters: clear assigned first so process() stops touching the source, then
+// give any in-flight process() time to return before destroying it.
+static void free_slot(lbr_recv *self, int i, int *miss, const char *why) {
+   lbr_log(self, "%s: \"%s\" (slot %d freed)", why, self->slots[i].chan_name, i);
+   atomic_store_explicit(&self->slots[i].assigned, false, memory_order_release);
+   wail_sleep_ms(50);
+   lb_source_destroy(self->slots[i].source);
+   self->slots[i].source = NULL;
+   self->slots[i].chan_name[0] = '\0';
+   self->slots[i].channel_id = 0;
+   miss[i] = 0;
+   set_port_name(self, i, "");
+}
+
 static void *mgr_main(void *arg) {
    lbr_recv *self = arg;
    int miss[LBR_SLOTS] = {0};
@@ -312,15 +327,7 @@ static void *mgr_main(void *arg) {
          for (size_t c = 0; c < nch; c++)
             if (chans[c].id_u64 == self->slots[i].channel_id) seen = true;
          miss[i] = seen ? 0 : miss[i] + 1;
-         if (miss[i] >= LBR_GONE_POLLS) {
-            lbr_log(self, "channel gone: \"%s\" (slot %d freed)", self->slots[i].chan_name, i);
-            atomic_store_explicit(&self->slots[i].assigned, false, memory_order_release);
-            wail_sleep_ms(50); // let an in-flight process() finish with the source
-            lb_source_destroy(self->slots[i].source);
-            self->slots[i].source = NULL;
-            miss[i] = 0;
-            set_port_name(self, i, "");
-         }
+         if (miss[i] >= LBR_GONE_POLLS) free_slot(self, i, miss, "channel gone");
       }
 
       // Assign new room-published channels.
@@ -380,6 +387,19 @@ static void *mgr_main(void *arg) {
             break;
          }
       }
+
+      // First-wins by name, reconciled after the fact. Two WAILs bridging one
+      // room rename their copies of a stream independently, so the second's
+      // old name matches no slot for a poll or two and takes a port the guard
+      // above would have refused. Converge by freeing the later duplicate.
+      for (int i = 0; i < LBR_SLOTS; i++) {
+         if (!atomic_load_explicit(&self->slots[i].assigned, memory_order_acquire)) continue;
+         for (int j = i + 1; j < LBR_SLOTS; j++) {
+            if (!atomic_load_explicit(&self->slots[j].assigned, memory_order_acquire)) continue;
+            if (strcmp(self->slots[i].chan_name, self->slots[j].chan_name) == 0)
+               free_slot(self, j, miss, "duplicate of a port we already carry");
+         }
+      }
    }
    return NULL;
 }
@@ -422,6 +442,12 @@ static void CLAP_ABI lbr_deactivate(const clap_plugin_t *plugin) {
          lb_source_destroy(self->slots[i].source);
          self->slots[i].source = NULL;
       }
+      // Release the slot too, not just its source: a reactivate re-runs
+      // discovery, and a slot still marked assigned for a live channel id is
+      // neither re-subscribed nor freed — it just renders silence forever.
+      atomic_store_explicit(&self->slots[i].assigned, false, memory_order_release);
+      self->slots[i].chan_name[0] = '\0';
+      self->slots[i].channel_id = 0;
    }
    if (self->link) {
       lb_enable(self->link, false);

--- a/wail-app/audio_engine.go
+++ b/wail-app/audio_engine.go
@@ -25,6 +25,10 @@ type AudioEngine interface {
 	// publishing stops holding a port on every WAIL Receive on the LAN. An
 	// empty set means "sending nothing", not "unknown".
 	SetPeerStreams(identity string, keep map[uint16]bool)
+	// ClearPeerIntent forgets what an identity last told us, so nothing of
+	// theirs is retirable again until it does. Needed wherever a DropPeer can
+	// be undone by something other than a fresh StreamNames.
+	ClearPeerIntent(identity string)
 	// DropPeer marks everything an identity publishes for retirement on a
 	// longer grace — they left the room (or, for the loopback identity, the
 	// server echo was turned off). The grace is what lets affinity hold a

--- a/wail-app/audio_engine_real.go
+++ b/wail-app/audio_engine_real.go
@@ -180,10 +180,13 @@ const (
 func enginePeerGoneGrace() time.Duration {
 	d, src := retireGracePeerGone, "default"
 	if v := os.Getenv("WAIL_STREAM_RETIRE_SEC"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+		// Floored, not just non-negative: a near-zero grace lets the sweep
+		// retire a stream inside the window HandleRemoteAudio drops the lock
+		// for its decode, which costs that frame and flaps the channel.
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
 			d, src = time.Duration(n)*time.Second, "WAIL_STREAM_RETIRE_SEC"
 		} else {
-			log.Printf("[audio] warn: bad WAIL_STREAM_RETIRE_SEC %q: using %s", v, d)
+			log.Printf("[audio] warn: bad WAIL_STREAM_RETIRE_SEC %q (want whole seconds >= 1): using %s", v, d)
 		}
 	}
 	log.Printf("[audio] departed-peer channel retirement: %s (%s)", d, src)
@@ -1103,6 +1106,14 @@ func (e *linkAudioEngine) HandleRemoteAudio(fromIdentity, displayName, streamNam
 	}
 
 	e.mu.Lock()
+	// The lock was dropped for the decode, so the boundary sweep may have
+	// retired this stream meanwhile. Placing the frame in the orphan would
+	// lose it and leave the next frame re-minting the channel — don't rely on
+	// the grace being long enough to make that unreachable.
+	if live, ok := e.emit[key]; !ok || live != st {
+		e.mu.Unlock()
+		return
+	}
 	for i, slot := range plcSlots {
 		if concealed[i] == nil {
 			continue
@@ -1152,6 +1163,16 @@ func (e *linkAudioEngine) SetPeerStreams(identity string, keep map[uint16]bool) 
 		own[id] = true
 	}
 	e.intent[identity] = peerIntent{keep: own}
+}
+
+// ClearPeerIntent forgets what we were told about an identity, putting it back
+// to "no news" — nothing of theirs is retirable until they say so again. The
+// counterpart to DropPeer for a source that will never send StreamNames (the
+// loopback echo), where the drop would otherwise stay in force forever.
+func (e *linkAudioEngine) ClearPeerIntent(identity string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	delete(e.intent, identity)
 }
 
 // DropPeer marks everything an identity publishes as retirable on the longer

--- a/wail-app/audio_engine_real_test.go
+++ b/wail-app/audio_engine_real_test.go
@@ -477,3 +477,33 @@ func TestRetirementKeepsHealthTotalsMonotonic(t *testing.T) {
 		t.Fatalf("total dropped to %d after retiring the stream, want 7 retained", got)
 	}
 }
+
+// Frames queued behind a PeerLeft publish under the peer-id fallback (the
+// registry entry is gone by the time they are handled), so retirement has to
+// cover that key too — otherwise the departure leaves a channel keyed by
+// something nothing will ever declare again, published for the session.
+func TestPeerIdKeyedStreamsAreRetirable(t *testing.T) {
+	le := newCaptureTestEngine(t)
+	feedRemoteStream(t, le, "peer-id-P", "", "", 0) // no Hello yet / peer already removed
+	le.DropPeer("peer-id-P")
+	drainPlayout(le)
+	sweep(le, time.Now().Add(retireGracePeerGone+time.Second))
+	if hasStream(le, "peer-id-P", 0) {
+		t.Fatal("a stream published under the peer-id fallback never retires")
+	}
+}
+
+// DropPeer on a source that will never send StreamNames (the loopback echo)
+// must be undoable, or re-enabling it leaves the drop in force and the monitor
+// channels are retired the next time frames pause.
+func TestClearPeerIntentMakesStreamsWantedAgain(t *testing.T) {
+	le := newCaptureTestEngine(t)
+	feedRemoteStream(t, le, "id-A:loopback", "Me (loopback)", "guitar", 0)
+	le.DropPeer("id-A:loopback")
+	le.ClearPeerIntent("id-A:loopback")
+	drainPlayout(le)
+	sweep(le, time.Now().Add(24*time.Hour))
+	if !hasStream(le, "id-A:loopback", 0) {
+		t.Fatal("cleared intent still retired the stream")
+	}
+}

--- a/wail-app/audio_engine_stub.go
+++ b/wail-app/audio_engine_stub.go
@@ -16,6 +16,7 @@ func (s *stubAudioEngine) Stop()                                                
 func (s *stubAudioEngine) HandleRemoteAudio(_, _, _ string, _ []byte)            {}
 func (s *stubAudioEngine) SetPeerStreams(_ string, _ map[uint16]bool)            {}
 func (s *stubAudioEngine) DropPeer(_ string)                                     {}
+func (s *stubAudioEngine) ClearPeerIntent(_ string)                              {}
 func (s *stubAudioEngine) SetRoomAnchor(_ int64, _ float64, _ uint32, _ float64) {}
 func (s *stubAudioEngine) AlignRoomLabel(_, _ int64)                             {}
 func (s *stubAudioEngine) OnGridSnap(_ int64)                                    {}

--- a/wail-app/session.go
+++ b/wail-app/session.go
@@ -513,7 +513,12 @@ func sessionLoop(
 			case "SetLoopback":
 				loopbackEnabled = cmd.Enabled
 				mesh.SendLoopback(cmd.Enabled)
-				if !cmd.Enabled {
+				if cmd.Enabled {
+					// Undo any earlier drop: nothing else ever will, since the echo
+					// identity never sends StreamNames, and a drop left in force
+					// retires the monitor channels the next time frames pause.
+					audioEngine.ClearPeerIntent(identity + ":loopback")
+				} else {
 					// The echo stops, so no StreamNames or PeerLeft will ever reach
 					// these — retire them explicitly or the monitor channels stay
 					// published for the rest of the session.
@@ -613,8 +618,14 @@ func sessionLoop(
 				}
 				logInfo("Peer %s left", name)
 				// Their channels stay published through the retirement grace, so a
-				// rejoin inside it keeps the same channels (affinity).
+				// rejoin inside it keeps the same channels (affinity). Drop the peer
+				// id too: their queued frames arrive on a different channel than this
+				// event, and once the registry entry is gone those frames publish
+				// under the peer-id fallback instead of the identity.
 				audioEngine.DropPeer(goneIdentity)
+				if goneIdentity != ev.PeerID {
+					audioEngine.DropPeer(ev.PeerID)
+				}
 				peers.Remove(ev.PeerID)
 				emitter.Emit("peer:left", PeerLeftEvent{PeerID: ev.PeerID})
 
@@ -1022,6 +1033,9 @@ func sessionLoop(
 				}
 				logWarn("Peer %s timed out", name)
 				audioEngine.DropPeer(deadIdentity)
+				if deadIdentity != deadID {
+					audioEngine.DropPeer(deadID) // late frames fall back to the peer id
+				}
 				peers.Remove(deadID)
 				mesh.RemovePeer(deadID)
 				emitter.Emit("peer:left", PeerLeftEvent{PeerID: deadID})


### PR DESCRIPTION
Follow-up to #492. An adversarial review of that PR found four real defects — three in the engine, one in the plugin. Each either leaves a channel published that nothing can ever retire, or retires one that should have stayed.

### 1. Departing peers left an unretirable ghost

`PeerLeft` and the liveness timeout dropped only the peer's *identity*. But their queued audio arrives on a different channel than the event, with no ordering guarantee between the two, so frames handled after `peers.Remove` fall through to the peer-id fallback (`identity = from`) and publish under **that** key. No intent is ever recorded for it, so the sweep never touches it.

That's the exact leak #492 set out to kill, on the path #492 changed. Now the peer id is dropped alongside the identity. (The Hello handler and the no-identity watchdog already did this; these two were the gaps.)

### 2. Loopback's drop was sticky

Turning the echo off marks `identity + ":loopback"` gone. Turning it back on did nothing, and that identity never sends `StreamNames`, so nothing ever cleared it — the intent-GC only fires once no streams remain, which they don't. The next pause in frames longer than the grace then retires the monitor channels *while loopback is enabled*, and resuming mints a fresh channel id, so the LAN sees it vanish and reappear on a possibly different port.

Adds `ClearPeerIntent` for sources that will never declare themselves.

### 3. Retirement could race the decode

`HandleRemoteAudio` caches its stream under the lock, drops it for the Opus decode, and re-acquires to place the frame. A short enough grace let the boundary sweep retire and delete that stream inside the window — the frame lands in an orphaned reassembler and is lost, and the next frame re-mints the channel. Repeats every boundary: a continuous close/republish flap.

Only reachable via an aggressive `WAIL_STREAM_RETIRE_SEC`, but the fix is not to rely on the grace being long enough: the stream is re-checked for liveness after re-acquiring the lock, and the configurable grace is floored at one second.

### 4. WAIL Receive could still double a port

The first-wins name guard compares against each slot's *current* `chan_name` — which #492's rename path mutates. Two WAILs bridging one room rename their copies independently, so for a poll or two the second's old name matches no slot and takes a port the guard would otherwise have refused. Both ports then settle on the same label.

Duplicates are now reconciled after assignment rather than only prevented at assign time, which converges regardless of rename ordering.

Also: `deactivate` destroyed each slot's source but left the slot `assigned` with a live channel id, so a reactivate neither re-subscribed it nor freed it — it just rendered silence forever. Pre-existing, but #492's id keying removed the accidental recovery (a later rename used to shake it loose).

### Testing

- 2 new engine tests: a peer-id-keyed stream is retirable; cleared intent makes streams wanted again
- Full `wail-app` suite both build modes (`-count=1`), vet, gofmt; plugins 4/4

One further review finding — a far-ahead mislabeled straggler pinning `reasm.MaxIndex()` and blocking retirement — is **not** in this PR. It is fixed separately in #495.

Claude Code wrote the bugs and then found them, which feels like a wash
