### PR TITLE
fix: recover grid alignment after the local Link grid moves

### DIFF
--- a/signaling-server/main.go
+++ b/signaling-server/main.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode"
 
 	"github.com/gorilla/websocket"
 	"golang.org/x/crypto/bcrypt"
@@ -761,6 +762,35 @@ func (h *hub) broadcastAudioBinary(room, peerID string, c *conn, data []byte, lo
 	}
 }
 
+// serverLoggedTarget is the only client log target mirrored into the relay's
+// own log — the grid-alignment diagnostics, which describe faults affecting a
+// whole room rather than one machine.
+const serverLoggedTarget = "align"
+
+// maxServerLoggedMessage caps a mirrored message. Clients may send up to the
+// websocket read limit, and this text reaches the operator's log pipeline.
+const maxServerLoggedMessage = 512
+
+// sanitizeForLog makes an unauthenticated client string safe to write into the
+// relay's log: control characters (newlines above all — they let a client forge
+// whole log lines and assert anything about any room) become spaces, and the
+// result is truncated.
+func sanitizeForLog(s string) string {
+	if len(s) > maxServerLoggedMessage {
+		s = s[:maxServerLoggedMessage] + "…(truncated)"
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if r == '\n' || r == '\r' || r == '\t' || unicode.IsControl(r) {
+			b.WriteByte(' ')
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
 func (h *hub) broadcastLog(room, peerID string, c *conn, msg clientMsg) {
 	if room == "" {
 		return
@@ -769,12 +799,17 @@ func (h *hub) broadcastLog(room, peerID string, c *conn, msg clientMsg) {
 	if r == nil {
 		return
 	}
-	// Warnings and errors also land in the relay's own log. A client-side
-	// fault that hits a whole room (a Link session merge, say) is otherwise
-	// only visible on whichever machine happened to notice it — and only if
-	// someone thinks to collect that machine's log afterwards.
-	if msg.Level == "warn" || msg.Level == "error" {
-		log.Printf("room %s peer %s %s [%s] %s", room, peerID, msg.Level, msg.Target, msg.Message)
+	// A room-wide fault (a Link session merge, say) is otherwise only visible
+	// on whichever machine happened to notice it, and only if someone thinks
+	// to collect that machine's log afterwards — so those land in the relay's
+	// log too. Deliberately narrow: only the "align" target, whose messages
+	// this relay's own code shape knows, and never the general client log
+	// stream. Peers already echo each other's logs, so mirroring everything
+	// would multiply a room's chatter into the operator's log — and every
+	// field here is unauthenticated client input.
+	if msg.Target == serverLoggedTarget && (msg.Level == "warn" || msg.Level == "error") {
+		log.Printf("room %s peer %s %s [%s] %s", room, peerID, msg.Level, msg.Target,
+			sanitizeForLog(msg.Message))
 	}
 	raw, err := json.Marshal(map[string]any{
 		"type": "log", "from": peerID, "level": msg.Level,

--- a/signaling-server/main.go
+++ b/signaling-server/main.go
@@ -769,6 +769,13 @@ func (h *hub) broadcastLog(room, peerID string, c *conn, msg clientMsg) {
 	if r == nil {
 		return
 	}
+	// Warnings and errors also land in the relay's own log. A client-side
+	// fault that hits a whole room (a Link session merge, say) is otherwise
+	// only visible on whichever machine happened to notice it — and only if
+	// someone thinks to collect that machine's log afterwards.
+	if msg.Level == "warn" || msg.Level == "error" {
+		log.Printf("room %s peer %s %s [%s] %s", room, peerID, msg.Level, msg.Target, msg.Message)
+	}
 	raw, err := json.Marshal(map[string]any{
 		"type": "log", "from": peerID, "level": msg.Level,
 		"target": msg.Target, "message": msg.Message, "timestamp_us": msg.TimestampUs,

--- a/wail-app/audio_engine.go
+++ b/wail-app/audio_engine.go
@@ -34,6 +34,11 @@ type AudioEngine interface {
 	// server echo was turned off). The grace is what lets affinity hold a
 	// channel across a reconnect blip.
 	DropPeer(identity string)
+	// TakeGridJump reports (and clears) a local Link grid jump detected since
+	// the last call — a session merge or transport reset moved the beat
+	// timeline out from under us. The session re-arms grid alignment on it;
+	// the slew cannot walk back a jump of whole beats.
+	TakeGridJump() (beats float64, ok bool)
 	// SetRoomAnchor applies a fresh relay interval_anchor: aligns the local→room
 	// interval labeler and adopts the room tempo/config.
 	SetRoomAnchor(currentIndex int64, bpm float64, bars uint32, quantum float64)

--- a/wail-app/audio_engine.go
+++ b/wail-app/audio_engine.go
@@ -116,6 +116,11 @@ const (
 	// snapMatchToleranceMs is the floor on that magnitude agreement, for snaps
 	// small enough that a percentage would be tighter than measurement noise.
 	snapMatchToleranceMs = 50
+	// jumpDetectMaxGapSec bounds the tick spacing the jump detector will judge.
+	// Beyond it the loop stalled (GC, a starved scheduler on a loaded machine)
+	// and the expected-beat arithmetic is guesswork — and a false jump is not
+	// free, it costs an audible re-entry snap.
+	jumpDetectMaxGapSec = 1.0
 	// gridJumpEvidenceWindow is how far back peer/tempo movement still counts
 	// as the explanation. Link's peer discovery and the timeline merge it
 	// triggers are tens of milliseconds apart, so same-tick evidence misses it.

--- a/wail-app/audio_engine.go
+++ b/wail-app/audio_engine.go
@@ -1,5 +1,7 @@
 package main
 
+import "time"
+
 // AudioEngine is WAIL's Link Audio audio path (ADR-0001/0002): capture subscribes
 // to local Link Audio channels and ships them as WAIF over the relay; playback
 // republishes remote streams as Link Audio channels one interval late. It
@@ -35,10 +37,11 @@ type AudioEngine interface {
 	// channel across a reconnect blip.
 	DropPeer(identity string)
 	// TakeGridJump reports (and clears) a local Link grid jump detected since
-	// the last call — a session merge or transport reset moved the beat
-	// timeline out from under us. The session re-arms grid alignment on it;
-	// the slew cannot walk back a jump of whole beats.
-	TakeGridJump() (beats float64, ok bool)
+	// the last call — something moved the beat timeline out from under us.
+	// The session re-arms grid alignment on it (the slew cannot walk back a
+	// jump of whole beats) and reports it to the room. Jumps WAIL caused
+	// itself are attributed and withheld rather than reported.
+	TakeGridJump() (GridJump, bool)
 	// SetRoomAnchor applies a fresh relay interval_anchor: aligns the local→room
 	// interval labeler and adopts the room tempo/config.
 	SetRoomAnchor(currentIndex int64, bpm float64, bars uint32, quantum float64)
@@ -89,6 +92,25 @@ type AudioEngine interface {
 	// diffs snapshots to surface them in the log panel and Network tab.
 	Health() EngineHealth
 }
+
+// GridJump is a detected discontinuity in the local Link beat timeline,
+// with what the engine could attribute it to. The cause is the point: a jump
+// is only actionable if you can tell a peer joining from a tempo change from
+// something WAIL did to itself.
+type GridJump struct {
+	Beats      float64 // signed jump, in beats
+	Ms         float64 // the same jump in milliseconds at the room tempo
+	Intervals  int64   // ≈ how many interval boundaries that is
+	Peers      uint64  // LAN Link peer count when it happened
+	Cause      string  // short attribution, for the headline
+	Detail     string  // the evidence behind it
+	SelfCaused bool    // WAIL moved its own grid (an entry snap) — not a fault
+}
+
+// gridSnapAttributionWindow is how recently our own snap must have run for a
+// detected jump to be credited to it. Comfortably longer than the poll
+// interval, far shorter than the gap between real merges.
+const gridSnapAttributionWindow = 2 * time.Second
 
 // EngineHealth is a snapshot of cumulative audio-path diagnostics.
 type EngineHealth struct {

--- a/wail-app/audio_engine.go
+++ b/wail-app/audio_engine.go
@@ -107,10 +107,30 @@ type GridJump struct {
 	SelfCaused bool    // WAIL moved its own grid (an entry snap) — not a fault
 }
 
-// gridSnapAttributionWindow is how recently our own snap must have run for a
-// detected jump to be credited to it. Comfortably longer than the poll
-// interval, far shorter than the gap between real merges.
-const gridSnapAttributionWindow = 2 * time.Second
+const (
+	// gridSnapAttributionWindow is how recently our own snap must have run for
+	// a detected jump to be credited to it. Recency is necessary but never
+	// sufficient — see matchesOwnSnap, which also requires the magnitudes to
+	// agree, so one snap cannot blanket-absorb an unrelated jump.
+	gridSnapAttributionWindow = 2 * time.Second
+	// snapMatchToleranceMs is the floor on that magnitude agreement, for snaps
+	// small enough that a percentage would be tighter than measurement noise.
+	snapMatchToleranceMs = 50
+	// gridJumpEvidenceWindow is how far back peer/tempo movement still counts
+	// as the explanation. Link's peer discovery and the timeline merge it
+	// triggers are tens of milliseconds apart, so same-tick evidence misses it.
+	gridJumpEvidenceWindow = 3 * time.Second
+)
+
+// jumpEvidence is when the attributable inputs last moved, carried across
+// ticks by the emit loop so a jump can be explained by something that happened
+// slightly before it.
+type jumpEvidence struct {
+	peersChangedAt time.Time
+	peersFrom      uint64
+	tempoChangedAt time.Time
+	tempoFrom      float64
+}
 
 // EngineHealth is a snapshot of cumulative audio-path diagnostics.
 type EngineHealth struct {

--- a/wail-app/audio_engine_real.go
+++ b/wail-app/audio_engine_real.go
@@ -1304,6 +1304,19 @@ func (e *linkAudioEngine) TakeGridJump() (GridJump, bool) {
 	return *j, true
 }
 
+// isGridJump reports whether the beat clock moved by more than elapsed time
+// can explain. bpm must be the tempo the beat is actually advancing at — the
+// session's, not the room's, which differ whenever a peer holds the session
+// elsewhere. A tick spaced further apart than jumpDetectMaxGapSec is not
+// judged at all: the loop stalled, so the expectation is guesswork, and a
+// false positive costs an audible re-entry snap.
+func isGridJump(deltaBeats, elapsedSec, bpm float64) bool {
+	if elapsedSec <= 0 || elapsedSec >= jumpDetectMaxGapSec || bpm <= 0 {
+		return false
+	}
+	return math.Abs(deltaBeats-elapsedSec*bpm/60.0) > 0.5
+}
+
 // noteGridJump hands a jump to the session — unless we caused it ourselves.
 // Our own snap moves the grid on purpose: re-entering conformance over it
 // would re-measure a grid we just aligned, and reporting it would send the
@@ -1472,12 +1485,23 @@ func (e *linkAudioEngine) emitLoop() {
 			// session merge/transport reset — which silently invalidates the
 			// labeler offset until the next anchor (the stable-multi-interval-
 			// delay failure mode seen in the field).
-			if haveLastBeat {
-				expected := (float64(clockMicros)/1e6 - lastBeatAt) * tempo / 60.0
-				if d := localBeat - lastBeat; math.Abs(d-expected) > 0.5 {
-					jump := e.classifyGridJump(d, tempo, sessionBPM, peers, ev, bpi, time.Now())
+			// Expected against the SESSION tempo, which is what the beat
+			// actually advances at — the room tempo can differ while a peer
+			// holds the session elsewhere, and then any delayed tick reads as
+			// a jump. A stalled tick is skipped outright rather than measured:
+			// after a GC pause or a starved scheduler on a loaded DAW machine
+			// the expectation is not trustworthy, and a false jump costs an
+			// audible re-entry snap.
+			elapsed := float64(clockMicros)/1e6 - lastBeatAt
+			beatBPM := sessionBPM
+			if beatBPM <= 0 {
+				beatBPM = tempo
+			}
+			if d := localBeat - lastBeat; haveLastBeat && isGridJump(d, elapsed, beatBPM) {
+				{
+					jump := e.classifyGridJump(d, beatBPM, sessionBPM, peers, ev, bpi, time.Now())
 					log.Printf("[audio] WARN: local Link beat jumped %+.2f beats (%+.0f ms, expected %+.2f from elapsed time) — cause: %s; %s",
-						jump.Beats, jump.Ms, expected, jump.Cause, jump.Detail)
+						jump.Beats, jump.Ms, elapsed*beatBPM/60.0, jump.Cause, jump.Detail)
 					// Our own snap moves the grid on purpose. Re-entering
 					// conformance over it would re-measure a grid we just
 					// aligned, and reporting it as a jump would send everyone

--- a/wail-app/audio_engine_real.go
+++ b/wail-app/audio_engine_real.go
@@ -1304,38 +1304,67 @@ func (e *linkAudioEngine) TakeGridJump() (GridJump, bool) {
 	return *j, true
 }
 
+// noteGridJump hands a jump to the session — unless we caused it ourselves.
+// Our own snap moves the grid on purpose: re-entering conformance over it
+// would re-measure a grid we just aligned, and reporting it would send the
+// room hunting a merge that never happened.
+func (e *linkAudioEngine) noteGridJump(j GridJump) {
+	if j.SelfCaused {
+		return
+	}
+	e.gridJump.Store(&j)
+}
+
 // classifyGridJump attributes a beat discontinuity to whatever evidence the
 // tick carries. Order matters: our own snap first (we know we did it), then a
 // changed peer set (a session merge re-phases the timeline), then a tempo
 // move. Anything left is reported as unattributed rather than guessed at.
-func (e *linkAudioEngine) classifyGridJump(beats, roomBPM, sessionBPM, lastSessionBPM float64, peers, lastPeers uint64, bpi float64) GridJump {
+func (e *linkAudioEngine) classifyGridJump(beats, roomBPM, sessionBPM float64, peers uint64, ev jumpEvidence, bpi float64, now time.Time) GridJump {
 	ms := 0.0
 	if roomBPM > 0 {
 		ms = beats * 60_000 / roomBPM
 	}
 	j := GridJump{Beats: beats, Ms: ms, Intervals: int64(math.Round(beats / bpi)), Peers: peers}
 
-	snapAge := time.Since(time.Unix(0, e.lastSnapAtNs.Load()))
 	switch {
-	case e.lastSnapAtNs.Load() != 0 && snapAge < gridSnapAttributionWindow:
+	case e.matchesOwnSnap(ms, now):
 		j.SelfCaused = true
 		j.Cause = "our own grid snap"
-		j.Detail = fmt.Sprintf("entry conformance snapped %+.0f ms %s ago; peers=%d tempo=%.2f BPM",
-			float64(e.lastSnapDeltaUs.Load())/1000, snapAge.Round(time.Millisecond), peers, sessionBPM)
-	case peers != lastPeers:
+		j.Detail = fmt.Sprintf("entry conformance snapped %+.0f ms, which is this jump; peers=%d tempo=%.2f BPM",
+			float64(e.lastSnapDeltaUs.Load())/1000, peers, sessionBPM)
+	case !ev.peersChangedAt.IsZero() && now.Sub(ev.peersChangedAt) < gridJumpEvidenceWindow:
 		j.Cause = "Link session merge"
-		j.Detail = fmt.Sprintf("LAN peer count %d→%d — a joining peer re-phased the shared timeline; tempo=%.2f BPM",
-			lastPeers, peers, sessionBPM)
-	case math.Abs(sessionBPM-lastSessionBPM) > 0.01:
+		j.Detail = fmt.Sprintf("LAN peer count %d→%d, %s before the jump — a joining peer re-phased the shared timeline; tempo=%.2f BPM",
+			ev.peersFrom, peers, now.Sub(ev.peersChangedAt).Round(time.Millisecond), sessionBPM)
+	case !ev.tempoChangedAt.IsZero() && now.Sub(ev.tempoChangedAt) < gridJumpEvidenceWindow:
 		j.Cause = "session tempo change"
-		j.Detail = fmt.Sprintf("session tempo %.2f→%.2f BPM (room %.2f); peers=%d",
-			lastSessionBPM, sessionBPM, roomBPM, peers)
+		j.Detail = fmt.Sprintf("session tempo %.2f→%.2f BPM, %s before the jump (room %.2f); peers=%d",
+			ev.tempoFrom, sessionBPM, now.Sub(ev.tempoChangedAt).Round(time.Millisecond), roomBPM, peers)
 	default:
 		j.Cause = "unattributed"
-		j.Detail = fmt.Sprintf("no peer or tempo change this tick (peers=%d, tempo=%.2f BPM) — a transport reset or an external ForceBeatAtTime",
-			peers, sessionBPM)
+		j.Detail = fmt.Sprintf("no peer or tempo change in the preceding %s (peers=%d, tempo=%.2f BPM) — a transport reset or an external ForceBeatAtTime",
+			gridJumpEvidenceWindow, peers, sessionBPM)
 	}
 	return j
+}
+
+// matchesOwnSnap reports whether a jump is the grid snap we just performed —
+// recent AND of the same magnitude. Recency alone is not evidence: a snap
+// smaller than the detector's own 0.5-beat threshold produces no jump at all,
+// yet would blanket-absorb a real merge arriving inside the window, withholding
+// it so nothing ever re-aligns. The record is consumed, so one snap can explain
+// at most one jump.
+func (e *linkAudioEngine) matchesOwnSnap(ms float64, now time.Time) bool {
+	at := e.lastSnapAtNs.Load()
+	if at == 0 || now.Sub(time.Unix(0, at)) >= gridSnapAttributionWindow {
+		return false
+	}
+	snapMs := math.Abs(float64(e.lastSnapDeltaUs.Load()) / 1000)
+	if math.Abs(snapMs-math.Abs(ms)) > math.Max(snapMatchToleranceMs, 0.2*snapMs) {
+		return false
+	}
+	e.lastSnapAtNs.Store(0)
+	return true
 }
 
 // Health sums the per-channel and per-stream diagnostic counters. Capture-side
@@ -1408,6 +1437,7 @@ func (e *linkAudioEngine) emitLoop() {
 	haveLastBeat := false
 	var lastPeers uint64
 	var lastSessionBPM float64
+	var ev jumpEvidence
 
 	for {
 		select {
@@ -1445,19 +1475,27 @@ func (e *linkAudioEngine) emitLoop() {
 			if haveLastBeat {
 				expected := (float64(clockMicros)/1e6 - lastBeatAt) * tempo / 60.0
 				if d := localBeat - lastBeat; math.Abs(d-expected) > 0.5 {
-					jump := e.classifyGridJump(d, tempo, sessionBPM, lastSessionBPM, peers, lastPeers, bpi)
+					jump := e.classifyGridJump(d, tempo, sessionBPM, peers, ev, bpi, time.Now())
 					log.Printf("[audio] WARN: local Link beat jumped %+.2f beats (%+.0f ms, expected %+.2f from elapsed time) — cause: %s; %s",
 						jump.Beats, jump.Ms, expected, jump.Cause, jump.Detail)
 					// Our own snap moves the grid on purpose. Re-entering
 					// conformance over it would re-measure a grid we just
 					// aligned, and reporting it as a jump would send everyone
 					// hunting a merge that never happened.
-					if !jump.SelfCaused {
-						e.gridJump.Store(&jump)
-					}
+					e.noteGridJump(jump)
 				}
 			}
 			lastBeat, lastBeatAt, haveLastBeat = localBeat, float64(clockMicros)/1e6, true
+			// Remember *when* the evidence last moved, not just the previous
+			// tick's values: peer discovery and the timeline merge it causes
+			// are tens of milliseconds apart, so comparing across one tick
+			// reports the merge it exists to name as "unattributed".
+			if haveLastBeat && peers != lastPeers {
+				ev.peersChangedAt, ev.peersFrom = time.Now(), lastPeers
+			}
+			if haveLastBeat && math.Abs(sessionBPM-lastSessionBPM) > 0.01 {
+				ev.tempoChangedAt, ev.tempoFrom = time.Now(), lastSessionBPM
+			}
 			lastPeers, lastSessionBPM = peers, sessionBPM
 
 			if labeled && (!haveLast || localIdx > lastLocalIdx) {

--- a/wail-app/audio_engine_real.go
+++ b/wail-app/audio_engine_real.go
@@ -150,12 +150,17 @@ type linkAudioEngine struct {
 	metronome   *metronomeStream
 	metronomeOn atomic.Bool
 
-	// Local-grid jump handoff: the emit loop detects the beat discontinuity,
-	// the session goroutine consumes it (TakeGridJump) and re-arms grid
-	// alignment. Two atomics rather than a lock — the magnitude is only for
-	// the log, so reading it a tick stale would be harmless.
-	gridJumpBeats   atomic.Uint64 // math.Float64bits of the jump, in beats
-	gridJumpPending atomic.Bool
+	// Local-grid jump handoff: the emit loop detects the beat discontinuity
+	// and attributes it; the session goroutine consumes it (TakeGridJump),
+	// re-arms grid alignment, and reports it to the room.
+	gridJump atomic.Pointer[GridJump]
+
+	// Our own entry snap moves the grid deliberately, which trips the same
+	// detector. Recording it is what separates "we did this" from "something
+	// out there did this" — the difference between a wasted re-alignment
+	// cycle and a real one.
+	lastSnapAtNs    atomic.Int64
+	lastSnapDeltaUs atomic.Int64
 
 	// curRoomIdx is the room index of the local interval currently in progress
 	// (emit loop publishes, HandleRemoteAudio reads) for label-offset
@@ -514,6 +519,10 @@ func (e *linkAudioEngine) RoomIndex(localIndex int64) (int64, bool) {
 // frames skip silently, never counting as underruns (the join-time ~500k
 // "underrun frames" were exactly this setup event misattributed as loss).
 func (e *linkAudioEngine) OnGridSnap(deltaUs int64) {
+	// Recorded before the early return: a backward snap moves the grid too,
+	// so it must still be attributable when the detector sees it.
+	e.lastSnapAtNs.Store(time.Now().UnixNano())
+	e.lastSnapDeltaUs.Store(deltaUs)
 	if deltaUs <= 0 {
 		return // backward jump: the playhead pauses; nothing to skip
 	}
@@ -1287,11 +1296,46 @@ func (e *linkAudioEngine) retireStreamLocked(key affinity.Key, st *emitStream) {
 // clearing it. The session polls this rather than the engine calling into the
 // steerer directly: the detector runs on the emit loop, and alignment state
 // belongs to the session goroutine.
-func (e *linkAudioEngine) TakeGridJump() (beats float64, ok bool) {
-	if !e.gridJumpPending.Swap(false) {
-		return 0, false
+func (e *linkAudioEngine) TakeGridJump() (GridJump, bool) {
+	j := e.gridJump.Swap(nil)
+	if j == nil {
+		return GridJump{}, false
 	}
-	return math.Float64frombits(e.gridJumpBeats.Load()), true
+	return *j, true
+}
+
+// classifyGridJump attributes a beat discontinuity to whatever evidence the
+// tick carries. Order matters: our own snap first (we know we did it), then a
+// changed peer set (a session merge re-phases the timeline), then a tempo
+// move. Anything left is reported as unattributed rather than guessed at.
+func (e *linkAudioEngine) classifyGridJump(beats, roomBPM, sessionBPM, lastSessionBPM float64, peers, lastPeers uint64, bpi float64) GridJump {
+	ms := 0.0
+	if roomBPM > 0 {
+		ms = beats * 60_000 / roomBPM
+	}
+	j := GridJump{Beats: beats, Ms: ms, Intervals: int64(math.Round(beats / bpi)), Peers: peers}
+
+	snapAge := time.Since(time.Unix(0, e.lastSnapAtNs.Load()))
+	switch {
+	case e.lastSnapAtNs.Load() != 0 && snapAge < gridSnapAttributionWindow:
+		j.SelfCaused = true
+		j.Cause = "our own grid snap"
+		j.Detail = fmt.Sprintf("entry conformance snapped %+.0f ms %s ago; peers=%d tempo=%.2f BPM",
+			float64(e.lastSnapDeltaUs.Load())/1000, snapAge.Round(time.Millisecond), peers, sessionBPM)
+	case peers != lastPeers:
+		j.Cause = "Link session merge"
+		j.Detail = fmt.Sprintf("LAN peer count %d→%d — a joining peer re-phased the shared timeline; tempo=%.2f BPM",
+			lastPeers, peers, sessionBPM)
+	case math.Abs(sessionBPM-lastSessionBPM) > 0.01:
+		j.Cause = "session tempo change"
+		j.Detail = fmt.Sprintf("session tempo %.2f→%.2f BPM (room %.2f); peers=%d",
+			lastSessionBPM, sessionBPM, roomBPM, peers)
+	default:
+		j.Cause = "unattributed"
+		j.Detail = fmt.Sprintf("no peer or tempo change this tick (peers=%d, tempo=%.2f BPM) — a transport reset or an external ForceBeatAtTime",
+			peers, sessionBPM)
+	}
+	return j
 }
 
 // Health sums the per-channel and per-stream diagnostic counters. Capture-side
@@ -1362,6 +1406,8 @@ func (e *linkAudioEngine) emitLoop() {
 	haveLast := false
 	var lastBeat, lastBeatAt float64
 	haveLastBeat := false
+	var lastPeers uint64
+	var lastSessionBPM float64
 
 	for {
 		select {
@@ -1370,6 +1416,10 @@ func (e *linkAudioEngine) emitLoop() {
 		case <-t.C:
 			e.link.CaptureAppSessionState(ss)
 			clockMicros := e.link.ClockMicros()
+			// Attribution evidence, sampled every tick so a jump can be
+			// explained rather than merely reported.
+			peers := e.link.NumPeers()
+			sessionBPM := ss.Tempo()
 
 			e.mu.Lock()
 			cfg := e.cfg
@@ -1395,17 +1445,20 @@ func (e *linkAudioEngine) emitLoop() {
 			if haveLastBeat {
 				expected := (float64(clockMicros)/1e6 - lastBeatAt) * tempo / 60.0
 				if d := localBeat - lastBeat; math.Abs(d-expected) > 0.5 {
-					log.Printf("[audio] WARN: local Link beat jumped %+.2f beats (expected %+.2f from elapsed time) — room-label offset stale until the next anchor (≈%+d intervals of potential shift)",
-						d, expected, int64(math.Round(d/bpi)))
-					// Hand it to the session so grid alignment can re-enter
-					// conformance: a jump of beats is far past what the slew
-					// can walk back, so without a re-snap the grid stays off
-					// for the rest of the session.
-					e.gridJumpBeats.Store(math.Float64bits(d))
-					e.gridJumpPending.Store(true)
+					jump := e.classifyGridJump(d, tempo, sessionBPM, lastSessionBPM, peers, lastPeers, bpi)
+					log.Printf("[audio] WARN: local Link beat jumped %+.2f beats (%+.0f ms, expected %+.2f from elapsed time) — cause: %s; %s",
+						jump.Beats, jump.Ms, expected, jump.Cause, jump.Detail)
+					// Our own snap moves the grid on purpose. Re-entering
+					// conformance over it would re-measure a grid we just
+					// aligned, and reporting it as a jump would send everyone
+					// hunting a merge that never happened.
+					if !jump.SelfCaused {
+						e.gridJump.Store(&jump)
+					}
 				}
 			}
 			lastBeat, lastBeatAt, haveLastBeat = localBeat, float64(clockMicros)/1e6, true
+			lastPeers, lastSessionBPM = peers, sessionBPM
 
 			if labeled && (!haveLast || localIdx > lastLocalIdx) {
 				e.onBoundary(cfg, tempo, localIdx, roomLabel)

--- a/wail-app/audio_engine_real.go
+++ b/wail-app/audio_engine_real.go
@@ -150,6 +150,13 @@ type linkAudioEngine struct {
 	metronome   *metronomeStream
 	metronomeOn atomic.Bool
 
+	// Local-grid jump handoff: the emit loop detects the beat discontinuity,
+	// the session goroutine consumes it (TakeGridJump) and re-arms grid
+	// alignment. Two atomics rather than a lock — the magnitude is only for
+	// the log, so reading it a tick stale would be harmless.
+	gridJumpBeats   atomic.Uint64 // math.Float64bits of the jump, in beats
+	gridJumpPending atomic.Bool
+
 	// curRoomIdx is the room index of the local interval currently in progress
 	// (emit loop publishes, HandleRemoteAudio reads) for label-offset
 	// confirmation. math.MinInt64 until the labeler is aligned.
@@ -1276,6 +1283,17 @@ func (e *linkAudioEngine) retireStreamLocked(key affinity.Key, st *emitStream) {
 		key.Identity, key.Stream)
 }
 
+// TakeGridJump reports a local Link grid jump detected since the last call,
+// clearing it. The session polls this rather than the engine calling into the
+// steerer directly: the detector runs on the emit loop, and alignment state
+// belongs to the session goroutine.
+func (e *linkAudioEngine) TakeGridJump() (beats float64, ok bool) {
+	if !e.gridJumpPending.Swap(false) {
+		return 0, false
+	}
+	return math.Float64frombits(e.gridJumpBeats.Load()), true
+}
+
 // Health sums the per-channel and per-stream diagnostic counters. Capture-side
 // values are drain-goroutine mirrors (atomics); emit-side counters are atomics
 // on their streams; the maps themselves are guarded by e.mu.
@@ -1379,6 +1397,12 @@ func (e *linkAudioEngine) emitLoop() {
 				if d := localBeat - lastBeat; math.Abs(d-expected) > 0.5 {
 					log.Printf("[audio] WARN: local Link beat jumped %+.2f beats (expected %+.2f from elapsed time) — room-label offset stale until the next anchor (≈%+d intervals of potential shift)",
 						d, expected, int64(math.Round(d/bpi)))
+					// Hand it to the session so grid alignment can re-enter
+					// conformance: a jump of beats is far past what the slew
+					// can walk back, so without a re-snap the grid stays off
+					// for the rest of the session.
+					e.gridJumpBeats.Store(math.Float64bits(d))
+					e.gridJumpPending.Store(true)
 				}
 			}
 			lastBeat, lastBeatAt, haveLastBeat = localBeat, float64(clockMicros)/1e6, true

--- a/wail-app/audio_engine_real_test.go
+++ b/wail-app/audio_engine_real_test.go
@@ -569,7 +569,9 @@ func TestGridJumpAttributesOurOwnSnap(t *testing.T) {
 	le := newCaptureTestEngine(t)
 	le.OnGridSnap(2_600_000) // entry conformance just snapped +2.6s
 
-	j := le.classifyGridJump(5.22, 120, 120, 120, 3, 3, 16)
+	now := time.Now()
+	// 5.22 beats at 120 BPM is 2610ms — the snap we just made.
+	j := le.classifyGridJump(5.22, 120, 120, 3, jumpEvidence{}, 16, now)
 
 	if !j.SelfCaused {
 		t.Fatalf("snap not recognised as self-caused: %+v", j)
@@ -577,18 +579,64 @@ func TestGridJumpAttributesOurOwnSnap(t *testing.T) {
 	if j.Cause != "our own grid snap" {
 		t.Fatalf("cause = %q", j.Cause)
 	}
-	// Self-caused jumps must never reach the session: no re-entry, no report.
-	le.gridJump.Store(nil)
+	// Consumed: one snap explains one jump, so a second jump in the same
+	// window is not silently absorbed by it.
+	j2 := le.classifyGridJump(5.22, 120, 120, 3, jumpEvidence{}, 16, now)
+	if j2.SelfCaused {
+		t.Fatal("one snap absorbed two jumps — a real one could vanish behind it")
+	}
+}
+
+// Recency alone must not credit a jump to our snap. A snap below the
+// detector's own threshold produces no jump at all, so crediting anything that
+// merely follows it would swallow a real merge and leave the grid unaligned
+// with nothing reported and nothing re-armed.
+func TestGridJumpDoesNotCreditAMismatchedSnap(t *testing.T) {
+	le := newCaptureTestEngine(t)
+	le.OnGridSnap(60_000) // a 60ms snap: far too small to have caused a 2.6s jump
+
+	j := le.classifyGridJump(5.22, 120, 120, 3, jumpEvidence{}, 16, time.Now())
+
+	if j.SelfCaused {
+		t.Fatalf("a 60ms snap was credited with a 2610ms jump: %+v", j)
+	}
+	if j.Cause != "unattributed" {
+		t.Fatalf("cause = %q, want \"unattributed\"", j.Cause)
+	}
+}
+
+// The emit loop must withhold self-caused jumps from the session — the actual
+// guard, not just the classification behind it.
+func TestSelfCausedJumpIsWithheldFromTheSession(t *testing.T) {
+	le := newCaptureTestEngine(t)
+
+	le.noteGridJump(GridJump{Beats: 5.22, Cause: "our own grid snap", SelfCaused: true})
 	if _, ok := le.TakeGridJump(); ok {
 		t.Fatal("a self-caused jump was handed to the session")
+	}
+
+	le.noteGridJump(GridJump{Beats: 5.22, Cause: "Link session merge"})
+	got, ok := le.TakeGridJump()
+	if !ok {
+		t.Fatal("a real jump was not handed to the session")
+	}
+	if got.Cause != "Link session merge" {
+		t.Fatalf("cause = %q", got.Cause)
+	}
+	if _, ok := le.TakeGridJump(); ok {
+		t.Fatal("the jump was delivered twice")
 	}
 }
 
 func TestGridJumpAttributesPeerAndTempoChanges(t *testing.T) {
 	le := newCaptureTestEngine(t)
 
-	// A peer joining re-phases the shared timeline.
-	j := le.classifyGridJump(5.22, 120, 120, 120, 4, 3, 16)
+	now := time.Now()
+
+	// A peer joined a moment before the jump — discovery and the timeline
+	// merge it causes are tens of ms apart, so the evidence must still count.
+	ev := jumpEvidence{peersChangedAt: now.Add(-200 * time.Millisecond), peersFrom: 3}
+	j := le.classifyGridJump(5.22, 120, 120, 4, ev, 16, now)
 	if j.Cause != "Link session merge" {
 		t.Fatalf("peer change cause = %q, want \"Link session merge\"", j.Cause)
 	}
@@ -599,20 +647,27 @@ func TestGridJumpAttributesPeerAndTempoChanges(t *testing.T) {
 		t.Fatalf("peers = %d, want 4", j.Peers)
 	}
 
+	// Evidence older than the window is not an explanation.
+	stale := jumpEvidence{peersChangedAt: now.Add(-time.Hour), peersFrom: 3}
+	if j := le.classifyGridJump(5.22, 120, 120, 4, stale, 16, now); j.Cause != "unattributed" {
+		t.Fatalf("hour-old peer change still credited: %q", j.Cause)
+	}
+
 	// Tempo moved, peer set steady.
-	j = le.classifyGridJump(2.0, 120, 124, 120, 3, 3, 16)
+	evT := jumpEvidence{tempoChangedAt: now.Add(-100 * time.Millisecond), tempoFrom: 120}
+	j = le.classifyGridJump(2.0, 120, 124, 3, evT, 16, now)
 	if j.Cause != "session tempo change" {
 		t.Fatalf("tempo change cause = %q", j.Cause)
 	}
 
 	// Nothing observable — say so rather than guessing.
-	j = le.classifyGridJump(2.0, 120, 120, 120, 3, 3, 16)
+	j = le.classifyGridJump(2.0, 120, 120, 3, jumpEvidence{}, 16, now)
 	if j.Cause != "unattributed" {
 		t.Fatalf("cause = %q, want \"unattributed\"", j.Cause)
 	}
 
 	// The magnitude conversions carry the units the log quotes.
-	j = le.classifyGridJump(4.0, 120, 120, 120, 3, 3, 16)
+	j = le.classifyGridJump(4.0, 120, 120, 3, jumpEvidence{}, 16, now)
 	if math.Abs(j.Ms-2000) > 1 {
 		t.Fatalf("4 beats at 120 BPM = %.0f ms, want 2000", j.Ms)
 	}

--- a/wail-app/audio_engine_real_test.go
+++ b/wail-app/audio_engine_real_test.go
@@ -672,3 +672,42 @@ func TestGridJumpAttributesPeerAndTempoChanges(t *testing.T) {
 		t.Fatalf("4 beats at 120 BPM = %.0f ms, want 2000", j.Ms)
 	}
 }
+
+// The jump detector compares the beat clock against elapsed time. Two ways
+// that goes wrong on a peer whose machine stalls or whose session tempo has
+// been pulled away by another peer — both of which cost an audible re-entry
+// snap when they produce a false positive.
+func TestGridJumpDetectionIsRobustToStallsAndTempoMismatch(t *testing.T) {
+	const tick = 0.005 // the emit loop's spacing
+
+	// Normal advance at the session tempo: not a jump.
+	if isGridJump(tick*120/60, tick, 120) {
+		t.Fatal("a normal tick read as a jump")
+	}
+
+	// A real discontinuity: 5.22 beats out of nowhere.
+	if !isGridJump(5.22, tick, 120) {
+		t.Fatal("a genuine 5.22-beat jump was missed")
+	}
+
+	// A stalled loop (GC, a starved scheduler): the beat advanced honestly
+	// over 5 seconds, but the expectation across such a gap is guesswork, so
+	// the detector must decline to judge rather than manufacture a jump.
+	if isGridJump(5*120/60, 5, 120) {
+		t.Fatal("a stalled tick was judged")
+	}
+
+	// The case the room tempo got wrong: the beat advances at the SESSION
+	// tempo, so judging it against the room's manufactures a jump out of an
+	// honest advance. It takes a wide tempo gap to exceed 0.5 beats inside the
+	// window the stall guard allows — a peer whose DAW sits at 160 while the
+	// room is on 120 does it in under a second.
+	gap := 0.9
+	beatsAt160 := gap * 160 / 60
+	if isGridJump(beatsAt160, gap, 160) {
+		t.Fatal("honest advance at the session tempo read as a jump")
+	}
+	if !isGridJump(beatsAt160, gap, 120) {
+		t.Fatal("test premise wrong: judging against the room tempo should have misfired here")
+	}
+}

--- a/wail-app/audio_engine_real_test.go
+++ b/wail-app/audio_engine_real_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"encoding/hex"
+	"math"
 	"testing"
 	"time"
 
@@ -554,5 +555,65 @@ func TestImminentAudioStillBlocksRetirement(t *testing.T) {
 
 	if !hasStream(le, "id-A", 0) {
 		t.Fatal("retired a stream with audio still due to play")
+	}
+}
+
+// --- grid-jump attribution ---
+
+// A jump is only actionable if you can tell what moved the grid. The most
+// important case to get right is our own entry snap: it moves the grid on
+// purpose and trips the same detector, so reporting it would send someone
+// hunting a session merge that never happened — and acting on it would
+// re-align a grid we just aligned.
+func TestGridJumpAttributesOurOwnSnap(t *testing.T) {
+	le := newCaptureTestEngine(t)
+	le.OnGridSnap(2_600_000) // entry conformance just snapped +2.6s
+
+	j := le.classifyGridJump(5.22, 120, 120, 120, 3, 3, 16)
+
+	if !j.SelfCaused {
+		t.Fatalf("snap not recognised as self-caused: %+v", j)
+	}
+	if j.Cause != "our own grid snap" {
+		t.Fatalf("cause = %q", j.Cause)
+	}
+	// Self-caused jumps must never reach the session: no re-entry, no report.
+	le.gridJump.Store(nil)
+	if _, ok := le.TakeGridJump(); ok {
+		t.Fatal("a self-caused jump was handed to the session")
+	}
+}
+
+func TestGridJumpAttributesPeerAndTempoChanges(t *testing.T) {
+	le := newCaptureTestEngine(t)
+
+	// A peer joining re-phases the shared timeline.
+	j := le.classifyGridJump(5.22, 120, 120, 120, 4, 3, 16)
+	if j.Cause != "Link session merge" {
+		t.Fatalf("peer change cause = %q, want \"Link session merge\"", j.Cause)
+	}
+	if j.SelfCaused {
+		t.Fatal("a merge is not self-caused")
+	}
+	if j.Peers != 4 {
+		t.Fatalf("peers = %d, want 4", j.Peers)
+	}
+
+	// Tempo moved, peer set steady.
+	j = le.classifyGridJump(2.0, 120, 124, 120, 3, 3, 16)
+	if j.Cause != "session tempo change" {
+		t.Fatalf("tempo change cause = %q", j.Cause)
+	}
+
+	// Nothing observable — say so rather than guessing.
+	j = le.classifyGridJump(2.0, 120, 120, 120, 3, 3, 16)
+	if j.Cause != "unattributed" {
+		t.Fatalf("cause = %q, want \"unattributed\"", j.Cause)
+	}
+
+	// The magnitude conversions carry the units the log quotes.
+	j = le.classifyGridJump(4.0, 120, 120, 120, 3, 3, 16)
+	if math.Abs(j.Ms-2000) > 1 {
+		t.Fatalf("4 beats at 120 BPM = %.0f ms, want 2000", j.Ms)
 	}
 }

--- a/wail-app/audio_engine_stub.go
+++ b/wail-app/audio_engine_stub.go
@@ -15,6 +15,7 @@ func (s *stubAudioEngine) Start() error                                         
 func (s *stubAudioEngine) Stop()                                                 {}
 func (s *stubAudioEngine) HandleRemoteAudio(_, _, _ string, _ []byte)            {}
 func (s *stubAudioEngine) SetPeerStreams(_ string, _ map[uint16]bool)            {}
+func (s *stubAudioEngine) TakeGridJump() (float64, bool)                         { return 0, false }
 func (s *stubAudioEngine) DropPeer(_ string)                                     {}
 func (s *stubAudioEngine) ClearPeerIntent(_ string)                              {}
 func (s *stubAudioEngine) SetRoomAnchor(_ int64, _ float64, _ uint32, _ float64) {}

--- a/wail-app/audio_engine_stub.go
+++ b/wail-app/audio_engine_stub.go
@@ -15,7 +15,7 @@ func (s *stubAudioEngine) Start() error                                         
 func (s *stubAudioEngine) Stop()                                                 {}
 func (s *stubAudioEngine) HandleRemoteAudio(_, _, _ string, _ []byte)            {}
 func (s *stubAudioEngine) SetPeerStreams(_ string, _ map[uint16]bool)            {}
-func (s *stubAudioEngine) TakeGridJump() (float64, bool)                         { return 0, false }
+func (s *stubAudioEngine) TakeGridJump() (GridJump, bool)                        { return GridJump{}, false }
 func (s *stubAudioEngine) DropPeer(_ string)                                     {}
 func (s *stubAudioEngine) ClearPeerIntent(_ string)                              {}
 func (s *stubAudioEngine) SetRoomAnchor(_ int64, _ float64, _ uint32, _ float64) {}

--- a/wail-app/internal/align/steerer.go
+++ b/wail-app/internal/align/steerer.go
@@ -22,6 +22,11 @@ const (
 	// snapSettle is the post-entry settling window during which the slew
 	// stays out of the way of the snap's aftershocks.
 	snapSettle = 5 * time.Second
+	// gateWedgeTimeout is how long the same-rate gate may stay shut before the
+	// steerer stops waiting for the tempo to come back and re-enters
+	// conformance. Long enough to sit out an ordinary tempo change and its
+	// re-anchor; short enough that a wedge is a blip, not a lost session.
+	gateWedgeTimeout = 10 * time.Second
 	// tempoGate suppresses the slew after any tempo commit (local user's
 	// hand, remote change, or entry adoption) so WAIL never fights a hand
 	// on the tempo knob. Deliberately longer than the 150ms echo guard.
@@ -80,11 +85,14 @@ type Steerer struct {
 	// audio — the jumped frames must skip silently, never count as underruns.
 	onSnapGrid func(deltaUs int64)
 
-	aligner          *interval.GridAligner
-	enabled          bool
-	entryPending     bool
-	lastSnapAt       time.Time
-	lastTempoAt      time.Time
+	aligner      *interval.GridAligner
+	enabled      bool
+	entryPending bool
+	lastSnapAt   time.Time
+	lastTempoAt  time.Time
+	// gateShutSince is when the same-rate gate last started blocking, zero
+	// while it is open — the wedge timer (see noteGateShut).
+	gateShutSince    time.Time
 	slewTarget       float64 // 0 = sitting at exact room tempo
 	slewDir          int     // sign of the active episode's δ (0 = not slewing)
 	slewPendingDir   int     // sign of the δ being confirmed (0 = none)
@@ -215,17 +223,25 @@ func (s *Steerer) Tick(bpi float64, now time.Time) {
 	// and nudging would fight it (field finding: the slew chased a stale
 	// 120 anchor while the session moved to 122, preventing the settle the
 	// detector hold-down waits for — a live-lock).
+	// Measured before the gate: the gate suppresses *steering*, never
+	// *reporting*. Returning without emitting froze the UI on whatever δ was
+	// current when the state last changed — a reading minutes stale, shown as
+	// if it were live (field: a badge stuck at "drifted 2605ms" for a quarter
+	// of an hour while the grid sat at ~10ms).
+	delta, ok := s.measureDelta(bpi)
+	if !ok {
+		return
+	}
 	baseline := roomBPM
 	if s.slewTarget != 0 {
 		baseline = s.slewTarget
 	}
 	if st := s.link.State(); math.Abs(st.BPM-baseline) > tempoThreshold {
+		s.emitState(delta)
+		s.noteGateShut(now, roomBPM, st.BPM)
 		return
 	}
-	delta, ok := s.measureDelta(bpi)
-	if !ok {
-		return
-	}
+	s.gateShutSince = time.Time{}
 	periodUs := int64(bpi * 60.0 / roomBPM * 1e6)
 	target, active := interval.SlewTempo(roomBPM, delta, periodUs)
 	if s.slewTarget != 0 && !active {
@@ -448,6 +464,55 @@ func (s *Steerer) measureDelta(bpi float64) (int64, bool) {
 }
 
 // emitState reports the bucketed alignment state on change only.
+// noteGateShut escalates a same-rate gate that has stayed shut too long.
+//
+// The gate assumes whoever owns the tempo hands it back shortly. When the
+// session tempo instead settles somewhere else — an external Link peer
+// joining at its own tempo, a session merge — the stale slew target keeps the
+// gate shut, and the gate returns before the settle branch that would clear
+// that target. It cannot unstick itself, and nothing else clears it: the only
+// snap path is entry conformance, armed only on (re)join. Field case: a peer
+// joined at 120 while a slew held 119.94; alignment then did nothing at all
+// for sixteen minutes. Re-entry is the way out — entry conformance adopts the
+// room tempo outright and snaps the grid.
+func (s *Steerer) noteGateShut(now time.Time, roomBPM, sessionBPM float64) {
+	if s.gateShutSince.IsZero() {
+		s.gateShutSince = now
+		return
+	}
+	if now.Sub(s.gateShutSince) < gateWedgeTimeout {
+		return
+	}
+	s.gateShutSince = time.Time{}
+	s.cancelSlew()
+	s.entryPending = true
+	s.logf("[align] same-rate gate shut %s (session %.4f BPM vs room %.4f) — re-running entry conformance",
+		gateWedgeTimeout, sessionBPM, roomBPM)
+}
+
+// OnGridJump re-arms entry conformance after the local Link grid moved out
+// from under us — a session merge or transport reset, which the engine
+// detects as a beat discontinuity. The slew only closes small phase errors at
+// a bounded rate, so a jump of whole beats is not something it can walk back;
+// without a re-snap the grid stays off for the rest of the session.
+func (s *Steerer) OnGridJump(beats float64, now time.Time) {
+	if !s.enabled {
+		return
+	}
+	s.gateShutSince = time.Time{}
+	s.cancelSlew()
+	s.entryPending = true
+	s.logf("[align] local grid jumped %+.2f beats — re-running entry conformance", beats)
+}
+
+// cancelSlew abandons any in-flight slew without restoring a tempo: both
+// callers hand the grid to entry conformance, which commits the room tempo
+// itself. Leaving the target set would re-shut the same-rate gate against it.
+func (s *Steerer) cancelSlew() {
+	s.slewTarget, s.slewDir = 0, 0
+	s.slewPendingDir, s.slewPendingCount = 0, 0
+}
+
 func (s *Steerer) emitState(deltaUs int64) {
 	state := stateName(deltaUs)
 	if state == s.lastState {

--- a/wail-app/internal/align/steerer.go
+++ b/wail-app/internal/align/steerer.go
@@ -47,6 +47,9 @@ const (
 	// error is stale enough to mislead. The UI only shows the figure past
 	// 10 ms, so this is the granularity that reads as "live".
 	emitDeltaUs = 10_000
+	// emitMinInterval bounds same-bucket reports. Without it the step above is
+	// no bound at all for an oscillating δ.
+	emitMinInterval = 3 * time.Second
 )
 
 // State is the slice of Link session state the steerer samples. Beat is
@@ -103,7 +106,8 @@ type Steerer struct {
 	slewPendingDir   int     // sign of the δ being confirmed (0 = none)
 	slewPendingCount int     // consecutive same-direction ticks past the deadband
 	lastState        string
-	lastEmittedUs    int64 // δ at the last emit — see emitState
+	lastEmittedUs    int64     // δ at the last emit — see emitState
+	lastEmitAt       time.Time // when that emit happened (same-bucket rate limit)
 	currentBPM       float64
 	anchorIndex      int64
 	haveRoomAnchor   bool
@@ -211,14 +215,22 @@ func (s *Steerer) SnapshotTempoAdopt(msgBPM float64) bool {
 // Tick for the same-rate gate that keeps the slew from fighting tempo
 // changes in flight.
 func (s *Steerer) Tick(bpi float64, now time.Time) {
+	// Every path that returns before the gate clears the wedge timer: it
+	// measures how long the gate has been *continuously* shut across ticks we
+	// actually evaluated, not wall time since it first shut. Otherwise a
+	// tempo-commit burst, or alignment being switched off for five minutes,
+	// leaves it accruing and the next evaluated tick escalates instantly.
 	if !s.enabled || !s.aligner.Ready() || s.entryPending {
+		s.gateShutSince = time.Time{}
 		return
 	}
 	if !slewAllowed(now, s.lastSnapAt, s.lastTempoAt) {
+		s.gateShutSince = time.Time{}
 		return
 	}
 	roomBPM, ok := s.aligner.RoomBPM()
 	if !ok || roomBPM <= 0 {
+		s.gateShutSince = time.Time{}
 		return
 	}
 	// Same-rate gate: δ is a phase measurement that is only meaningful when
@@ -236,6 +248,7 @@ func (s *Steerer) Tick(bpi float64, now time.Time) {
 	// of an hour while the grid sat at ~10ms).
 	delta, ok := s.measureDelta(bpi)
 	if !ok {
+		s.gateShutSince = time.Time{}
 		return
 	}
 	baseline := roomBPM
@@ -243,7 +256,12 @@ func (s *Steerer) Tick(bpi float64, now time.Time) {
 		baseline = s.slewTarget
 	}
 	if st := s.link.State(); math.Abs(st.BPM-baseline) > tempoThreshold {
-		s.emitState(delta)
+		// Bucket only while the gate is shut. δ is a phase measurement between
+		// grids ticking at different rates, so it sweeps and wraps at ±period/2
+		// — publishing that at tick rate would trade a stale number for a
+		// meaningless one. The bucket still moves if things get materially
+		// worse, and the recovery paths bound how long this can last.
+		s.emitBucket(delta)
 		s.noteGateShut(now, roomBPM, st.BPM)
 		return
 	}
@@ -262,7 +280,7 @@ func (s *Steerer) Tick(bpi float64, now time.Time) {
 			s.slewPendingDir, s.slewPendingCount = 0, 0
 			s.logf("[align] slew settled (δ=%+.1f ms), restored %.1f BPM", float64(delta)/1000, roomBPM)
 		}
-		s.emitState(delta)
+		s.emitState(delta, now)
 		return
 	}
 	if active {
@@ -279,7 +297,7 @@ func (s *Steerer) Tick(bpi float64, now time.Time) {
 			s.slewPendingDir, s.slewPendingCount = dir, 1
 		}
 		if s.slewPendingCount < slewPersistenceTicks {
-			s.emitState(delta)
+			s.emitState(delta, now)
 			return
 		}
 		if target != s.slewTarget {
@@ -291,7 +309,7 @@ func (s *Steerer) Tick(bpi float64, now time.Time) {
 	} else {
 		s.slewPendingDir, s.slewPendingCount = 0, 0
 	}
-	s.emitState(delta)
+	s.emitState(delta, now)
 }
 
 // SetEnabled toggles grid alignment (ADR-0006 debug control). Disabling
@@ -377,7 +395,7 @@ func (s *Steerer) tryEntry(bpi float64, now time.Time) {
 	} else {
 		s.logf("[align] entry: grid already aligned (δ=%+.1f ms)", float64(delta)/1000)
 	}
-	s.emitState(delta)
+	s.emitState(delta, now)
 	// The snap may have shifted the grid past a boundary since SetRoomAnchor
 	// sampled the labeler — re-derive the label by construction.
 	s.applyRoomLabel(bpi)
@@ -482,6 +500,15 @@ func (s *Steerer) measureDelta(bpi float64) (int64, bool) {
 // for sixteen minutes. Re-entry is the way out — entry conformance adopts the
 // room tempo outright and snaps the grid.
 func (s *Steerer) noteGateShut(now time.Time, roomBPM, sessionBPM float64) {
+	// Only a stale slew target is a wedge. With no slew in flight the gate is
+	// shut because something else genuinely owns the tempo, which is the case
+	// the gate exists to respect — a DAW tempo ramp holds it shut for as long
+	// as the ramp lasts, and escalating there would yank the tempo back and
+	// snap the grid, audibly, every gateWedgeTimeout for the whole ramp.
+	if s.slewTarget == 0 {
+		s.gateShutSince = time.Time{}
+		return
+	}
 	if s.gateShutSince.IsZero() {
 		s.gateShutSince = now
 		return
@@ -511,10 +538,22 @@ func (s *Steerer) OnGridJump(beats float64, now time.Time) {
 	s.logf("[align] local grid jumped %+.2f beats — re-running entry conformance", beats)
 }
 
-// cancelSlew abandons any in-flight slew without restoring a tempo: both
-// callers hand the grid to entry conformance, which commits the room tempo
-// itself. Leaving the target set would re-shut the same-rate gate against it.
+// cancelSlew abandons an in-flight slew, putting the tempo back first. The
+// slew works by holding the session away from the room tempo, so clearing the
+// bookkeeping alone strands it there: entry conformance is not guaranteed to
+// commit a tempo (it only adopts past tempoThreshold, and not at all until the
+// aligner is Ready), and SetEnabled's restore keys off the very target we just
+// cleared — leaving the session parked on a slew tempo with nothing tracking it.
 func (s *Steerer) cancelSlew() {
+	if s.slewTarget != 0 {
+		restore := s.currentBPM
+		if roomBPM, ok := s.aligner.RoomBPM(); ok && roomBPM > 0 {
+			restore = roomBPM
+		}
+		if restore > 0 {
+			s.link.SetTempo(restore)
+		}
+	}
 	s.slewTarget, s.slewDir = 0, 0
 	s.slewPendingDir, s.slewPendingCount = 0, 0
 }
@@ -524,13 +563,36 @@ func (s *Steerer) cancelSlew() {
 // the reported error froze at whatever δ was when the state last changed, so a
 // grid recovering from 2.6 s to 60 ms still read "drifted 2605ms" — a number
 // with no relationship to the present.
-func (s *Steerer) emitState(deltaUs int64) {
+func (s *Steerer) emitState(deltaUs int64, now time.Time) {
 	state := stateName(deltaUs)
-	moved := abs64(deltaUs-s.lastEmittedUs) >= emitDeltaUs
-	if state == s.lastState && !moved {
+	if state != s.lastState {
+		s.publish(state, deltaUs, now)
 		return
 	}
-	s.lastState, s.lastEmittedUs = state, deltaUs
+	// Same bucket: report a materially different δ, but not more often than
+	// emitMinInterval. The step alone does not bound anything — the reference
+	// is the last *emitted* δ, so a value alternating by more than the step
+	// (±12ms jitter is squarely the slew's own operating regime) clears it on
+	// every single tick and streams events indefinitely.
+	if abs64(deltaUs-s.lastEmittedUs) < emitDeltaUs {
+		return
+	}
+	if !s.lastEmitAt.IsZero() && now.Sub(s.lastEmitAt) < emitMinInterval {
+		return
+	}
+	s.publish(state, deltaUs, now)
+}
+
+// emitBucket reports a state change only, ignoring δ movement — for ticks
+// where the measurement itself is not trustworthy enough to publish.
+func (s *Steerer) emitBucket(deltaUs int64) {
+	if state := stateName(deltaUs); state != s.lastState {
+		s.publish(state, deltaUs, time.Time{})
+	}
+}
+
+func (s *Steerer) publish(state string, deltaUs int64, now time.Time) {
+	s.lastState, s.lastEmittedUs, s.lastEmitAt = state, deltaUs, now
 	s.emit(state, float64(deltaUs)/1000)
 }
 

--- a/wail-app/internal/align/steerer.go
+++ b/wail-app/internal/align/steerer.go
@@ -108,6 +108,7 @@ type Steerer struct {
 	lastState        string
 	lastEmittedUs    int64     // δ at the last emit — see emitState
 	lastEmitAt       time.Time // when that emit happened (same-bucket rate limit)
+	lastJumpEntryAt  time.Time // last jump-triggered re-entry (snaps are audible)
 	currentBPM       float64
 	anchorIndex      int64
 	haveRoomAnchor   bool
@@ -255,7 +256,7 @@ func (s *Steerer) Tick(bpi float64, now time.Time) {
 	if s.slewTarget != 0 {
 		baseline = s.slewTarget
 	}
-	if st := s.link.State(); math.Abs(st.BPM-baseline) > tempoThreshold {
+	if st := s.link.State(); math.Abs(st.BPM-baseline) > sameRateBand(baseline) {
 		// Bucket only while the gate is shut. δ is a phase measurement between
 		// grids ticking at different rates, so it sweeps and wraps at ±period/2
 		// — publishing that at tick rate would trade a stale number for a
@@ -488,23 +489,33 @@ func (s *Steerer) measureDelta(bpi float64) (int64, bool) {
 }
 
 // emitState reports the bucketed alignment state on change only.
-// noteGateShut escalates a same-rate gate that has stayed shut too long.
+// sameRateBand is how far the session tempo may sit from the slew's baseline
+// before δ stops meaning anything. Proportional, not the flat adoption
+// threshold it used to share: the gate exists to avoid fighting a real tempo
+// move (120→122 is 1.7%), but at 0.01 BPM a peer whose clock wanders by a
+// tenth also tripped it — and then the slew went dormant and phase drifted
+// uncorrected for the rest of the session. At half a percent, δ is still a
+// sound measurement over the tens of seconds a slew episode takes.
+func sameRateBand(baselineBPM float64) float64 {
+	return math.Max(tempoThreshold, 0.005*baselineBPM)
+}
+
+// noteGateShut clears a slew target that has been holding the gate shut
+// against itself.
 //
-// The gate assumes whoever owns the tempo hands it back shortly. When the
-// session tempo instead settles somewhere else — an external Link peer
-// joining at its own tempo, a session merge — the stale slew target keeps the
-// gate shut, and the gate returns before the settle branch that would clear
-// that target. It cannot unstick itself, and nothing else clears it: the only
-// snap path is entry conformance, armed only on (re)join. Field case: a peer
-// joined at 120 while a slew held 119.94; alignment then did nothing at all
-// for sixteen minutes. Re-entry is the way out — entry conformance adopts the
-// room tempo outright and snaps the grid.
+// The gate compares the session tempo against the slew's target while a slew
+// is in flight, and returns before the settle branch that would clear that
+// target — so once something else moves the tempo, the stale target keeps the
+// gate shut and the gate prevents clearing the target. Sixteen minutes of no
+// alignment at all, in the field.
+//
+// Clearing the target is the whole fix: the baseline falls back to the room
+// tempo, and the gate re-evaluates honestly. If it opens, normal steering
+// resumes; if it stays shut, the tempo really has moved and waiting is
+// correct — the room adopts it shortly and the gate opens then. Deliberately
+// no tempo write and no forced re-entry here: both would fight whoever
+// legitimately owns the tempo, and a re-entry snap is audible.
 func (s *Steerer) noteGateShut(now time.Time, roomBPM, sessionBPM float64) {
-	// Only a stale slew target is a wedge. With no slew in flight the gate is
-	// shut because something else genuinely owns the tempo, which is the case
-	// the gate exists to respect — a DAW tempo ramp holds it shut for as long
-	// as the ramp lasts, and escalating there would yank the tempo back and
-	// snap the grid, audibly, every gateWedgeTimeout for the whole ramp.
 	if s.slewTarget == 0 {
 		s.gateShutSince = time.Time{}
 		return
@@ -517,9 +528,11 @@ func (s *Steerer) noteGateShut(now time.Time, roomBPM, sessionBPM float64) {
 		return
 	}
 	s.gateShutSince = time.Time{}
-	s.cancelSlew()
-	s.entryPending = true
-	s.logf("[align] same-rate gate shut %s (session %.4f BPM vs room %.4f) — re-running entry conformance",
+	// No restore: a shut gate is proof the session is not at our slew target,
+	// so there is nothing of ours still in force to put back.
+	s.slewTarget, s.slewDir = 0, 0
+	s.slewPendingDir, s.slewPendingCount = 0, 0
+	s.logf("[align] slew target abandoned after %s of a shut gate (session %.4f BPM vs room %.4f) — re-measuring against the room tempo",
 		gateWedgeTimeout, sessionBPM, roomBPM)
 }
 
@@ -532,6 +545,16 @@ func (s *Steerer) OnGridJump(beats float64, now time.Time) {
 	if !s.enabled {
 		return
 	}
+	// Re-entry snaps the grid, which is audible. Detection is a heuristic over
+	// a sampled beat clock, so one bad reading must not be able to snap the
+	// grid repeatedly on a peer whose machine is stalling — rate limit it to
+	// the settle window entry conformance already observes.
+	if !s.lastJumpEntryAt.IsZero() && now.Sub(s.lastJumpEntryAt) < snapSettle {
+		s.logf("[align] local grid jumped %+.2f beats — ignored, re-entered %s ago",
+			beats, now.Sub(s.lastJumpEntryAt).Round(time.Millisecond))
+		return
+	}
+	s.lastJumpEntryAt = now
 	s.gateShutSince = time.Time{}
 	s.cancelSlew()
 	s.entryPending = true

--- a/wail-app/internal/align/steerer.go
+++ b/wail-app/internal/align/steerer.go
@@ -42,6 +42,11 @@ const (
 	// every two seconds in the field. Settling stays immediate — restoring
 	// the room tempo is always safe.
 	slewPersistenceTicks = 2
+	// emitDeltaUs is how far δ must move inside one state bucket before the
+	// UI is told again. Below it the number is jitter; above it the displayed
+	// error is stale enough to mislead. The UI only shows the figure past
+	// 10 ms, so this is the granularity that reads as "live".
+	emitDeltaUs = 10_000
 )
 
 // State is the slice of Link session state the steerer samples. Beat is
@@ -98,6 +103,7 @@ type Steerer struct {
 	slewPendingDir   int     // sign of the δ being confirmed (0 = none)
 	slewPendingCount int     // consecutive same-direction ticks past the deadband
 	lastState        string
+	lastEmittedUs    int64 // δ at the last emit — see emitState
 	currentBPM       float64
 	anchorIndex      int64
 	haveRoomAnchor   bool
@@ -513,12 +519,18 @@ func (s *Steerer) cancelSlew() {
 	s.slewPendingDir, s.slewPendingCount = 0, 0
 }
 
+// emitState reports alignment to the UI on a bucket change, and also when δ
+// itself has moved materially inside the same bucket. Bucket-only was a trap:
+// the reported error froze at whatever δ was when the state last changed, so a
+// grid recovering from 2.6 s to 60 ms still read "drifted 2605ms" — a number
+// with no relationship to the present.
 func (s *Steerer) emitState(deltaUs int64) {
 	state := stateName(deltaUs)
-	if state == s.lastState {
+	moved := abs64(deltaUs-s.lastEmittedUs) >= emitDeltaUs
+	if state == s.lastState && !moved {
 		return
 	}
-	s.lastState = state
+	s.lastState, s.lastEmittedUs = state, deltaUs
 	s.emit(state, float64(deltaUs)/1000)
 }
 

--- a/wail-app/internal/align/steerer_test.go
+++ b/wail-app/internal/align/steerer_test.go
@@ -965,3 +965,38 @@ func TestGridJumpReRunsEntryConformance(t *testing.T) {
 		t.Fatalf("expected exactly one entry snap after the jump, got %v", f.snaps)
 	}
 }
+
+// Within one bucket the reported δ must track the real one. Emitting only on a
+// bucket change froze the number at whatever δ was when the state last
+// changed, so a grid recovering from 2.6s to 60ms still read 2605ms.
+func TestReportedErrorTracksDeltaInsideAState(t *testing.T) {
+	now := time.Now()
+	s, f, emits := newSteerer(16_600_000) // 2.6s late — "drifted"
+	observe(s, now)
+	now = now.Add(snapSettle + time.Second)
+	f.state.BPM = 130 // gate shut, so nothing steers and δ is ours to script
+	s.Tick(16, now)
+	if lastEmit(emits) != "drifted" {
+		t.Fatalf("expected drifted, got %q", lastEmit(emits))
+	}
+
+	// Still drifted, but much closer than before.
+	f.timeAtBeat = 14_060_000 // 60ms late
+	*emits = nil
+	s.Tick(16, now.Add(time.Second))
+
+	if len(*emits) == 0 {
+		t.Fatal("δ improved from 2.6s to 60ms inside one bucket and nothing was reported")
+	}
+	if errMs := (*emits)[len(*emits)-1].errMs; math.Abs(errMs-60) > 5 {
+		t.Fatalf("reported δ = %.1f ms, want ~60", errMs)
+	}
+
+	// Jitter below the step must not spam the UI.
+	f.timeAtBeat = 14_062_000 // 2ms of movement
+	*emits = nil
+	s.Tick(16, now.Add(2*time.Second))
+	if len(*emits) != 0 {
+		t.Fatalf("2ms of jitter emitted %d events", len(*emits))
+	}
+}

--- a/wail-app/internal/align/steerer_test.go
+++ b/wail-app/internal/align/steerer_test.go
@@ -969,21 +969,24 @@ func TestGridJumpReRunsEntryConformance(t *testing.T) {
 // Within one bucket the reported δ must track the real one. Emitting only on a
 // bucket change froze the number at whatever δ was when the state last
 // changed, so a grid recovering from 2.6s to 60ms still read 2605ms.
+//
+// This is the gate-OPEN path deliberately: while the gate is shut the rates
+// differ and δ sweeps, so that path reports the bucket only.
 func TestReportedErrorTracksDeltaInsideAState(t *testing.T) {
 	now := time.Now()
 	s, f, emits := newSteerer(16_600_000) // 2.6s late — "drifted"
 	observe(s, now)
 	now = now.Add(snapSettle + time.Second)
-	f.state.BPM = 130 // gate shut, so nothing steers and δ is ours to script
 	s.Tick(16, now)
 	if lastEmit(emits) != "drifted" {
 		t.Fatalf("expected drifted, got %q", lastEmit(emits))
 	}
 
-	// Still drifted, but much closer than before.
+	// Still drifted, but far closer than the number last reported.
 	f.timeAtBeat = 14_060_000 // 60ms late
 	*emits = nil
-	s.Tick(16, now.Add(time.Second))
+	now = now.Add(emitMinInterval + time.Second)
+	s.Tick(16, now)
 
 	if len(*emits) == 0 {
 		t.Fatal("δ improved from 2.6s to 60ms inside one bucket and nothing was reported")
@@ -992,11 +995,119 @@ func TestReportedErrorTracksDeltaInsideAState(t *testing.T) {
 		t.Fatalf("reported δ = %.1f ms, want ~60", errMs)
 	}
 
-	// Jitter below the step must not spam the UI.
-	f.timeAtBeat = 14_062_000 // 2ms of movement
+	// Movement below the step is jitter, not news.
+	f.timeAtBeat = 14_062_000
 	*emits = nil
-	s.Tick(16, now.Add(2*time.Second))
+	s.Tick(16, now.Add(emitMinInterval+time.Second))
 	if len(*emits) != 0 {
-		t.Fatalf("2ms of jitter emitted %d events", len(*emits))
+		t.Fatalf("2ms of movement emitted %d events", len(*emits))
+	}
+}
+
+// The wedge is specifically a stale slew target holding the gate shut against
+// itself. With no slew in flight the gate is shut because something else
+// genuinely owns the tempo — a DAW tempo ramp holds it shut for the length of
+// the ramp — and that is the case the gate exists to respect. Escalating there
+// yanks the tempo back and snaps the grid, audibly, every timeout.
+func TestGateShutWithNoSlewNeverEscalates(t *testing.T) {
+	now := time.Now()
+	s, f, _ := newSteerer(14_000_000) // aligned: no slew will start
+	observe(s, now)
+	now = now.Add(snapSettle + time.Second)
+
+	f.state.BPM = 130 // an external owner holds the tempo away from the room
+	f.snaps, f.tempos = nil, nil
+	for i := 0; i < 200; i++ { // ~3 minutes of ticks
+		s.Tick(16, now.Add(time.Duration(i)*time.Second))
+	}
+
+	if len(f.snaps) != 0 {
+		t.Fatalf("escalated with no slew in flight: %d grid snaps during a tempo ramp", len(f.snaps))
+	}
+	if len(f.tempos) != 0 {
+		t.Fatalf("fought the tempo owner: %v", f.tempos)
+	}
+	if s.entryPending {
+		t.Fatal("re-armed entry conformance over a tempo nobody asked us to take")
+	}
+}
+
+// The wedge timer must measure ticks that actually evaluated the gate, not
+// wall time. Otherwise a spell where Tick returns early — a tempo-commit
+// burst, or alignment switched off — leaves it accruing, and the first
+// evaluated tick escalates with no grace at all.
+func TestWedgeTimerCountsOnlyEvaluatedTicks(t *testing.T) {
+	now := time.Now()
+	s, f, _ := newSteerer(14_020_000)
+	observe(s, now)
+	now = now.Add(snapSettle + time.Second)
+	for i := 0; i < slewPersistenceTicks; i++ {
+		s.Tick(16, now)
+	}
+	if s.slewTarget == 0 {
+		t.Fatal("expected an active slew")
+	}
+
+	f.state.BPM = 130 // gate shuts
+	s.Tick(16, now)   // timer starts
+
+	// Alignment goes off for well past the timeout, then comes back.
+	s.SetEnabled(false, 16, now.Add(time.Second))
+	s.SetEnabled(true, 16, now.Add(time.Minute))
+	observe(s, now.Add(time.Minute)) // entry runs, clearing entryPending
+
+	// The very next evaluated tick must not escalate on a minute-old timer.
+	s.Tick(16, now.Add(time.Minute+snapSettle+time.Second))
+	if s.entryPending {
+		t.Fatal("escalated instantly on a stale timer — the gate was not continuously shut")
+	}
+}
+
+// Abandoning a slew must put the tempo back. The slew holds the session away
+// from the room tempo, so clearing the bookkeeping alone strands it there with
+// nothing tracking it — SetEnabled's restore keys off the very target cleared.
+func TestAbandonedSlewRestoresTheTempo(t *testing.T) {
+	now := time.Now()
+	s, f, _ := newSteerer(14_020_000)
+	observe(s, now)
+	now = now.Add(snapSettle + time.Second)
+	for i := 0; i < slewPersistenceTicks; i++ {
+		s.Tick(16, now)
+	}
+	slewed := lastTempo(f)
+	if s.slewTarget == 0 || approxEq(slewed, 120) {
+		t.Fatalf("expected the slew to hold the tempo off 120, got %v", f.tempos)
+	}
+
+	s.OnGridJump(5.22, now)
+
+	if got := lastTempo(f); !approxEq(got, 120) {
+		t.Fatalf("tempo left at %v after abandoning the slew, want the room's 120", got)
+	}
+}
+
+// A δ that oscillates by more than the step must not emit every tick: the
+// reference is the last *emitted* value, so the step alone bounds nothing.
+func TestOscillatingDeltaDoesNotStreamEvents(t *testing.T) {
+	now := time.Now()
+	s, f, emits := newSteerer(14_040_000) // 40ms: "drifted"
+	observe(s, now)
+	now = now.Add(snapSettle + time.Second)
+	s.Tick(16, now)
+	*emits = nil
+
+	// ±12ms of jitter inside one bucket, one tick a second.
+	for i := 0; i < 30; i++ {
+		// 40ms vs 60ms: 20ms apart, so past the step, but both well inside
+		// the same bucket — jitter, not a state change.
+		if i%2 == 0 {
+			f.timeAtBeat = 14_040_000
+		} else {
+			f.timeAtBeat = 14_060_000
+		}
+		s.Tick(16, now.Add(time.Duration(i+1)*time.Second))
+	}
+	if len(*emits) > 30/int(emitMinInterval/time.Second)+1 {
+		t.Fatalf("jitter streamed %d events over 30 ticks", len(*emits))
 	}
 }

--- a/wail-app/internal/align/steerer_test.go
+++ b/wail-app/internal/align/steerer_test.go
@@ -1111,3 +1111,83 @@ func TestOscillatingDeltaDoesNotStreamEvents(t *testing.T) {
 		t.Fatalf("jitter streamed %d events over 30 ticks", len(*emits))
 	}
 }
+
+// --- long-run behaviour: one tempo, one hour, peers coming and going ---
+
+// The real workload is an hour on a fixed tempo, not the handful of ticks the
+// other tests cover. Over that span a quiet, aligned grid must stay quiet: no
+// grid snaps (a snap is audible), no tempo writes, no spurious re-entry, and a
+// UI event budget that doesn't grow with time.
+func TestAnHourOnAFixedTempoStaysQuiet(t *testing.T) {
+	start := time.Now()
+	s, f, emits := newSteerer(14_000_000) // aligned
+	observe(s, start)
+	f.snaps, f.tempos, *emits = nil, nil, nil
+
+	for i := 0; i < 3600; i++ {
+		s.Tick(16, start.Add(snapSettle+time.Duration(i)*time.Second))
+	}
+
+	if len(f.snaps) != 0 {
+		t.Fatalf("%d audible grid snaps during a quiet hour", len(f.snaps))
+	}
+	if len(f.tempos) != 0 {
+		t.Fatalf("wrote the tempo %d times with nothing to correct: %v", len(f.tempos), f.tempos)
+	}
+	if s.entryPending {
+		t.Fatal("entry conformance re-armed itself over a quiet hour")
+	}
+	if len(*emits) > 2 {
+		t.Fatalf("%d UI events over a quiet hour", len(*emits))
+	}
+}
+
+// Peers joining and leaving is the event that actually happens in these
+// sessions, and each one re-phases the shared Link timeline. Every merge must
+// recover — one snap, tempo back on the room's — and an hour of them must not
+// leave the steerer wedged or drifting in its own state.
+func TestRepeatedMergesOverAnHourEachRecover(t *testing.T) {
+	start := time.Now()
+	s, f, _ := newSteerer(14_000_000)
+	observe(s, start)
+
+	const merges = 12 // one every five minutes
+	for m := 0; m < merges; m++ {
+		at := start.Add(time.Duration(m) * 5 * time.Minute)
+
+		// A joining peer shoves the grid 2.6s and parks the session tempo at
+		// its own — exactly the field case.
+		f.timeAtBeat = 16_600_000
+		f.state.BPM = 120.0
+		f.snaps = nil
+		s.OnGridJump(5.22, at)
+		if !s.entryPending {
+			t.Fatalf("merge %d did not re-arm entry conformance", m)
+		}
+
+		// Entry runs on the next anchor/pong and snaps the grid back.
+		observe(s, at.Add(time.Second))
+		if len(f.snaps) != 1 {
+			t.Fatalf("merge %d: %d snaps, want exactly 1", m, len(f.snaps))
+		}
+		if s.entryPending {
+			t.Fatalf("merge %d: entry still pending after conformance ran", m)
+		}
+
+		// Grid is aligned again; the rest of the five minutes is steady state.
+		f.timeAtBeat = 14_000_000
+		for i := 0; i < 300; i++ {
+			s.Tick(16, at.Add(snapSettle+time.Duration(i)*time.Second))
+		}
+		if s.slewTarget != 0 {
+			t.Fatalf("merge %d: still slewing five minutes later (target %v)", m, s.slewTarget)
+		}
+		if got := lastTempo(f); got != 0 && !approxEq(got, 120) {
+			t.Fatalf("merge %d: tempo left at %v, want the room's 120", m, got)
+		}
+	}
+
+	if s.gateShutSince != (time.Time{}) {
+		t.Fatal("wedge timer left running after an hour of recoveries")
+	}
+}

--- a/wail-app/internal/align/steerer_test.go
+++ b/wail-app/internal/align/steerer_test.go
@@ -869,17 +869,18 @@ func TestSnapshotAdoptionOscillator(t *testing.T) {
 
 // --- recovery from a grid that moved out from under us ---
 
-// The same-rate gate waits for whoever owns the tempo to hand it back. When
-// the session tempo simply settles somewhere else, the stale slew target keeps
-// the gate shut and the gate returns before the settle that would clear the
-// target — a wedge that cannot open itself. Field case: a Link peer joined at
-// 120 while a slew held 119.94, and alignment did nothing for 16 minutes.
-func TestGateShutTooLongReRunsEntryConformance(t *testing.T) {
+// The wedge: the gate compares the session tempo against the slew's target
+// while slewing, and returns before the settle that would clear that target,
+// so once something else moves the tempo the stale target holds the gate shut
+// against itself. Sixteen minutes of no alignment, in the field.
+//
+// The fix is to abandon the target so the baseline falls back to the room
+// tempo — not to seize the tempo or force an audible re-entry, either of
+// which would fight whoever legitimately owns it.
+func TestShutGateAbandonsAStaleSlewTarget(t *testing.T) {
 	now := time.Now()
-	s, f, _ := newSteerer(14_020_000) // 20ms late: past the deadband, slew territory
+	s, f, _ := newSteerer(14_020_000)
 	observe(s, now)
-
-	// Let a slew take hold, so slewTarget is set (persistence + tempo gate).
 	now = now.Add(snapSettle + time.Second)
 	for i := 0; i < slewPersistenceTicks; i++ {
 		s.Tick(16, now)
@@ -888,26 +889,38 @@ func TestGateShutTooLongReRunsEntryConformance(t *testing.T) {
 		t.Fatal("expected an active slew to set up the wedge")
 	}
 
-	// Something else moves the session tempo and leaves it there.
+	// A real tempo move, well outside the same-rate band, shuts the gate.
 	f.state.BPM = 130
-	f.snaps = nil
+	f.snaps, f.tempos = nil, nil
 
 	s.Tick(16, now)
-	if s.entryPending {
-		t.Fatal("re-entered conformance immediately — the gate must first wait out an ordinary tempo change")
-	}
-	s.Tick(16, now.Add(gateWedgeTimeout+time.Second))
-	if !s.entryPending {
-		t.Fatal("gate stayed shut past the timeout without re-running entry conformance")
-	}
-	if s.slewTarget != 0 {
-		t.Fatal("stale slew target survived — it would re-shut the gate against the room tempo")
+	if s.slewTarget == 0 {
+		t.Fatal("abandoned the target immediately — the gate must first wait out an ordinary tempo change")
 	}
 
-	// Entry conformance now adopts the room tempo and re-snaps.
-	observe(s, now.Add(gateWedgeTimeout+2*time.Second))
-	if lastTempo(f) != 120 {
-		t.Fatalf("entry did not adopt the room tempo: %v", f.tempos)
+	s.Tick(16, now.Add(gateWedgeTimeout+time.Second))
+	if s.slewTarget != 0 {
+		t.Fatal("stale slew target survived the timeout — it holds the gate shut against itself")
+	}
+	if len(f.tempos) != 0 {
+		t.Fatalf("wrote the tempo while another owner held it: %v", f.tempos)
+	}
+	if len(f.snaps) != 0 {
+		t.Fatalf("%d audible snaps over a tempo change we should have waited out", len(f.snaps))
+	}
+	if s.entryPending {
+		t.Fatal("forced a re-entry over a tempo nobody asked us to take")
+	}
+
+	// Once the room adopts the new tempo, the gate opens and steering resumes
+	// against the correct baseline.
+	f.timeAtBeat = 14_020_000
+	s.OnAnchor(8_000_000, 0, 130, 16, now.Add(gateWedgeTimeout+2*time.Second))
+	for i := 0; i < slewPersistenceTicks+1; i++ {
+		s.Tick(16, now.Add(gateWedgeTimeout+time.Duration(20+i)*time.Second))
+	}
+	if len(f.tempos) == 0 {
+		t.Fatal("still dormant after the room caught up to the new tempo")
 	}
 }
 
@@ -1056,10 +1069,10 @@ func TestWedgeTimerCountsOnlyEvaluatedTicks(t *testing.T) {
 	s.SetEnabled(true, 16, now.Add(time.Minute))
 	observe(s, now.Add(time.Minute)) // entry runs, clearing entryPending
 
-	// The very next evaluated tick must not escalate on a minute-old timer.
+	// The very next evaluated tick must not act on a minute-old timer.
 	s.Tick(16, now.Add(time.Minute+snapSettle+time.Second))
-	if s.entryPending {
-		t.Fatal("escalated instantly on a stale timer — the gate was not continuously shut")
+	if s.slewTarget == 0 {
+		t.Fatal("abandoned the slew instantly on a stale timer — the gate was not continuously shut")
 	}
 }
 
@@ -1189,5 +1202,107 @@ func TestRepeatedMergesOverAnHourEachRecover(t *testing.T) {
 
 	if s.gateShutSince != (time.Time{}) {
 		t.Fatal("wedge timer left running after an hour of recoveries")
+	}
+}
+
+// A peer on a jittery clock measures a noisy δ — the WAN offset estimate
+// teleports, which is what slewPersistenceTicks exists for. Over an hour that
+// noise must not turn into tempo flapping the whole room hears, and must never
+// snap the grid: a snap is audible, and noise is not evidence of a real move.
+func TestJitteryClockDoesNotFlapTempoOrSnap(t *testing.T) {
+	start := time.Now()
+	s, f, emits := newSteerer(14_000_000)
+	observe(s, start)
+	f.snaps, f.tempos, *emits = nil, nil, nil
+
+	// δ spikes alternating either side of the deadband, ±40ms, once a second
+	// for an hour — a teleporting offset estimate, not real drift.
+	offsets := []int64{40_000, -40_000, 30_000, -50_000, 45_000, -35_000}
+	for i := 0; i < 3600; i++ {
+		f.timeAtBeat = 14_000_000 + offsets[i%len(offsets)]
+		s.Tick(16, start.Add(snapSettle+time.Duration(i)*time.Second))
+	}
+
+	t.Logf("hour of jitter: %d snaps, %d tempo writes, %d UI events",
+		len(f.snaps), len(f.tempos), len(*emits))
+	if len(f.snaps) != 0 {
+		t.Fatalf("clock jitter snapped the grid %d times — audible, and on noise", len(f.snaps))
+	}
+	// The slew may act on a confirmed direction, but alternating noise must not
+	// keep it moving the tempo: real drift persists, spikes flip sign.
+	if len(f.tempos) > 60 {
+		t.Fatalf("tempo written %d times in an hour of jitter — flapping the room's tempo", len(f.tempos))
+	}
+	if len(*emits) > 3600/int(emitMinInterval/time.Second)+2 {
+		t.Fatalf("%d UI events over an hour of jitter", len(*emits))
+	}
+}
+
+// Detection is a heuristic over a sampled clock, so a single bad reading must
+// not be able to snap the grid over and over on a peer whose machine stalls.
+func TestRepeatedJumpReportsDoNotSnapRepeatedly(t *testing.T) {
+	now := time.Now()
+	s, f, _ := newSteerer(16_600_000) // 2.6s out, so entry would snap
+	observe(s, now)
+	f.snaps = nil
+
+	// Ten "jumps" in quick succession, as a stalling machine might report.
+	for i := 0; i < 10; i++ {
+		at := now.Add(time.Duration(i) * 200 * time.Millisecond)
+		s.OnGridJump(5.22, at)
+		observe(s, at)
+	}
+	if len(f.snaps) > 1 {
+		t.Fatalf("%d grid snaps from a burst of jump reports, want at most 1", len(f.snaps))
+	}
+
+	// Past the settle window a genuine new jump is still honoured.
+	f.snaps = nil
+	s.OnGridJump(5.22, now.Add(snapSettle+time.Second))
+	if !s.entryPending {
+		t.Fatal("a real jump after the window was ignored")
+	}
+}
+
+// A peer whose clock wanders around one intended tempo used to gate the slew
+// off entirely — the flat 0.01 BPM band treated a tenth of a BPM the same as a
+// deliberate 120→122 move — so phase drifted uncorrected for the whole hour.
+// With a proportional band the wobble is inside the noise and the slew keeps
+// working, without WAIL ever fighting the peer for the tempo knob.
+func TestWanderingPeerTempoStillLetsTheSlewCorrectPhase(t *testing.T) {
+	start := time.Now()
+	s, f, _ := newSteerer(14_020_000) // a real 20ms phase error to close
+	observe(s, start)
+	f.snaps, f.tempos = nil, nil
+
+	for i := 0; i < 120; i++ {
+		// The peer re-asserts their own wandering tempo every tick.
+		if i%2 == 0 {
+			f.state.BPM = 120.0
+		} else {
+			f.state.BPM = 119.9
+		}
+		s.Tick(16, start.Add(snapSettle+time.Duration(i)*time.Second))
+	}
+
+	if len(f.tempos) == 0 {
+		t.Fatal("the slew stayed dormant through the wobble — phase would drift all session")
+	}
+	if len(f.snaps) != 0 {
+		t.Fatalf("%d audible snaps during an ordinary clock wobble", len(f.snaps))
+	}
+	if s.entryPending {
+		t.Fatal("re-armed entry conformance over a wobble")
+	}
+
+	// A genuine tempo move must still gate the slew: 120→124 is 3.3%, far
+	// outside the band, and WAIL must not fight it.
+	f.tempos = nil
+	for i := 0; i < 30; i++ {
+		f.state.BPM = 124
+		s.Tick(16, start.Add(10*time.Minute+time.Duration(i)*time.Second))
+	}
+	if len(f.tempos) != 0 {
+		t.Fatalf("fought a real tempo change: %v", f.tempos)
 	}
 }

--- a/wail-app/internal/align/steerer_test.go
+++ b/wail-app/internal/align/steerer_test.go
@@ -866,3 +866,102 @@ func TestSnapshotAdoptionOscillator(t *testing.T) {
 		t.Fatalf("gated steady state drifted: a=%v b=%v", a, b)
 	}
 }
+
+// --- recovery from a grid that moved out from under us ---
+
+// The same-rate gate waits for whoever owns the tempo to hand it back. When
+// the session tempo simply settles somewhere else, the stale slew target keeps
+// the gate shut and the gate returns before the settle that would clear the
+// target — a wedge that cannot open itself. Field case: a Link peer joined at
+// 120 while a slew held 119.94, and alignment did nothing for 16 minutes.
+func TestGateShutTooLongReRunsEntryConformance(t *testing.T) {
+	now := time.Now()
+	s, f, _ := newSteerer(14_020_000) // 20ms late: past the deadband, slew territory
+	observe(s, now)
+
+	// Let a slew take hold, so slewTarget is set (persistence + tempo gate).
+	now = now.Add(snapSettle + time.Second)
+	for i := 0; i < slewPersistenceTicks; i++ {
+		s.Tick(16, now)
+	}
+	if s.slewTarget == 0 {
+		t.Fatal("expected an active slew to set up the wedge")
+	}
+
+	// Something else moves the session tempo and leaves it there.
+	f.state.BPM = 130
+	f.snaps = nil
+
+	s.Tick(16, now)
+	if s.entryPending {
+		t.Fatal("re-entered conformance immediately — the gate must first wait out an ordinary tempo change")
+	}
+	s.Tick(16, now.Add(gateWedgeTimeout+time.Second))
+	if !s.entryPending {
+		t.Fatal("gate stayed shut past the timeout without re-running entry conformance")
+	}
+	if s.slewTarget != 0 {
+		t.Fatal("stale slew target survived — it would re-shut the gate against the room tempo")
+	}
+
+	// Entry conformance now adopts the room tempo and re-snaps.
+	observe(s, now.Add(gateWedgeTimeout+2*time.Second))
+	if lastTempo(f) != 120 {
+		t.Fatalf("entry did not adopt the room tempo: %v", f.tempos)
+	}
+}
+
+// While the gate is shut the UI must still get a live δ. Emitting only after
+// the gate meant the badge froze on whatever δ was current when the state last
+// changed, presenting a minutes-old reading as if it were now.
+func TestGatedTicksStillReportState(t *testing.T) {
+	now := time.Now()
+	s, f, emits := newSteerer(14_000_000) // aligned
+	observe(s, now)
+	now = now.Add(snapSettle + time.Second)
+	s.Tick(16, now)
+
+	// Tempo moves away (gate shuts) AND the grid drifts badly.
+	f.state.BPM = 130
+	f.timeAtBeat = 16_600_000 // 2.6s late — the field's stuck badge
+	*emits = nil
+
+	s.Tick(16, now.Add(time.Second))
+	if len(*emits) == 0 {
+		t.Fatal("a gated tick reported nothing — the UI keeps showing a stale δ")
+	}
+	if got := lastEmit(emits); got != "drifted" {
+		t.Fatalf("state = %q, want \"drifted\"", got)
+	}
+	if errMs := (*emits)[len(*emits)-1].errMs; math.Abs(errMs-2600) > 1 {
+		t.Fatalf("reported δ = %.1f ms, want ~2600 (the live measurement)", errMs)
+	}
+}
+
+// A beat jump is past anything the slew can walk back, so it has to re-enter
+// conformance — the engine detects it, the session forwards it here.
+func TestGridJumpReRunsEntryConformance(t *testing.T) {
+	now := time.Now()
+	s, f, _ := newSteerer(14_020_000)
+	observe(s, now)
+	now = now.Add(snapSettle + time.Second)
+	for i := 0; i < slewPersistenceTicks; i++ {
+		s.Tick(16, now)
+	}
+
+	s.OnGridJump(5.22, now)
+	if !s.entryPending {
+		t.Fatal("a grid jump must re-arm entry conformance")
+	}
+	if s.slewTarget != 0 {
+		t.Fatal("a grid jump must abandon the in-flight slew")
+	}
+
+	// The re-entry snaps the grid onto the room again.
+	f.snaps = nil
+	f.timeAtBeat = 16_600_000 // the jump left us 2.6s late
+	observe(s, now.Add(time.Second))
+	if len(f.snaps) != 1 {
+		t.Fatalf("expected exactly one entry snap after the jump, got %v", f.snaps)
+	}
+}

--- a/wail-app/link_test.go
+++ b/wail-app/link_test.go
@@ -9,19 +9,24 @@ import (
 func TestAboveThresholdEmitsChange(t *testing.T) {
 	d := NewTempoChangeDetector(120.0)
 	now := time.Now()
-	d.Check(120.02, now) // candidate
-	bpm, changed := d.Check(120.02, now.Add(tempoHoldDown))
-	if !changed || bpm != 120.02 {
-		t.Fatal("expected change after hold-down")
+	d.Check(122.0, now) // candidate
+	bpm, changed := d.Check(122.0, now.Add(tempoHoldDown))
+	if !changed || bpm != 122.0 {
+		t.Fatalf("expected a change to 122 after hold-down, got %.4f changed=%v", bpm, changed)
 	}
 }
 
+// Hundredths of a BPM are Link convergence noise, not intent. WAIL observes
+// the session rather than owning the tempo, so the reporting bar sits above
+// that noise — see tempoReportThreshold.
 func TestBelowThresholdIgnored(t *testing.T) {
 	d := NewTempoChangeDetector(120.0)
 	now := time.Now()
-	_, changed := d.Check(120.005, now)
-	if changed {
-		t.Fatal("should not change below threshold")
+	for _, bpm := range []float64{120.005, 120.02, 120.1, 119.9} {
+		d.Check(bpm, now)
+		if _, changed := d.Check(bpm, now.Add(tempoHoldDown+time.Second)); changed {
+			t.Fatalf("%.3f reported as a deliberate tempo change", bpm)
+		}
 	}
 }
 
@@ -133,5 +138,53 @@ func TestSetLastTempoRejectsInvalid(t *testing.T) {
 	d.SetLastTempo(-50.0)
 	if d.LastTempo() != 120.0 {
 		t.Fatal("negative should be rejected by SetLastTempo")
+	}
+}
+
+// A peer whose clock wanders around one intended tempo must not have each
+// excursion reported to the room as a tempo change. WAIL never originates a
+// tempo — it observes the Link session, which is the DAW's intent plus Link's
+// convergence noise — and at the old 0.01 BPM bar a 119.9↔120 wobble dragged
+// the whole room's tempo and left every peer's slew gated off.
+func TestWanderingClockIsNotReportedAsATempoChange(t *testing.T) {
+	d := NewTempoChangeDetector(120)
+	now := time.Now()
+
+	for i := 0; i < 600; i++ { // ten minutes of wobble at one reading a second
+		bpm := 120.0
+		if i%2 == 1 {
+			bpm = 119.9
+		}
+		if got, ok := d.Check(bpm, now.Add(time.Duration(i)*time.Second)); ok {
+			t.Fatalf("tick %d: wobble to %.2f reported as a tempo change (%.4f)", i, bpm, got)
+		}
+	}
+}
+
+// A real tempo change must still get through, and arrive as the value a human
+// would have typed rather than the fraction Link happened to report.
+func TestDeliberateTempoChangeIsReportedAndSnapped(t *testing.T) {
+	now := time.Now()
+
+	// 120 → ~124, observed slightly off as Link converges.
+	d := NewTempoChangeDetector(120)
+	d.Check(123.97, now)
+	got, ok := d.Check(123.97, now.Add(tempoHoldDown+time.Second))
+	if !ok {
+		t.Fatal("a 4 BPM change was not reported")
+	}
+	if got != 124 {
+		t.Fatalf("reported %.4f, want 124 — the room reference should carry the intended value", got)
+	}
+
+	// A genuinely fractional project tempo must survive untouched.
+	d2 := NewTempoChangeDetector(120)
+	d2.Check(128.5, now)
+	got, ok = d2.Check(128.5, now.Add(tempoHoldDown+time.Second))
+	if !ok {
+		t.Fatal("a change to 128.5 was not reported")
+	}
+	if got != 128.5 {
+		t.Fatalf("reported %.4f, want 128.5 left alone", got)
 	}
 }

--- a/wail-app/link_types.go
+++ b/wail-app/link_types.go
@@ -8,7 +8,25 @@ import (
 )
 
 const (
-	tempoChangeThreshold  = 0.01 // BPM
+	// tempoSteadyBand is how tightly a candidate reading must hold during the
+	// hold-down to count as steady. Tight on purpose: this asks "has it stopped
+	// moving?", not "is it different enough to matter".
+	tempoSteadyBand = 0.01 // BPM
+	// tempoReportThreshold is how far the session must sit from the last
+	// reported tempo before that counts as a deliberate change worth telling
+	// the room. WAIL never originates a tempo — it observes the Link session,
+	// which is the DAW's intent plus Link's convergence noise — so this is a
+	// denoising bar, and 0.01 was far below the noise: a peer whose clock
+	// wanders 119.9↔120 was reporting each excursion as a tempo change, which
+	// dragged the whole room's tempo and left every peer's slew gated off.
+	// A human's smallest deliberate nudge is a decimal place, not a hundredth.
+	tempoReportThreshold = 0.25 // BPM
+	// tempoIntegerSnap pulls a reported tempo onto a whole number when it is
+	// this close to one. The room tempo is the reference every peer's grid
+	// math derives from, so it should carry the intended value rather than
+	// whichever fraction the first reporter happened to sample. Deliberately
+	// narrow: 128.5 is someone's actual project tempo and must survive.
+	tempoIntegerSnap      = 0.1 // BPM
 	echoGuardDuration     = 150 * time.Millisecond
 	linkPollInterval      = 20 * time.Millisecond // 50 Hz
 	snapshotIntervalTicks = 10                    // ~200ms at 50Hz
@@ -95,14 +113,14 @@ func (d *TempoChangeDetector) Check(bpm float64, now time.Time) (float64, bool) 
 		d.echoGuardUntil = nil
 	}
 
-	if math.Abs(bpm-d.lastTempo) <= tempoChangeThreshold {
-		// Settled at (or back to) the reported tempo: nothing pending.
+	if math.Abs(bpm-d.lastTempo) <= tempoReportThreshold {
+		// Within the noise band of the reported tempo: not a change.
 		d.hasCandidate = false
 		return 0, false
 	}
 
 	// Hold-down: the reading is a candidate until it holds for tempoHoldDown.
-	if !d.hasCandidate || math.Abs(bpm-d.candidate) > tempoChangeThreshold {
+	if !d.hasCandidate || math.Abs(bpm-d.candidate) > tempoSteadyBand {
 		d.candidate = bpm
 		d.candidateSince = now
 		d.hasCandidate = true
@@ -111,9 +129,20 @@ func (d *TempoChangeDetector) Check(bpm float64, now time.Time) (float64, bool) 
 	if now.Sub(d.candidateSince) < tempoHoldDown {
 		return 0, false
 	}
-	d.lastTempo = bpm
+	reported := snapToIntegerTempo(bpm)
+	d.lastTempo = reported
 	d.hasCandidate = false
-	return bpm, true
+	return reported, true
+}
+
+// snapToIntegerTempo rounds a tempo onto a whole number when it is within
+// tempoIntegerSnap of one — recovering the value a human typed from the value
+// Link reported. Anything further out is left exactly as observed.
+func snapToIntegerTempo(bpm float64) float64 {
+	if r := math.Round(bpm); math.Abs(bpm-r) <= tempoIntegerSnap && r > 0 {
+		return r
+	}
+	return bpm
 }
 
 // LastTempo returns the last known tempo.

--- a/wail-app/session.go
+++ b/wail-app/session.go
@@ -1007,10 +1007,17 @@ func sessionLoop(
 		// settling and tempo commits; never fires while entry is pending).
 		case <-alignTicker.C:
 			// A Link session merge or transport reset moves the local beat
-			// timeline bodily; the engine detects it, alignment has to act on
-			// it (the slew cannot walk back whole beats).
-			if beats, jumped := audioEngine.TakeGridJump(); jumped {
-				steer.OnGridJump(beats, time.Now())
+			// timeline bodily; the engine detects it and attributes it.
+			// Alignment has to act (the slew cannot walk back whole beats),
+			// and the room has to hear about it: a merge hits every peer on
+			// that LAN, so the cause belongs in the relay's log too, not just
+			// on whichever machine happened to notice.
+			if jump, jumped := audioEngine.TakeGridJump(); jumped {
+				steer.OnGridJump(jump.Beats, time.Now())
+				msg := fmt.Sprintf("grid jumped %+.2f beats (%+.0f ms, ≈%+d intervals) — cause: %s; %s",
+					jump.Beats, jump.Ms, jump.Intervals, jump.Cause, jump.Detail)
+				logWarn("%s", msg)
+				mesh.SendLog("warn", "align", msg, uint64(time.Now().UnixMicro()))
 			}
 			steer.Tick(intervalCfg.BeatsPerInterval(), time.Now())
 

--- a/wail-app/session.go
+++ b/wail-app/session.go
@@ -1006,6 +1006,12 @@ func sessionLoop(
 		// against the room grid with bounded tempo nudges (gated against entry
 		// settling and tempo commits; never fires while entry is pending).
 		case <-alignTicker.C:
+			// A Link session merge or transport reset moves the local beat
+			// timeline bodily; the engine detects it, alignment has to act on
+			// it (the slew cannot walk back whole beats).
+			if beats, jumped := audioEngine.TakeGridJump(); jumped {
+				steer.OnGridJump(beats, time.Now())
+			}
 			steer.Tick(intervalCfg.BeatsPerInterval(), time.Now())
 
 		// --- Ping timer ---


### PR DESCRIPTION
Diagnosed from a live session showing `drifted 2605ms` in the header badge. Three separate failures, all behind that one number.

## What happened

A Link session merge moved the local beat timeline bodily:

```
19:31:18.521  WARN: local Link beat jumped +5.22 beats (expected +0.01 from elapsed time)
19:31:19.701  capture re-anchored on "Real Train": stamp diverged past threshold — audible splice
```

5.22 beats at 119.9 BPM is 2612ms — the badge's 2605ms. After that, **zero alignment activity for sixteen minutes** (verified: no `[align]` lines at all between the jump and the end of the log), while the grid itself was fine at ~10ms.

## 1. Nothing acts on a detected grid jump

The engine finds the discontinuity and logs it. Nothing consumes it. The only snap path is entry conformance, armed on (re)join alone, and the slew closes phase error at a bounded rate — walking back 2.6s with a 0.06 BPM nudge is hours. A live capture of the *current* shipped code doing exactly that:

```
[align] slew: δ=-2220.3 ms → tempo 119.9400 BPM
```

The jump the detector already finds is now forwarded to the steerer, which re-runs entry conformance: adopt the room tempo, measure δ, snap.

## 2. The same-rate gate can wedge permanently

The gate skips steering while the session tempo differs from the slew's baseline — sound, since something else owns the tempo. But a peer joined at 120 while a slew held 119.94, and the gate `return`s **before** the settle branch that would clear `slewTarget`. So the stale target keeps the gate shut, and the gate prevents clearing the target. Nothing else can: entry conformance isn't armed mid-session.

`OnRejoin`'s own comment already names this hazard — *"a stale target would wedge the same-rate gate exactly as a mid-slew tempo commit does"* — it was handled for rejoin and left open for an external tempo change.

Once the gate has been shut past `gateWedgeTimeout` (10s — long enough to sit out an ordinary tempo change and its re-anchor), the steerer abandons the slew and re-enters conformance rather than waiting for a tempo that already left.

## 3. The gate suppressed reporting, not just steering

`emitState` only fires on a state *bucket* change, and the gated path returned before reaching it. So the badge kept showing δ from whenever the state last changed — a reading minutes old, presented as live. That's the "2605ms" you keep looking at long after the grid recovered.

δ is now measured before the gate and emitted on gated ticks too. The gate governs whether we steer, never whether we tell the truth.

## Testing

Three tests in `internal/align`, all mutation-checked — reverting to the old behaviour reproduces the exact field failure (`gate stayed shut past the timeout without re-running entry conformance`, `a gated tick reported nothing — the UI keeps showing a stale δ`):

- gate shut past the timeout re-runs entry conformance and drops the stale target
- gated ticks still report, with the live δ (~2600ms), not silence
- a grid jump re-arms entry and abandons the in-flight slew, and the re-entry snaps

Full `wail-app` suite both build modes (`-count=1`), vet, gofmt.

**Note on the E2E:** `scripts/tier2-e2e.sh` passes (0 loss, 4/4 placement), but running it is what caused the disruption above — it spins up Link peers that join whatever session is on the LAN. It should not be run against a live jam; that's worth a warning in CLAUDE.md next to the pair-debug guidance, and I'd suggest it as a follow-up.

Co-authored by a very tired language model
