### PR TITLE
fix: bin tier2 placement by the classified block, not the raw frequency

### DIFF
--- a/scripts/tier2-e2e.sh
+++ b/scripts/tier2-e2e.sh
@@ -210,10 +210,17 @@ if [ "$MODE" = step ]; then
         # Per-second VOTE for the capture room of what is heard now (no edge
         # margins anywhere): each receiver interval tallies its seconds and
         # the majority wins, so the odd skewed/straddle second is harmless.
-        c = (freq - f0)/step * blockdur
+        # Bin by the block we just classified to, NOT by the raw frequency.
+        # The estimate is routinely tens of Hz flat (Opus + resample), which
+        # the ±step/2 check above tolerates on purpose — but deriving the
+        # content position from the raw value then drops the tone into the
+        # PREVIOUS block, reporting a placement failure for audio that landed
+        # exactly where it should. 672Hz is a 720Hz tone: accepted as block 3,
+        # binned as block 2. That was the intermittent off-by-one.
+        c = k * blockdur
         if (c < -1) next
         bi = 0
-        for (i = nb; i >= 1; i--) if (cs[i] <= c) { bi = i; break }
+        for (i = nb; i >= 1; i--) if (cs[i] <= c + 0.001) { bi = i; break }
         if (bi == 0) next
         # Join-transition exclusion: intervals captured before the room
         # tempo settled carry skewed labels by design (ADR-0006 entry


### PR DESCRIPTION
The intermittent one-interval placement failures were the harness, not the engine.

## What was happening

The checker classifies each received second to the nearest tone block, deliberately tolerating ±step/2 because the frequency estimate is routinely tens of Hz flat (Opus + resample — the script's own comment says ±80 Hz). It then derived the content position from the **raw** frequency:

```awk
k = int((freq - f0)/step + 0.5)     # nearest block: 672Hz → k=3 (720Hz), |−48| ≤ 80 ✓
diff = freq - (f0 + k*step); if (diff > step/2) next
c = (freq - f0)/step * blockdur     # ← but bins by RAW freq: 2.7 blocks → previous block
```

So a tone the checker had just accepted as block 3 got binned as block 2 — reported as `majority-captured room 3, want room 4`. Two real examples from one captured run:

| Playing room | Heard | True tone | Raw binning | Result |
|---|---|---|---|---|
| 5 | 672 Hz | 720 Hz (block 3) | 2.7 → block 2 | ✗ off by one |
| 9 | 1344 Hz | 1360 Hz (block 7) | 6.9 → block 6 | ✗ off by one |

Whether a run failed came down to which tones the estimator happened to read flat enough to cross a block edge — which is exactly why it presented as a flaky placement bug in the engine, and why the failure count varied run to run with no code changes.

## The proof it isn't the engine

Replaying the **captured logs of a failing run** through the corrected checker — same audio, same engine, only the arithmetic changed:

```
before:  placement: 8 checks, 2 failures   VERDICT=FAIL
after:   placement: 9 checks, 0 failures   VERDICT=PASS
```

The receiver's own log for that run was clean throughout: `local=N room=N` every interval, 200/200 frames, no re-anchors, no late frames, no label shifts. The audio was landing where it should.

## The fix

Bin by the block index the checker already computed and validated, rather than re-deriving it from the raw estimate. Plus a small epsilon on the block lookup so float drift in `blockdur` can't reintroduce the same off-by-one for non-integer interval lengths.

## Status, honestly

11 runs since the fix: **9 clean, 1 sporadic single-interval miss (2/3 votes), 1 run with every interval off by one and unanimous votes.** That last one is a different animal from what's fixed here — a systematic offset for a whole run, not tone-dependent noise — and it did not reproduce in the following 6 runs, so I have not been able to capture it with logs. It is either a genuine intermittent engine race at startup or another harness edge; this PR does not claim to address it.

So: this removes the dominant failure mode and makes the harness's verdict mean what it says, but a rarer failure remains open. Worth knowing before treating a green tier2 as proof of anything.

Also worth noting for anyone reading the older results in this repo's PRs: `VERDICT=FAIL` can also mean `checks < 3` with zero placement failures — a short run fails the gate without finding anything wrong.

Claude Code did the typing, blame it accordingly
