### PR TITLE
fix: review fixes for #495 and #496 that missed their merges

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -16,8 +16,15 @@ find_package(Threads REQUIRED)
 # reinstalling does not change the code already loaded — without this, telling a
 # stale instance from a current one means correlating process start times
 # against file mtimes.
-file(READ "${CMAKE_CURRENT_SOURCE_DIR}/../VERSION" WAIL_VERSION_RAW)
+set(WAIL_VERSION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../VERSION")
+if(NOT EXISTS "${WAIL_VERSION_FILE}")
+  message(FATAL_ERROR "VERSION not found at ${WAIL_VERSION_FILE}. The plugins read the repo version from it; build from a full checkout.")
+endif()
+file(READ "${WAIL_VERSION_FILE}" WAIL_VERSION_RAW)
 string(STRIP "${WAIL_VERSION_RAW}" WAIL_PLUGIN_VERSION)
+# file(READ) is not a configure dependency on its own, so a version bump would
+# leave the stamp reporting the previous release — worse than no stamp.
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${WAIL_VERSION_FILE}")
 
 set(CLAP_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/../vendor/clap/include")
 if(NOT EXISTS "${CLAP_INCLUDE}/clap/clap.h")

--- a/plugins/wail_link.h
+++ b/plugins/wail_link.h
@@ -13,6 +13,15 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,6 +39,50 @@ static inline void lb_temp_log_path(const char *filename, char *buf, unsigned lo
 #else
    snprintf(buf, cap, "/tmp/%s", filename);
 #endif
+}
+
+// lb_module_stamp identifies the binary this code was loaded from, by the
+// mtime of that file, and reports its path.
+//
+// A compile-time macro cannot answer the question it looks like it answers.
+// __DATE__/__TIME__ record when one translation unit was compiled, not when
+// the bundle was linked or installed — edit a sibling source, rebuild, and the
+// bundle changes while the stamp does not. And a DAW keeps a plugin mapped for
+// the life of the process, so "which build is actually running" is exactly the
+// question that comes up, and it must not be answerable wrongly. Reading the
+// loaded module's own file cannot go stale: it is the file the running code
+// came from.
+static inline void lb_module_stamp(char *stamp, unsigned long stampCap, char *path,
+                                   unsigned long pathCap) {
+   snprintf(stamp, stampCap, "unknown");
+   if (path && pathCap) snprintf(path, pathCap, "?");
+   const char *found = NULL;
+#ifdef _WIN32
+   char self[MAX_PATH];
+   HMODULE mod = NULL;
+   if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                              GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                          (LPCSTR)(void *)&lb_module_stamp, &mod) &&
+       GetModuleFileNameA(mod, self, (DWORD)sizeof(self)))
+      found = self;
+#else
+   Dl_info info;
+   if (dladdr((void *)&lb_module_stamp, &info) && info.dli_fname) found = info.dli_fname;
+#endif
+   if (!found) return;
+   if (path && pathCap) snprintf(path, pathCap, "%s", found);
+
+   struct stat st;
+   if (stat(found, &st) != 0) return;
+   time_t   mt = st.st_mtime;
+   struct tm tmv;
+#ifdef _WIN32
+   if (localtime_s(&tmv, &mt) != 0) return;
+#else
+   if (!localtime_r(&mt, &tmv)) return;
+#endif
+   if (strftime(stamp, stampCap, "%Y-%m-%d %H:%M:%S", &tmv) == 0)
+      snprintf(stamp, stampCap, "unknown");
 }
 
 typedef struct lb_link lb_link;

--- a/plugins/wail_recv.c
+++ b/plugins/wail_recv.c
@@ -37,13 +37,12 @@
 #include "wail_link.h"
 #include "wail_thread.h" // wail_thread / wail_mutex / wail_sleep_ms
 
-// Identifies the running binary in the log. The version alone can't: a DAW
-// keeps a bundle mapped for the life of the process, so the stale case is
-// "same version, older build" — the compile time is what separates them.
+// Names the release in the log; lb_module_stamp supplies which build of it is
+// actually loaded (the version alone can't — the stale case is "same version,
+// older build", which is every case during development).
 #ifndef WAIL_PLUGIN_VERSION
 #define WAIL_PLUGIN_VERSION "unknown"
 #endif
-#define WAIL_PLUGIN_BUILT __DATE__ " " __TIME__
 
 #define LBR_SLOTS 16
 #define LBR_RING_FRAMES 32768 // power of two; ~0.68s stereo @48k
@@ -514,11 +513,16 @@ static bool CLAP_ABI lbr_activate(const clap_plugin_t *plugin, double sr, uint32
    self->link = lb_create(120.0);
    lb_enable(self->link, true);
    lb_enable_audio(self->link, true);
+   char stamp[64], modpath[512];
+   lb_module_stamp(stamp, sizeof(stamp), modpath, sizeof(modpath));
    lbr_log(self, "=== recv activated: build %s (%s) host=\"%s %s\" sr=%.0f%s ===",
-           WAIL_PLUGIN_VERSION, WAIL_PLUGIN_BUILT,
+           WAIL_PLUGIN_VERSION, stamp,
            self->host && self->host->name ? self->host->name : "?",
            self->host && self->host->version ? self->host->version : "?", sr,
            self->rate_ok ? "" : " — NOT 48k: outputting silence");
+   // Which copy the host actually loaded — installed bundle, build tree, or a
+   // stale duplicate — is the other half of "is this the build I think it is".
+   lbr_log(self, "    loaded from %s", modpath);
    // Fresh log file, so forget what the previous activation had recorded —
    // otherwise an unchanged channel set means the reopened log never states
    // the state it exists to record.

--- a/plugins/wail_recv.c
+++ b/plugins/wail_recv.c
@@ -81,7 +81,18 @@ typedef struct {
    bool        has_last;
    uint32_t    rate;
    uint64_t    align_dropped;
-   bool        logged_pop;
+   bool        logged_pop; // process(): first pop handed off already
+
+   // First-pop details, filled by process() and written out by the manager —
+   // logging from the audio thread is blocking I/O and is not allowed here.
+   // Published by pop_pending; process() writes the fields before the release
+   // store and never touches them again, so the manager reads them safely.
+   _Atomic bool pop_pending;
+   struct {
+      size_t   frames, channels;
+      uint32_t rate;
+      double   begin_beat;
+   } pop;
 } lbr_slot;
 
 typedef struct {
@@ -152,9 +163,17 @@ static void slot_drain(lbr_recv *self, lbr_slot *s) {
    lb_state *st = lb_capture(self->link);
    while (lb_source_pop(s->source, &b, LBR_QUANTUM)) {
       if (!s->logged_pop) {
+         // Hand the first-pop details to the manager to write. This runs on
+         // the audio thread, where lbr_log's buffered write + fflush is a
+         // blocking disk I/O the threading contract here forbids outright —
+         // and it shares its FILE with the manager, so it could block on
+         // another thread's write to /tmp inside the process deadline.
+         s->pop.frames = b.num_frames;
+         s->pop.channels = b.num_channels;
+         s->pop.rate = b.sample_rate;
+         s->pop.begin_beat = b.begin_beat;
+         atomic_store_explicit(&s->pop_pending, true, memory_order_release);
          s->logged_pop = true;
-         lbr_log(self, "first pop: frames=%zu ch=%zu rate=%u begin_beat=%.3f (0=unmapped)",
-                 b.num_frames, b.num_channels, b.sample_rate, b.begin_beat);
       }
       if (b.num_frames == 0 || b.begin_beat == 0) continue; // unmapped (cross-session) — skip
       uint32_t nf = (uint32_t)b.num_frames;
@@ -331,7 +350,14 @@ static uint64_t lbr_entry_hash(uint64_t id, const char *name) {
 // repetition and would bury them.
 static void log_snapshot(lbr_recv *self, const lb_channel_info *chans, size_t nch) {
    uint64_t sig = 0;
-   for (size_t c = 0; c < nch; c++) sig += lbr_entry_hash(chans[c].id_u64, chans[c].name);
+   for (size_t c = 0; c < nch; c++) {
+      // Only channels this plugin could carry. Every other Link Audio channel
+      // on the LAN — another app's tracks being renamed or armed — would
+      // otherwise churn the signature and dump the table for something we
+      // never act on.
+      if (strncmp(chans[c].name, LBR_ROOM_PREFIX, strlen(LBR_ROOM_PREFIX)) != 0) continue;
+      sig += lbr_entry_hash(chans[c].id_u64, chans[c].name);
+   }
    for (int i = 0; i < LBR_SLOTS; i++)
       if (atomic_load_explicit(&self->slots[i].assigned, memory_order_acquire))
          sig += lbr_entry_hash(self->slots[i].channel_id ^ (uint64_t)(i + 1),
@@ -339,9 +365,11 @@ static void log_snapshot(lbr_recv *self, const lb_channel_info *chans, size_t nc
    if (sig == self->snapshot_sig) return;
    self->snapshot_sig = sig;
 
-   for (size_t c = 0; c < nch; c++)
+   for (size_t c = 0; c < nch; c++) {
+      if (strncmp(chans[c].name, LBR_ROOM_PREFIX, strlen(LBR_ROOM_PREFIX)) != 0) continue;
       lbr_log(self, "  chan id=%016llx name=\"%s\"", (unsigned long long)chans[c].id_u64,
               chans[c].name);
+   }
    for (int i = 0; i < LBR_SLOTS; i++)
       if (atomic_load_explicit(&self->slots[i].assigned, memory_order_acquire))
          lbr_log(self, "  slot %d id=%016llx name=\"%s\"", i,
@@ -370,6 +398,15 @@ static void *mgr_main(void *arg) {
       wail_sleep_ms(500);
       lb_channel_info chans[LB_MAX_CHANNELS];
       size_t nch = lb_channels(self->link, chans, LB_MAX_CHANNELS);
+
+      // Write out any first-pop details process() handed over.
+      for (int i = 0; i < LBR_SLOTS; i++) {
+         lbr_slot *s = &self->slots[i];
+         if (!atomic_load_explicit(&s->pop_pending, memory_order_acquire)) continue;
+         atomic_store_explicit(&s->pop_pending, false, memory_order_relaxed);
+         lbr_log(self, "first pop on port %d: frames=%zu ch=%zu rate=%u begin_beat=%.3f (0=unmapped)",
+                 i + 1, s->pop.frames, s->pop.channels, s->pop.rate, s->pop.begin_beat);
+      }
 
       // Free slots whose channel has disappeared for a while.
       for (int i = 0; i < LBR_SLOTS; i++) {
@@ -482,6 +519,10 @@ static bool CLAP_ABI lbr_activate(const clap_plugin_t *plugin, double sr, uint32
            self->host && self->host->name ? self->host->name : "?",
            self->host && self->host->version ? self->host->version : "?", sr,
            self->rate_ok ? "" : " — NOT 48k: outputting silence");
+   // Fresh log file, so forget what the previous activation had recorded —
+   // otherwise an unchanged channel set means the reopened log never states
+   // the state it exists to record.
+   self->snapshot_sig = 0;
    atomic_store(&self->running, true);
    if (wail_thread_create(&self->mgr_thread, mgr_main, self) != 0) {
       atomic_store(&self->running, false);

--- a/plugins/wail_send.c
+++ b/plugins/wail_send.c
@@ -32,6 +32,11 @@
 // per setup (same class as the recv path's output-path constant).
 #define LBS_STAMP_AHEAD_US 10000
 
+// Names the release; lb_module_stamp supplies which build of it is loaded.
+#ifndef WAIL_PLUGIN_VERSION
+#define WAIL_PLUGIN_VERSION "unknown"
+#endif
+
 typedef struct {
    clap_plugin_t      plugin;
    const clap_host_t *host;
@@ -46,7 +51,15 @@ typedef struct {
    char track_name[CLAP_NAME_SIZE];
 
    FILE *log;
-   bool  logged_commit;
+
+   // First-commit result, handed from the audio thread to the main thread to
+   // write: lbs_log does a buffered write plus an fflush, which process() must
+   // not do. Published by commit_pending; process() sets commit_ok before the
+   // release store and never touches it again.
+   bool         logged_commit;
+   _Atomic bool commit_pending;
+   bool         commit_ok;
+   uint32_t     commit_frames;
 } lb_send;
 
 static void lbs_log(lb_send *self, const char *fmt, ...) {
@@ -111,7 +124,10 @@ static clap_process_status CLAP_ABI lbs_process(const clap_plugin_t *plugin, con
    lb_release(st);
    if (!self->logged_commit) {
       self->logged_commit = true;
-      lbs_log(self, "first commit: %s (frames=%u)", ok ? "ok" : "WITHHELD (no source subscribed?)", n);
+      self->commit_ok = ok;
+      self->commit_frames = n;
+      atomic_store_explicit(&self->commit_pending, true, memory_order_release);
+      if (self->host && self->host->request_callback) self->host->request_callback(self->host);
    }
    return CLAP_PROCESS_CONTINUE;
 }
@@ -135,11 +151,15 @@ static bool CLAP_ABI lbs_activate(const clap_plugin_t *plugin, double sr, uint32
    lb_enable_audio(self->link, true);
    refresh_track_name(self);
    const char *name = self->track_name[0] ? self->track_name : "WAIL Send";
+   char stamp[64], modpath[512];
+   lb_module_stamp(stamp, sizeof(stamp), modpath, sizeof(modpath));
    if (self->rate_ok) {
       self->sink = lb_sink_create(self->link, name, 16384);
-      lbs_log(self, "=== send activated: host=\"%s %s\" sr=%.0f channel=\"%s\" ===",
+      lbs_log(self, "=== send activated: build %s (%s) host=\"%s %s\" sr=%.0f channel=\"%s\" ===",
+              WAIL_PLUGIN_VERSION, stamp,
               self->host && self->host->name ? self->host->name : "?",
               self->host && self->host->version ? self->host->version : "?", sr, name);
+      lbs_log(self, "    loaded from %s", modpath);
    } else {
       lbs_log(self, "!!! send activated at sr=%.0f — Link Audio is 48kHz-only; "
                     "this instance passes audio but publishes NOTHING "
@@ -212,7 +232,11 @@ static const void *CLAP_ABI lbs_get_extension(const clap_plugin_t *p, const char
    return NULL;
 }
 static void CLAP_ABI lbs_main_thread(const clap_plugin_t *p) {
-   (void)p;
+   lb_send *self = p->plugin_data;
+   if (!atomic_load_explicit(&self->commit_pending, memory_order_acquire)) return;
+   atomic_store_explicit(&self->commit_pending, false, memory_order_relaxed);
+   lbs_log(self, "first commit: %s (frames=%u)",
+           self->commit_ok ? "ok" : "WITHHELD (no source subscribed?)", self->commit_frames);
 }
 
 static const char *lbs_features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_UTILITY, NULL};

--- a/wail-app/audio_engine_real.go
+++ b/wail-app/audio_engine_real.go
@@ -1214,7 +1214,11 @@ func (e *linkAudioEngine) retirableLocked(key affinity.Key) (time.Duration, bool
 // grace shorter than one interval would otherwise cut audio mid-flight.
 // Boundary-aligned (called from onBoundary under mu) so a sink never closes
 // while topUpSinks is feeding it. Caller holds e.mu.
-func (e *linkAudioEngine) sweepRetiredLocked(now time.Time) {
+// roomLabel is the boundary being processed, which is also the horizon's
+// reference: this runs before the release loop advances each scheduler, so
+// reading the cursor from the schedulers here would measure the *previous*
+// boundary and retire one interval sooner than intended.
+func (e *linkAudioEngine) sweepRetiredLocked(now time.Time, roomLabel int64) {
 	for key, st := range e.emit {
 		grace, ok := e.retirableLocked(key)
 		if !ok {
@@ -1227,17 +1231,24 @@ func (e *linkAudioEngine) sweepRetiredLocked(now time.Time) {
 		// sender whose labels run ahead of our playout leaves stragglers
 		// buffered that far ahead, and Drop only clears at or below the release
 		// cursor — so asking for an empty reassembler keeps a dead channel
-		// published for as many boundaries as that peer is mislabeled, which is
-		// unbounded. Anything at or below the horizon still blocks: playout
-		// releases label−D and drops one boundary later, so the interval that
+		// published for as many boundaries as that peer is mislabeled. Anything
+		// at or below the horizon still blocks: an interval is released at
+		// boundary index+D and dropped one boundary later, so the interval that
 		// just played is still held here and must not be cut.
+		backlog := 0
 		if min, buffered := st.reasm.MinIndex(); buffered {
-			playing, started := st.sched.Playing()
-			if !started || min <= playing+st.sched.Offset()+retireHorizonIntervals {
+			if min <= roomLabel+retireHorizonIntervals {
 				continue
 			}
+			// Past the horizon: this audio is not imminent, and retiring
+			// discards it. Count it so the log can say so — silently dropping
+			// a decoded backlog is exactly the kind of thing that should not
+			// have to be inferred later.
+			if max, ok := st.reasm.MaxIndex(); ok {
+				backlog = int(max-min) + 1
+			}
 		}
-		e.retireStreamLocked(key, st)
+		e.retireStreamLocked(key, st, backlog)
 	}
 	// Forget intent for identities with nothing published left, so the map
 	// tracks the room rather than growing for the session's lifetime.
@@ -1258,7 +1269,11 @@ func (e *linkAudioEngine) sweepRetiredLocked(now time.Time) {
 // retireStreamLocked unpublishes one stream: its Link Audio channel leaves the
 // LAN (so every WAIL Receive frees the port it held), its counters fold into
 // the engine's retired totals, and it drops out of e.emit. Caller holds e.mu.
-func (e *linkAudioEngine) retireStreamLocked(key affinity.Key, st *emitStream) {
+// backlog is how many buffered intervals go with it — nonzero only on the
+// horizon path, where the stream still held audio too far ahead to be
+// imminent. The log has to name that, or a discarded decode looks from the
+// outside like the sender simply stopping.
+func (e *linkAudioEngine) retireStreamLocked(key affinity.Key, st *emitStream, backlog int) {
 	for _, sk := range st.sinks {
 		sk.Close()
 	}
@@ -1271,9 +1286,14 @@ func (e *linkAudioEngine) retireStreamLocked(key affinity.Key, st *emitStream) {
 	e.retired.EmitSinkWriteRejected += st.sinkWriteRejected.Load()
 	e.retired.OpusDecodeFailures += st.decodeFailures.Load()
 	delete(e.emit, key)
+	name := affinity.FormatRoomChannelName(st.lastDisplayName, streamLabel(st.lastStreamName, key.Stream))
+	if backlog > 0 {
+		log.Printf("[audio] retired Link Audio channel %q (%s stream %d — sender stopped publishing it; discarded %d buffered interval(s) labeled too far ahead to play)",
+			name, key.Identity, key.Stream, backlog)
+		return
+	}
 	log.Printf("[audio] retired Link Audio channel %q (%s stream %d — sender stopped publishing it)",
-		affinity.FormatRoomChannelName(st.lastDisplayName, streamLabel(st.lastStreamName, key.Stream)),
-		key.Identity, key.Stream)
+		name, key.Identity, key.Stream)
 }
 
 // Health sums the per-channel and per-stream diagnostic counters. Capture-side
@@ -1408,7 +1428,7 @@ func (e *linkAudioEngine) onBoundary(cfg interval.Config, tempo float64, localId
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	e.sweepRetiredLocked(time.Now())
+	e.sweepRetiredLocked(time.Now(), roomLabel)
 	for _, st := range e.emit {
 		release, advanced := st.sched.OnBoundary(roomLabel)
 		if !advanced {

--- a/wail-app/audio_engine_real_test.go
+++ b/wail-app/audio_engine_real_test.go
@@ -349,10 +349,12 @@ func drainPlayout(le *linkAudioEngine) {
 	}
 }
 
-func sweep(le *linkAudioEngine, at time.Time) {
+// sweep runs the retirement pass for the boundary labeled roomLabel, the same
+// way onBoundary does: before any scheduler has advanced for that boundary.
+func sweep(le *linkAudioEngine, at time.Time, roomLabel int64) {
 	le.mu.Lock()
 	defer le.mu.Unlock()
-	le.sweepRetiredLocked(at)
+	le.sweepRetiredLocked(at, roomLabel)
 }
 
 func hasStream(le *linkAudioEngine, identity string, streamID uint16) bool {
@@ -379,7 +381,7 @@ func TestEmitStreamRetiredWhenSenderDropsIt(t *testing.T) {
 
 	// Still buffered: retiring here would cut the tail off the last interval,
 	// which playout is still holding (release runs D boundaries behind).
-	sweep(le, past)
+	sweep(le, past, retireTestInterval+10)
 	if !hasStream(le, "id-A", 1) {
 		t.Fatal("retired a stream that still had audio buffered — that truncates the last interval")
 	}
@@ -387,12 +389,12 @@ func TestEmitStreamRetiredWhenSenderDropsIt(t *testing.T) {
 	drainPlayout(le)
 
 	// Inside the grace, frames could still be in flight.
-	sweep(le, time.Now())
+	sweep(le, time.Now(), retireTestInterval+10)
 	if !hasStream(le, "id-A", 1) {
 		t.Fatal("retired inside the grace period")
 	}
 
-	sweep(le, time.Now().Add(retireGraceDropped+time.Second))
+	sweep(le, time.Now().Add(retireGraceDropped+time.Second), retireTestInterval+10)
 	if hasStream(le, "id-A", 1) {
 		t.Fatal("dropped stream still published after its grace expired")
 	}
@@ -408,7 +410,7 @@ func TestEmitStreamsRetiredWhenSenderDeclaresNone(t *testing.T) {
 	feedRemoteStream(t, le, "id-A", "Alice", "guitar", 0)
 	le.SetPeerStreams("id-A", map[uint16]bool{})
 	drainPlayout(le)
-	sweep(le, time.Now().Add(retireGraceDropped+time.Second))
+	sweep(le, time.Now().Add(retireGraceDropped+time.Second), retireTestInterval+10)
 	if len(le.emit) != 0 {
 		t.Fatalf("expected every stream retired, %d still published", len(le.emit))
 	}
@@ -423,11 +425,11 @@ func TestDepartedPeerKeepsChannelsThroughLongerGrace(t *testing.T) {
 	le.DropPeer("id-A")
 	drainPlayout(le)
 
-	sweep(le, time.Now().Add(retireGraceDropped+time.Second))
+	sweep(le, time.Now().Add(retireGraceDropped+time.Second), retireTestInterval+10)
 	if !hasStream(le, "id-A", 0) {
 		t.Fatal("a departed peer's channel went away on the short grace — a brief reconnect loses routing")
 	}
-	sweep(le, time.Now().Add(retireGracePeerGone+time.Second))
+	sweep(le, time.Now().Add(retireGracePeerGone+time.Second), retireTestInterval+10)
 	if hasStream(le, "id-A", 0) {
 		t.Fatal("departed peer's channel still published after the peer-gone grace")
 	}
@@ -442,7 +444,7 @@ func TestRejoinInsideGraceKeepsTheSameChannel(t *testing.T) {
 	le.DropPeer("id-A")
 	le.SetPeerStreams("id-A", map[uint16]bool{0: true}) // rejoined, still sending stream 0
 	drainPlayout(le)
-	sweep(le, time.Now().Add(24*time.Hour))
+	sweep(le, time.Now().Add(24*time.Hour), retireTestInterval+10)
 
 	st, ok := le.emit[affinity.Key{Identity: "id-A", Stream: 0}]
 	if !ok {
@@ -459,7 +461,7 @@ func TestStreamWithoutDeclaredIntentIsNeverRetired(t *testing.T) {
 	le := newCaptureTestEngine(t)
 	feedRemoteStream(t, le, "id-A", "Alice", "guitar", 0)
 	drainPlayout(le)
-	sweep(le, time.Now().Add(24*time.Hour))
+	sweep(le, time.Now().Add(24*time.Hour), retireTestInterval+10)
 	if !hasStream(le, "id-A", 0) {
 		t.Fatal("retired a stream with no declared intent")
 	}
@@ -478,7 +480,7 @@ func TestRetirementKeepsHealthTotalsMonotonic(t *testing.T) {
 
 	le.SetPeerStreams("id-A", map[uint16]bool{})
 	drainPlayout(le)
-	sweep(le, time.Now().Add(retireGraceDropped+time.Second))
+	sweep(le, time.Now().Add(retireGraceDropped+time.Second), retireTestInterval+10)
 
 	if got := le.Health().EmitFramesMissingAtPlay; got != 7 {
 		t.Fatalf("total dropped to %d after retiring the stream, want 7 retained", got)
@@ -494,7 +496,7 @@ func TestPeerIdKeyedStreamsAreRetirable(t *testing.T) {
 	feedRemoteStream(t, le, "peer-id-P", "", "", 0) // no Hello yet / peer already removed
 	le.DropPeer("peer-id-P")
 	drainPlayout(le)
-	sweep(le, time.Now().Add(retireGracePeerGone+time.Second))
+	sweep(le, time.Now().Add(retireGracePeerGone+time.Second), retireTestInterval+10)
 	if hasStream(le, "peer-id-P", 0) {
 		t.Fatal("a stream published under the peer-id fallback never retires")
 	}
@@ -509,7 +511,7 @@ func TestClearPeerIntentMakesStreamsWantedAgain(t *testing.T) {
 	le.DropPeer("id-A:loopback")
 	le.ClearPeerIntent("id-A:loopback")
 	drainPlayout(le)
-	sweep(le, time.Now().Add(24*time.Hour))
+	sweep(le, time.Now().Add(24*time.Hour), retireTestInterval+10)
 	if !hasStream(le, "id-A:loopback", 0) {
 		t.Fatal("cleared intent still retired the stream")
 	}
@@ -522,14 +524,13 @@ func TestClearPeerIntentMakesStreamsWantedAgain(t *testing.T) {
 func TestFarAheadStragglerDoesNotBlockRetirement(t *testing.T) {
 	le := newCaptureTestEngine(t)
 	feedRemoteStreamAt(t, le, "id-A", "Alice", "guitar", 0, 5000)
-	st := le.emit[affinity.Key{Identity: "id-A", Stream: 0}]
-	if st == nil {
+	if le.emit[affinity.Key{Identity: "id-A", Stream: 0}] == nil {
 		t.Fatal("stream not published")
 	}
-	st.sched.OnBoundary(3) // local playout is way behind the sender's labels
 
+	// Boundary 3: the straggler at 5000 sits far past the horizon (3+2).
 	le.SetPeerStreams("id-A", map[uint16]bool{})
-	sweep(le, time.Now().Add(retireGraceDropped+time.Second))
+	sweep(le, time.Now().Add(retireGraceDropped+time.Second), 3)
 
 	if hasStream(le, "id-A", 0) {
 		t.Fatal("a straggler beyond the playout horizon still blocks retirement")
@@ -542,15 +543,14 @@ func TestFarAheadStragglerDoesNotBlockRetirement(t *testing.T) {
 func TestImminentAudioStillBlocksRetirement(t *testing.T) {
 	le := newCaptureTestEngine(t)
 	feedRemoteStreamAt(t, le, "id-A", "Alice", "guitar", 0, 5)
-	st := le.emit[affinity.Key{Identity: "id-A", Stream: 0}]
-	if st == nil {
+	if le.emit[affinity.Key{Identity: "id-A", Stream: 0}] == nil {
 		t.Fatal("stream not published")
 	}
-	// playing = 3-D = 2, so interval 5 sits exactly on the horizon (D+2).
-	st.sched.OnBoundary(3)
 
+	// Boundary 3: interval 5 sits exactly on the horizon (3+2), the edge that
+	// must still hold the channel open.
 	le.SetPeerStreams("id-A", map[uint16]bool{})
-	sweep(le, time.Now().Add(24*time.Hour))
+	sweep(le, time.Now().Add(24*time.Hour), 3)
 
 	if !hasStream(le, "id-A", 0) {
 		t.Fatal("retired a stream with audio still due to play")


### PR DESCRIPTION
These three commits were reviewed and fixed on the #495 and #496 branches, but both PRs merged before the fixes landed on them, so none of this reached main. Same content, re-landed on current main — no new work, and nothing here has been reviewed less than what it fixes.

Verified absent from main before re-landing (`pop_pending`, `lb_module_stamp`, `CMAKE_CONFIGURE_DEPENDS`, the `backlog` parameter: zero hits).

### 1. The retirement horizon was measured against the wrong boundary (#495)

`sweepRetiredLocked` runs *before* the loop that advances each scheduler, so `Playing()` returned the **previous** boundary's release cursor. The horizon was one interval tighter than intended — and one interval inside the band the emit loop itself treats as normal buffering, so a stream mislabeled by exactly D+2 got retired while the engine's own check considered its buffering fine. The boundary label is now passed in and measured from directly.

That also exposed a test that wasn't testing anything: with no scheduler advanced, the "audio still due must block retirement" regression test was passing through the not-yet-playing branch, which production essentially never takes. It now drives the label and is mutation-checked — simulating the stale-cursor bug fails it.

Retiring past the horizon also discards decoded audio, and the log line said only "sender stopped publishing it", attributing to the sender something we did. It now reports how many buffered intervals went with it.

### 2. The plugins logged from the audio thread (#496)

`slot_drain` wrote its "first pop" line straight to the log, so `process()` did a buffered write plus an `fflush` inside its deadline — against the threading contract stated at the top of that very file. Pre-existing, but #496 made collisions routine by giving the manager thread a much larger share of the same `FILE`. `process()` now hands the details over and the manager writes them. WAIL Send had the identical bug (`first commit` from `lbs_process`), fixed through its existing `on_main_thread`.

Also in that commit: the snapshot signature covered every Link Audio channel on the LAN rather than only room-published ones, so an unrelated app renaming its tracks churned the signature and dumped the table for something this plugin never acts on; `snapshot_sig` survived deactivate, so a deactivate/reactivate with an unchanged channel set reopened the log and recorded nothing; and `file(READ)` on VERSION was not a configure dependency, so a version bump left the stamp reporting the previous release.

### 3. The build stamp read a compile time, not the build (#496)

`__DATE__`/`__TIME__` record when one translation unit was compiled, not when the bundle was linked. Editing `wail_link.cpp` — the file most likely to change while debugging these plugins — produces a changed `.clap` carrying an unchanged stamp, which is the incremental case the stamp exists for.

Replaced with the loaded module's own mtime and path, via `dladdr` / `GetModuleHandleEx`. That cannot go stale, because it reads the file the running code came from:

```
=== recv activated: build 4.0.1 (2026-07-31 19:38:38) host="clap-trap 1.0.0" sr=48000 ===
    loaded from /Users/andrew/git/WAIL/build/plugins/wail-recv.clap/Contents/MacOS/wail-recv
```

Verified both directions: the stamp matches the binary's mtime exactly, and touching `wail_link.cpp` relinks the bundle and moves the stamp with it (19:37:55 → 19:38:38) where the compile-time macro would not have. The path answers the other half — which copy the host actually loaded — which is what made the original problem hard to pin down.

### Testing

- Full `wail-app` suite both build modes (`-count=1`), gofmt, vet
- Plugins 4/4, zero compiler warnings
- VERSION-bump reconfigure verified by hand; module stamp verified against the binary's real mtime

Claude Code: present but not responsible
