### PR TITLE
feat: stamp the recv plugin's build and log channel transitions

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -11,6 +11,14 @@ set(CMAKE_C_VISIBILITY_PRESET hidden)
 
 find_package(Threads REQUIRED)
 
+# Stamp the repo version into the plugins so a running instance can say which
+# build it is. A DAW keeps a bundle mapped for the life of the process, so
+# reinstalling does not change the code already loaded — without this, telling a
+# stale instance from a current one means correlating process start times
+# against file mtimes.
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/../VERSION" WAIL_VERSION_RAW)
+string(STRIP "${WAIL_VERSION_RAW}" WAIL_PLUGIN_VERSION)
+
 set(CLAP_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/../vendor/clap/include")
 if(NOT EXISTS "${CLAP_INCLUDE}/clap/clap.h")
   message(FATAL_ERROR "CLAP headers not found at ${CLAP_INCLUDE}. Run: git submodule update --init vendor/clap")
@@ -78,6 +86,7 @@ endif()
 function(add_wail_link_plugin name)
   add_library(${name} MODULE ${ARGN})
   target_include_directories(${name} PRIVATE "${CLAP_INCLUDE}" "${CMAKE_CURRENT_SOURCE_DIR}")
+  target_compile_definitions(${name} PRIVATE WAIL_PLUGIN_VERSION="${WAIL_PLUGIN_VERSION}")
   set_target_properties(${name} PROPERTIES CXX_VISIBILITY_PRESET hidden VISIBILITY_INLINES_HIDDEN ON)
   target_link_libraries(${name} PRIVATE wail-link)
   if(MSVC)

--- a/plugins/wail_recv.c
+++ b/plugins/wail_recv.c
@@ -37,6 +37,14 @@
 #include "wail_link.h"
 #include "wail_thread.h" // wail_thread / wail_mutex / wail_sleep_ms
 
+// Identifies the running binary in the log. The version alone can't: a DAW
+// keeps a bundle mapped for the life of the process, so the stale case is
+// "same version, older build" — the compile time is what separates them.
+#ifndef WAIL_PLUGIN_VERSION
+#define WAIL_PLUGIN_VERSION "unknown"
+#endif
+#define WAIL_PLUGIN_BUILT __DATE__ " " __TIME__
+
 #define LBR_SLOTS 16
 #define LBR_RING_FRAMES 32768 // power of two; ~0.68s stereo @48k
 #define LBR_ANCHORS 512
@@ -93,6 +101,8 @@ typedef struct {
 
    wail_thread  mgr_thread;
    _Atomic bool running;
+
+   uint64_t snapshot_sig; // manager-thread only; last logged discovery+slot state
 
    FILE *log;
 } lbr_recv;
@@ -297,6 +307,47 @@ static const char *display_name(const char *chan, char *buf, size_t cap) {
    return buf;
 }
 
+// Snapshot signature: FNV-1a per entry, summed. Summing is commutative, so a
+// reordered discovery list is not mistaken for a change; slot entries mix in
+// the index, so a slot's position does count.
+static uint64_t lbr_entry_hash(uint64_t id, const char *name) {
+   uint64_t h = 1469598103934665603ULL;
+   const uint8_t *idb = (const uint8_t *)&id;
+   for (size_t i = 0; i < sizeof id; i++) {
+      h ^= idb[i];
+      h *= 1099511628211ULL;
+   }
+   for (const char *p = name; *p; p++) {
+      h ^= (uint8_t)*p;
+      h *= 1099511628211ULL;
+   }
+   return h;
+}
+
+// log_snapshot records discovery and the slot table, but only when either has
+// changed. Channel identity across a rename is the premise slot keying rests
+// on, so those transitions must be readable from the log rather than inferred
+// after the fact — while the steady state, at two polls a second, is pure
+// repetition and would bury them.
+static void log_snapshot(lbr_recv *self, const lb_channel_info *chans, size_t nch) {
+   uint64_t sig = 0;
+   for (size_t c = 0; c < nch; c++) sig += lbr_entry_hash(chans[c].id_u64, chans[c].name);
+   for (int i = 0; i < LBR_SLOTS; i++)
+      if (atomic_load_explicit(&self->slots[i].assigned, memory_order_acquire))
+         sig += lbr_entry_hash(self->slots[i].channel_id ^ (uint64_t)(i + 1),
+                               self->slots[i].chan_name);
+   if (sig == self->snapshot_sig) return;
+   self->snapshot_sig = sig;
+
+   for (size_t c = 0; c < nch; c++)
+      lbr_log(self, "  chan id=%016llx name=\"%s\"", (unsigned long long)chans[c].id_u64,
+              chans[c].name);
+   for (int i = 0; i < LBR_SLOTS; i++)
+      if (atomic_load_explicit(&self->slots[i].assigned, memory_order_acquire))
+         lbr_log(self, "  slot %d id=%016llx name=\"%s\"", i,
+                 (unsigned long long)self->slots[i].channel_id, self->slots[i].chan_name);
+}
+
 // free_slot releases a slot's subscription and clears its port label. Ordering
 // matters: clear assigned first so process() stops touching the source, then
 // give any in-flight process() time to return before destroying it.
@@ -400,6 +451,9 @@ static void *mgr_main(void *arg) {
                free_slot(self, j, miss, "duplicate of a port we already carry");
          }
       }
+
+      // After the poll's decisions, so the slot table logged is the outcome.
+      log_snapshot(self, chans, nch);
    }
    return NULL;
 }
@@ -423,7 +477,8 @@ static bool CLAP_ABI lbr_activate(const clap_plugin_t *plugin, double sr, uint32
    self->link = lb_create(120.0);
    lb_enable(self->link, true);
    lb_enable_audio(self->link, true);
-   lbr_log(self, "=== recv activated: host=\"%s %s\" sr=%.0f%s ===",
+   lbr_log(self, "=== recv activated: build %s (%s) host=\"%s %s\" sr=%.0f%s ===",
+           WAIL_PLUGIN_VERSION, WAIL_PLUGIN_BUILT,
            self->host && self->host->name ? self->host->name : "?",
            self->host && self->host->version ? self->host->version : "?", sr,
            self->rate_ok ? "" : " — NOT 48k: outputting silence");


### PR DESCRIPTION
Both changes come straight out of debugging a live session where a peer renamed a DAW track, the name reached WAIL, and the receive plugin's ports never updated.

### The build stamp

The rename was working. The app had renamed the sink in place, the LAN showed the new name, and a freshly-launched host relabelled its port correctly. The DAW didn't, because it had loaded the plugin bundle 90 minutes before the fixed build was installed — and macOS keeps a bundle mapped for the life of the process, so replacing the file on disk changes nothing about the code already running.

Establishing that meant comparing the host's process start time against the bundle's mtime. Checking the installed *file* actively misled: it was the current build, while the process was executing the previous one.

The activation line now names the build and where it came from:

```
=== recv activated: build 4.0.1 (2026-07-31 19:38:38) host="clap-trap 1.0.0" sr=48000 ===
    loaded from /Users/andrew/git/WAIL/build/plugins/wail-recv.clap/Contents/MacOS/wail-recv
```

Version comes from the repo `VERSION` via CMake (the plugins had no version plumbing at all). The build identity is the **mtime of the loaded module itself**, found with `dladdr` / `GetModuleHandleEx` — not a compile-time macro, for reasons in the review notes below. The path is the other half of the same question: which copy the host actually loaded.

### Change-triggered snapshot logging

Slot keying is built on the assumption that a channel keeps its id across a rename. When that was in doubt there was no way to check it from a log — the plugin recorded subscribe/free/rename events but never the ids behind them, so the only options were inference or a bespoke instrumented build. I ended up writing the latter, which is the tell.

The manager now logs its discovery snapshot and slot table — ids and names side by side — whenever either changes:

```
renamed: "WAIL · rp · alpha" → "WAIL · rp · beta" (port 5)
  chan id=4e2d7a3a34777a68 name="WAIL · rp · beta"      ← same id
  slot 4 id=4e2d7a3a34777a68 name="WAIL · rp · beta"    ← relabelled in place
```

**Only on change.** My first version logged every poll, which I measured before proposing it: 18 lines/s in a 5-channel session (~4.4 MB/hour), ~64 lines/s in a 16-channel one, per instance, all sharing one log file. Change-triggered, the same 24-second scenario (subscribe, rename, disappearance) produces **69 lines instead of 452**, and steady state produces none.

The signature sums a per-entry FNV-1a hash, so a reordered discovery list isn't mistaken for a change; slot entries mix in the index, so a slot's position does count.

---

## Fixes after review

An adversarial review found five real defects, all fixed on this branch:

1. **The plugin logged from the audio thread.** `slot_drain` wrote its "first pop" line straight to the log, so `process()` did a buffered write plus an `fflush` inside its deadline — against the threading contract stated at the top of that same file. Pre-existing, but this PR made collisions routine by giving the manager a much larger share of the same `FILE`. `process()` now hands the details over and the manager writes them. WAIL Send had the identical bug (`first commit` from `lbs_process`), fixed the same way through its existing `on_main_thread`.
2. **The snapshot hashed every channel on the LAN**, not just room-published ones, so an unrelated app renaming its tracks churned the signature and dumped the table for something this plugin never acts on. Signature and dump are now scoped to the room prefix.
3. **`snapshot_sig` survived deactivate**, so a deactivate/reactivate with an unchanged channel set reopened the log and recorded nothing — precisely the state the feature exists to capture. Reset on activate.
4. **`file(READ)` is not a configure dependency**, so a VERSION bump left the stamp reporting the previous release, which is worse than no stamp. Fixed and verified: bump VERSION, plain `cmake --build`, and it reconfigures, recompiles, and carries the new version. A missing `VERSION` is now a clear configure error too, matching how this file already guards its other out-of-tree dependencies.
5. **`__DATE__`/`__TIME__` was the wrong mechanism.** It records when one translation unit was compiled, not when the bundle was linked — so editing `wail_link.cpp` produces a changed `.clap` with an unchanged stamp, the exact incremental case the stamp exists for. Replaced with the loaded module's own mtime, which cannot go stale because it reads the file the running code came from. Verified both ways: the stamp matches the binary's mtime exactly, and touching `wail_link.cpp` relinks the bundle and moves the stamp with it.

### Testing

- Plugins 4/4, zero compiler warnings
- Verified against the real scenario: the actual `.clap` under `minidaw` with a separate process publishing and renaming a channel — genuinely cross-process, the topology the same-process unit test doesn't cover

With moral support from Claude Code, which needed the logs it forgot to write
