### PR TITLE
fix: don't let a mislabeled straggler pin a dead channel open

### DIFF
--- a/wail-app/audio_engine_real.go
+++ b/wail-app/audio_engine_real.go
@@ -173,6 +173,12 @@ const (
 	retireGracePeerGone = 30 * time.Second
 )
 
+// retireHorizonIntervals is how far past the release cursor (plus D) buffered
+// audio still counts as imminent, and so still blocks retirement. Matches the
+// margin the emit loop already treats as normal buffering before it calls a
+// sender's labels an anchor mismatch.
+const retireHorizonIntervals = 2
+
 // enginePeerGoneGrace resolves how long a departed peer's channels stay
 // published, WAIL_STREAM_RETIRE_SEC overriding the default. Always logs the
 // effective value: a session must be diagnosable from its log alone, without
@@ -1217,8 +1223,19 @@ func (e *linkAudioEngine) sweepRetiredLocked(now time.Time) {
 		if now.Sub(st.lastFrameAt) < grace {
 			continue
 		}
-		if _, buffered := st.reasm.MaxIndex(); buffered {
-			continue // still has audio to play out
+		// "Drained" has to mean nothing *imminent*, not nothing at all. A
+		// sender whose labels run ahead of our playout leaves stragglers
+		// buffered that far ahead, and Drop only clears at or below the release
+		// cursor — so asking for an empty reassembler keeps a dead channel
+		// published for as many boundaries as that peer is mislabeled, which is
+		// unbounded. Anything at or below the horizon still blocks: playout
+		// releases label−D and drops one boundary later, so the interval that
+		// just played is still held here and must not be cut.
+		if min, buffered := st.reasm.MinIndex(); buffered {
+			playing, started := st.sched.Playing()
+			if !started || min <= playing+st.sched.Offset()+retireHorizonIntervals {
+				continue
+			}
 		}
 		e.retireStreamLocked(key, st)
 	}

--- a/wail-app/audio_engine_real_test.go
+++ b/wail-app/audio_engine_real_test.go
@@ -318,12 +318,19 @@ const retireTestInterval = int64(5)
 // WAIF stream through the ingestion path, exactly as the relay would.
 func feedRemoteStream(t *testing.T, le *linkAudioEngine, identity, display, streamName string, streamID uint16) {
 	t.Helper()
+	feedRemoteStreamAt(t, le, identity, display, streamName, streamID, retireTestInterval)
+}
+
+// feedRemoteStreamAt is feedRemoteStream with an explicit room interval index,
+// for exercising senders whose labels sit far from local playout.
+func feedRemoteStreamAt(t *testing.T, le *linkAudioEngine, identity, display, streamName string, streamID uint16, roomIdx int64) {
+	t.Helper()
 	enc, err := NewIntervalEncoder(2, engineInternalRate, 128)
 	if err != nil {
 		t.Fatalf("encoder: %v", err)
 	}
 	pcm := make([]int16, 960*2*2) // 2 stereo 20ms frames
-	frames, _, err := enc.EncodeInterval(pcm, retireTestInterval, streamID, 0, 120, 4, 4)
+	frames, _, err := enc.EncodeInterval(pcm, roomIdx, streamID, 0, 120, 4, 4)
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}
@@ -505,5 +512,47 @@ func TestClearPeerIntentMakesStreamsWantedAgain(t *testing.T) {
 	sweep(le, time.Now().Add(24*time.Hour))
 	if !hasStream(le, "id-A:loopback", 0) {
 		t.Fatal("cleared intent still retired the stream")
+	}
+}
+
+// A sender whose room labels run far ahead of our playout leaves stragglers
+// buffered beyond the playout horizon. Drop only clears at or below the release
+// cursor, so requiring an empty reassembler kept a dead channel published for
+// as many boundaries as that peer was mislabeled — unbounded in practice.
+func TestFarAheadStragglerDoesNotBlockRetirement(t *testing.T) {
+	le := newCaptureTestEngine(t)
+	feedRemoteStreamAt(t, le, "id-A", "Alice", "guitar", 0, 5000)
+	st := le.emit[affinity.Key{Identity: "id-A", Stream: 0}]
+	if st == nil {
+		t.Fatal("stream not published")
+	}
+	st.sched.OnBoundary(3) // local playout is way behind the sender's labels
+
+	le.SetPeerStreams("id-A", map[uint16]bool{})
+	sweep(le, time.Now().Add(retireGraceDropped+time.Second))
+
+	if hasStream(le, "id-A", 0) {
+		t.Fatal("a straggler beyond the playout horizon still blocks retirement")
+	}
+}
+
+// The other side of that horizon: audio due imminently — including the interval
+// that just played, which playout drops only a boundary later — must still hold
+// the channel open, or retirement truncates it.
+func TestImminentAudioStillBlocksRetirement(t *testing.T) {
+	le := newCaptureTestEngine(t)
+	feedRemoteStreamAt(t, le, "id-A", "Alice", "guitar", 0, 5)
+	st := le.emit[affinity.Key{Identity: "id-A", Stream: 0}]
+	if st == nil {
+		t.Fatal("stream not published")
+	}
+	// playing = 3-D = 2, so interval 5 sits exactly on the horizon (D+2).
+	st.sched.OnBoundary(3)
+
+	le.SetPeerStreams("id-A", map[uint16]bool{})
+	sweep(le, time.Now().Add(24*time.Hour))
+
+	if !hasStream(le, "id-A", 0) {
+		t.Fatal("retired a stream with audio still due to play")
 	}
 }

--- a/wail-app/internal/emit/emit_test.go
+++ b/wail-app/internal/emit/emit_test.go
@@ -207,3 +207,29 @@ func TestMissingCountsAgainstTotalAndMaxFrame(t *testing.T) {
 		t.Fatalf("Missing = (%d,%d), want (2,1)", m, c)
 	}
 }
+
+func TestMinIndexTracksLowestBufferedInterval(t *testing.T) {
+	r := New(2, 960)
+	if _, ok := r.MinIndex(); ok {
+		t.Fatal("empty reassembler must report no buffered interval")
+	}
+	pcm := make([]int16, 960*2)
+	r.Add(70, 0, pcm, false, 0)
+	r.Add(12, 0, pcm, false, 0)
+	r.Add(4000, 0, pcm, false, 0)
+
+	min, ok := r.MinIndex()
+	if !ok || min != 12 {
+		t.Fatalf("MinIndex = (%d,%v), want (12,true)", min, ok)
+	}
+	// The distinction retirement depends on: one far-ahead straggler must not
+	// read as "audio is still playing" the way MaxIndex would.
+	r.Drop(70)
+	min, ok = r.MinIndex()
+	if !ok || min != 4000 {
+		t.Fatalf("after Drop(70) MinIndex = (%d,%v), want (4000,true)", min, ok)
+	}
+	if max, _ := r.MaxIndex(); max != min {
+		t.Fatalf("single straggler should have MinIndex == MaxIndex, got %d vs %d", min, max)
+	}
+}

--- a/wail-app/internal/emit/reassembler.go
+++ b/wail-app/internal/emit/reassembler.go
@@ -202,6 +202,20 @@ func (r *Reassembler) MaxIndex() (max int64, ok bool) {
 	return max, ok
 }
 
+// MinIndex returns the lowest interval index currently buffered; ok is false
+// when nothing is buffered. Retirement uses it to ask whether anything
+// *imminent* is held: MaxIndex cannot answer that, since one straggler far
+// beyond the playout horizon (a sender whose room labels run ahead) would
+// otherwise read as "still playing" for as many boundaries as it is ahead.
+func (r *Reassembler) MinIndex() (min int64, ok bool) {
+	for idx := range r.partials {
+		if !ok || idx < min {
+			min, ok = idx, true
+		}
+	}
+	return min, ok
+}
+
 // Drop discards any partial for interval `index` and every earlier interval
 // (they can never be played once we've moved past them).
 func (r *Reassembler) Drop(upToInclusive int64) {


### PR DESCRIPTION
The fifth finding from the review of #492, split out because #494 merged before this landed on its branch.

### The bug

Retirement required an **empty** reassembler to consider a stream drained. `Drop` only clears at or below the release cursor, so audio buffered *ahead* of playout survives until the cursor reaches it — and a sender whose room labels run ahead of us leaves exactly that. This is not hypothetical: the emit loop already warns about it as `[audio] WARN: … sender labels N intervals ahead of playout (anchor offset mismatch)`.

The dead channel then stays published for as many boundaries as that peer is mislabeled. Nothing bounds N. At the default 4 bars / 120 BPM that's 8s per interval, so a peer mislabeled by 100 intervals holds its channel for over 13 minutes — on every WAIL Receive on the LAN.

I originally reported this one as "delayed by N boundaries rather than prevented, so it drains on its own" and deferred it. The mechanism was right — the release cursor does advance on room labels regardless of traffic, so `Drop` does catch up eventually — but N is set by how badly a peer is mislabeled and isn't bounded by anything, so "delayed" was not the same as "self-correcting". Fixing it rather than leaving it noted.

### The fix

Drained now means nothing **imminent** rather than nothing at all. A straggler past `release cursor + D + 2 intervals` no longer blocks retirement; audio at or below that horizon still does, which is what keeps the interval that just played — dropped only a boundary later — from being cut. The two-interval margin matches what the emit loop already treats as normal buffering before it calls a sender mislabeled, so the two thresholds agree.

Adds `Reassembler.MinIndex`. `MaxIndex` can't answer this question: a lone far-ahead partial is simultaneously the highest and the only one, so "is anything imminent" needs the low end.

### Testing

- `TestFarAheadStragglerDoesNotBlockRetirement` — straggler at interval 5000 with playout at 2, sender declares nothing, must retire
- `TestImminentAudioStillBlocksRetirement` — audio sitting exactly on the horizon must **not** retire, guarding the truncation case
- `TestMinIndexTracksLowestBufferedInterval` in the pure `emit` package
- Mutation-checked: restoring the `MaxIndex` check fails the straggler test with "a straggler beyond the playout horizon still blocks retirement"
- Full `wail-app` suite both build modes (`-count=1`), vet, gofmt
- `./scripts/tier2-e2e.sh` **PASS** — 0 loss, 4/4 interval placement checks

Powered by artificial mediocrity, supervised by a slightly better-read version of itself
