### PR TITLE
fix: redeclare send-stream count mid-session via update_streams

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -253,6 +253,7 @@ Two independent time domains exist in the system:
 | `LogBroadcast` (`log`) | Client → Server → Room | Broadcast structured log entry to all room peers (opt-in) |
 | `MetricsReport` | Client → Server | Per-peer audio frame counts + pipeline state (consumed server-side, not relayed) |
 | `rate_limit_warning` | Server → Client | Warning that the peer is sending too fast and will be disconnected if it continues |
+| `update_streams` | Client → Server | Redeclare the send-stream count mid-session; the relay rescales the binary rate limit and room slot accounting. Acked with `update_streams_ok`, rejected with `update_streams_error` (`room_full`) |
 
 ## Key Design Decisions
 
@@ -268,7 +269,7 @@ Two independent time domains exist in the system:
 
 6. **Server-relayed architecture**: All data flows through the signaling server (no direct P2P). This eliminates ICE/STUN/TURN negotiation complexity at the cost of an extra hop and server bandwidth scaling quadratically with room size.
 
-7. **Stream-count-aware rate limiting**: Per-connection token bucket rate limiting on the signaling server. Binary message rate scales with `stream_count` (60 tokens/sec/stream, 2× burst), text rate is fixed at 100/sec. Escalation: drop excess messages → warn log → send `rate_limit_warning` to client → disconnect after 50 cumulative violations. Join messages are exempt from text rate limiting so peers can always reconnect.
+7. **Stream-count-aware rate limiting**: Per-connection token bucket rate limiting on the signaling server. Binary message rate scales with `stream_count` (100 tokens/sec/stream, 2500-token burst/stream — a full interval of frames), text rate is fixed at 100/sec. Escalation: drop excess messages → warn log → send `rate_limit_warning` to client → disconnect after 50 cumulative violations. Join messages are exempt from text rate limiting so peers can always reconnect. Streams open and close mid-session (capture toggles, restore auto-enable, in-app senders), so the client recomputes its live send-stream count each status tick (enabled capture channels + test tone/WAV/metronome) and pushes `update_streams` when it drifts from the last declaration; the relay rescales the bucket in place (preserving tokens, so updates can't mint free capacity), re-checks room capacity, and resets the violation counter.
 
 8. **Pure engine logic in `internal/` packages**: interval math, scheduler, loss, affinity, and interval assembly/reassembly are cgo- and network-free, so they are fully unit-tested; the cgo Link Audio layer and the relay wrap that proven logic.
 

--- a/signaling-server/main.go
+++ b/signaling-server/main.go
@@ -48,6 +48,7 @@ const (
 	baseTextBurst     = 200.0  // max tokens
 	rateLimitWarnMax  = 50     // violations before disconnect
 	maxStreamsPerPeer = 16     // cap stream_count for rate-limit scaling
+	roomCapacity      = 32     // max summed stream slots per room
 )
 
 // ---------------------------------------------------------------------------
@@ -126,6 +127,20 @@ type tokenBucket struct {
 
 func newTokenBucket(rate, burst float64) tokenBucket {
 	return tokenBucket{tokens: burst, maxTokens: burst, refillRate: rate, lastRefill: time.Now()}
+}
+
+// rescale changes the refill rate and burst in place, preserving the current
+// token level (clamped to the new max) so a stream-count update can never
+// mint free capacity.
+func (b *tokenBucket) rescale(rate, burst float64) {
+	now := time.Now()
+	b.tokens += now.Sub(b.lastRefill).Seconds() * b.refillRate
+	b.lastRefill = now
+	b.refillRate = rate
+	b.maxTokens = burst
+	if b.tokens > b.maxTokens {
+		b.tokens = b.maxTokens
+	}
 }
 
 func (b *tokenBucket) allow() bool {
@@ -550,7 +565,6 @@ func (h *hub) join(c *conn, msg clientMsg) (string, string, int) {
 		}
 	}
 
-	const roomCapacity = 32
 	var usedSlots int
 	h.db.QueryRow("SELECT COALESCE(SUM(stream_count), 0) FROM peers WHERE room = ?", roomName).Scan(&usedSlots)
 	if usedSlots+streamCount > roomCapacity {
@@ -656,6 +670,52 @@ func (h *hub) join(c *conn, msg clientMsg) (string, string, int) {
 		c.sendJSON(am)
 	}
 	return roomName, peerID, streamCount
+}
+
+// updateStreams lets a joined peer redeclare its stream count mid-session
+// (streams can be opened/closed at any time, but join only sizes the rate
+// limit once). Returns the new effective count when it changed — the caller
+// (readPump) then rescales the binary token bucket — or 0 when the count was
+// unchanged or the update was rejected. room/peerID are readPump's cached
+// locals, never c.room/c.peerID (eviction races).
+func (h *hub) updateStreams(room, peerID string, c *conn, msg clientMsg) int {
+	if room == "" {
+		return 0
+	}
+	streamCount := msg.StreamCount
+	if streamCount < 1 {
+		streamCount = 1
+	}
+	if streamCount > maxStreamsPerPeer {
+		streamCount = maxStreamsPerPeer
+	}
+	// c.streamCount is only ever touched by this conn's readPump goroutine
+	// (join and here), so no lock is needed.
+	old := c.streamCount
+	if streamCount == old {
+		c.sendJSON(map[string]any{"type": "update_streams_ok", "stream_count": streamCount})
+		return 0
+	}
+
+	// Room capacity is accounted in stream slots (same as join): the peer may
+	// grow only into the slots not used by others. Shrinking always fits.
+	var usedSlots int
+	h.db.QueryRow("SELECT COALESCE(SUM(stream_count), 0) FROM peers WHERE room = ?", room).Scan(&usedSlots)
+	if usedSlots-old+streamCount > roomCapacity {
+		log.Printf("peer %s stream_count update %d -> %d rejected: room %s full (%d/%d slots)",
+			peerID, old, streamCount, room, usedSlots, roomCapacity)
+		c.sendJSON(map[string]any{
+			"type": "update_streams_error", "code": "room_full",
+			"slots_available": roomCapacity - (usedSlots - old),
+		})
+		return 0
+	}
+
+	h.db.Exec("UPDATE peers SET stream_count = ? WHERE room = ? AND peer_id = ?", streamCount, room, peerID)
+	c.streamCount = streamCount
+	log.Printf("peer %s in room %s updated stream_count %d -> %d", peerID, room, old, streamCount)
+	c.sendJSON(map[string]any{"type": "update_streams_ok", "stream_count": streamCount})
+	return streamCount
 }
 
 func (h *hub) signal(room, peerID string, c *conn, msg clientMsg) {
@@ -1029,6 +1089,16 @@ func (c *conn) readPump(h *hub) {
 			if room != "" {
 				loopback = msg.Enabled
 				log.Printf("peer %s loopback=%v in room %s", peerID, loopback, room)
+			}
+		case "update_streams":
+			// A peer that opens/closes streams mid-session redeclares its count;
+			// rescale the binary bucket in place (preserving tokens) and reset
+			// the violation counter — violations accumulated while honestly
+			// under-declared were the relay's undersized bucket, not abuse.
+			if sc := h.updateStreams(room, peerID, c, msg); sc > 0 && binaryBucket != nil {
+				binaryBucket.rescale(baseBinaryRate*float64(sc), baseBinaryBurst*float64(sc))
+				violations = 0
+				warned = false
 			}
 		}
 	}

--- a/signaling-server/main_test.go
+++ b/signaling-server/main_test.go
@@ -604,3 +604,194 @@ func TestJoinUpgradesLegacyHash(t *testing.T) {
 		t.Fatalf("join failed after upgrade: %v", resp)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// update_streams
+// ---------------------------------------------------------------------------
+
+func TestTokenBucketRescale(t *testing.T) {
+	// Grow: rate and burst increase, existing tokens are preserved.
+	b := newTokenBucket(100, 2500)
+	b.refillRate = 0 // freeze refill for determinism
+	for i := 0; i < 2000; i++ {
+		b.allow()
+	}
+	b.rescale(400, 10000)
+	if b.tokens != 500 {
+		t.Fatalf("expected 500 tokens preserved after grow, got %v", b.tokens)
+	}
+	if b.maxTokens != 10000 || b.refillRate != 400 {
+		t.Fatalf("rescale did not apply new rate/burst: %+v", b)
+	}
+
+	// Shrink: tokens above the new max are clamped, none minted.
+	b.rescale(50, 300)
+	if b.tokens != 300 {
+		t.Fatalf("expected tokens clamped to 300 after shrink, got %v", b.tokens)
+	}
+
+	// An empty bucket stays empty — a rescale must never mint free capacity.
+	b2 := newTokenBucket(100, 2500)
+	b2.refillRate = 0
+	for i := 0; i < 2500; i++ {
+		b2.allow()
+	}
+	b2.rescale(1600, 40000)
+	if b2.tokens != 0 {
+		t.Fatalf("expected 0 tokens after rescale of empty bucket, got %v", b2.tokens)
+	}
+}
+
+// joinDirect joins a conn straight through the hub (no websocket) and returns
+// the connection for inspection.
+func joinDirect(t *testing.T, h *hub, room, peerID string, streamCount int) *conn {
+	t.Helper()
+	c := &conn{send: make(chan wsMessage, 16)}
+	gotRoom, gotPeer, gotSC := h.join(c, clientMsg{
+		Type: "join", Room: room, PeerID: peerID,
+		StreamCount: streamCount, ClientVersion: "99.0.0",
+	})
+	if gotRoom == "" {
+		t.Fatalf("join failed for %s", peerID)
+	}
+	if gotPeer != peerID || gotSC != streamCount {
+		t.Fatalf("join returned (%s, %d), want (%s, %d)", gotPeer, gotSC, peerID, streamCount)
+	}
+	return c
+}
+
+func dbStreamCount(t *testing.T, h *hub, room, peerID string) int {
+	t.Helper()
+	var n int
+	if err := h.db.QueryRow("SELECT stream_count FROM peers WHERE room = ? AND peer_id = ?", room, peerID).
+		Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+func drainJSON(t *testing.T, c *conn) map[string]any {
+	t.Helper()
+	select {
+	case m := <-c.send:
+		var v map[string]any
+		if err := json.Unmarshal(m.data, &v); err != nil {
+			t.Fatal(err)
+		}
+		return v
+	case <-time.After(time.Second):
+		t.Fatal("no message on conn send channel")
+		return nil
+	}
+}
+
+func TestUpdateStreams(t *testing.T) {
+	h := newHub(testDB(t))
+	c := joinDirect(t, h, "room", "A", 1)
+	drainJSON(t, c) // join_ok
+
+	if got := h.updateStreams("room", "A", c, clientMsg{StreamCount: 4}); got != 4 {
+		t.Fatalf("updateStreams returned %d, want 4", got)
+	}
+	if n := dbStreamCount(t, h, "room", "A"); n != 4 {
+		t.Fatalf("DB stream_count = %d, want 4", n)
+	}
+	if c.streamCount != 4 {
+		t.Fatalf("conn streamCount = %d, want 4", c.streamCount)
+	}
+	msg := drainJSON(t, c)
+	if msg["type"] != "update_streams_ok" || msg["stream_count"] != float64(4) {
+		t.Fatalf("expected update_streams_ok(4), got %v", msg)
+	}
+}
+
+func TestUpdateStreamsRoomFull(t *testing.T) {
+	h := newHub(testDB(t))
+	// Fill the room to capacity: 16 + 15 = 31 slots, then A joins with 1 → 32.
+	joinDirect(t, h, "room", "B", 16)
+	joinDirect(t, h, "room", "C", 15)
+	cA := joinDirect(t, h, "room", "A", 1)
+	drainJSON(t, cA) // join_ok
+
+	if got := h.updateStreams("room", "A", cA, clientMsg{StreamCount: 4}); got != 0 {
+		t.Fatalf("updateStreams returned %d, want 0 (rejected)", got)
+	}
+	if n := dbStreamCount(t, h, "room", "A"); n != 1 {
+		t.Fatalf("DB stream_count = %d, want unchanged 1", n)
+	}
+	msg := drainJSON(t, cA)
+	if msg["type"] != "update_streams_error" || msg["code"] != "room_full" {
+		t.Fatalf("expected update_streams_error(room_full), got %v", msg)
+	}
+	if msg["slots_available"] != float64(1) {
+		t.Fatalf("expected slots_available 1, got %v", msg["slots_available"])
+	}
+
+	// Shrinking always fits, even in a full room.
+	if got := h.updateStreams("room", "B", mustConn(t, h, "room", "B"), clientMsg{StreamCount: 10}); got != 10 {
+		t.Fatalf("shrink returned %d, want 10", got)
+	}
+}
+
+func mustConn(t *testing.T, h *hub, room, peerID string) *conn {
+	t.Helper()
+	r := h.getRoom(room)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	c, ok := r.connMap[peerID]
+	if !ok {
+		t.Fatalf("peer %s not in room %s", peerID, room)
+	}
+	return c
+}
+
+func TestUpdateStreamsClamped(t *testing.T) {
+	h := newHub(testDB(t))
+	c := joinDirect(t, h, "room", "A", 1)
+	drainJSON(t, c) // join_ok
+
+	if got := h.updateStreams("room", "A", c, clientMsg{StreamCount: 100}); got != maxStreamsPerPeer {
+		t.Fatalf("updateStreams returned %d, want clamped %d", got, maxStreamsPerPeer)
+	}
+	if n := dbStreamCount(t, h, "room", "A"); n != maxStreamsPerPeer {
+		t.Fatalf("DB stream_count = %d, want %d", n, maxStreamsPerPeer)
+	}
+}
+
+func TestUpdateStreamsUnchanged(t *testing.T) {
+	h := newHub(testDB(t))
+	c := joinDirect(t, h, "room", "A", 2)
+	drainJSON(t, c) // join_ok
+
+	// Re-declaring the current count is acked but reports no change (0).
+	if got := h.updateStreams("room", "A", c, clientMsg{StreamCount: 2}); got != 0 {
+		t.Fatalf("updateStreams returned %d, want 0 (unchanged)", got)
+	}
+	msg := drainJSON(t, c)
+	if msg["type"] != "update_streams_ok" || msg["stream_count"] != float64(2) {
+		t.Fatalf("expected update_streams_ok(2), got %v", msg)
+	}
+}
+
+// End-to-end over a websocket: a joined peer redeclares its stream count and
+// the relay acks and persists it.
+func TestUpdateStreamsWS(t *testing.T) {
+	h, srv := testServer(t)
+	ws := dialWS(t, srv)
+	joinRoom(t, ws, "ws-room", "A", 1)
+
+	if err := ws.WriteJSON(map[string]any{"type": "update_streams", "stream_count": 4}); err != nil {
+		t.Fatal(err)
+	}
+	ws.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var resp map[string]any
+	if err := ws.ReadJSON(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["type"] != "update_streams_ok" || resp["stream_count"] != float64(4) {
+		t.Fatalf("expected update_streams_ok(4), got %v", resp)
+	}
+	if n := dbStreamCount(t, h, "ws-room", "A"); n != 4 {
+		t.Fatalf("DB stream_count = %d, want 4", n)
+	}
+}

--- a/wail-app/protocol.go
+++ b/wail-app/protocol.go
@@ -148,6 +148,10 @@ type SignalMessage struct {
 	// relay rescales the per-peer binary rate limit mid-session)
 	StreamCount uint16 `json:"stream_count,omitempty"`
 
+	// UpdateStreamsError (update_streams_error from the relay)
+	Code           string `json:"code,omitempty"`
+	SlotsAvailable uint64 `json:"slots_available,omitempty"`
+
 	// MetricsReport
 	DCOpen          bool                       `json:"dc_open,omitempty"`
 	PluginConnected bool                       `json:"plugin_connected,omitempty"`
@@ -207,6 +211,10 @@ type MeshEvent struct {
 	Target      string
 	Message     string
 	TimestampUs uint64
+
+	// UpdateStreamsError
+	Code           string
+	SlotsAvailable uint64
 }
 
 // StreamNamesToWire converts internal u16-keyed stream names to string-keyed for wire format.

--- a/wail-app/protocol.go
+++ b/wail-app/protocol.go
@@ -144,6 +144,10 @@ type SignalMessage struct {
 	// Loopback (set_loopback: relay echoes our own audio frames back)
 	Enabled bool `json:"enabled,omitempty"`
 
+	// UpdateStreams (update_streams: redeclare our send-stream count so the
+	// relay rescales the per-peer binary rate limit mid-session)
+	StreamCount uint16 `json:"stream_count,omitempty"`
+
 	// MetricsReport
 	DCOpen          bool                       `json:"dc_open,omitempty"`
 	PluginConnected bool                       `json:"plugin_connected,omitempty"`
@@ -172,6 +176,7 @@ type ServerMsg struct {
 	Code             string                     `json:"code,omitempty"`
 	MinVersion       *string                    `json:"min_version,omitempty"`
 	SlotsAvailable   *uint64                    `json:"slots_available,omitempty"`
+	StreamCount      *uint32                    `json:"stream_count,omitempty"` // update_streams_ok ack
 	From             string                     `json:"from,omitempty"`
 	Payload          json.RawMessage            `json:"payload,omitempty"`
 	Level            string                     `json:"level,omitempty"`

--- a/wail-app/session.go
+++ b/wail-app/session.go
@@ -248,6 +248,13 @@ func sessionLoop(
 	localSendActive := make(map[uint16]bool)
 	loggedFirstFrameSent := false
 
+	// Relay rate-limit bookkeeping: the relay scales our per-peer binary token
+	// bucket by the stream count declared at join, but streams open and close
+	// all session long (capture toggles, restore-set auto-enable, in-app
+	// senders). The status tick pushes an update_streams whenever the live
+	// count drifts from what we last declared. Initialized to the join value.
+	lastDeclaredStreams := int(config.StreamCount)
+
 	// Test tone state
 	var testToneBoundaryCh chan IntervalBoundaryInfo
 	var testToneCancelFn context.CancelFunc
@@ -704,6 +711,9 @@ func sessionLoop(
 				}()
 
 				reconnect = nil
+				// The rejoin re-declared the configured stream count; the next
+				// status tick pushes update_streams if the live count differs.
+				lastDeclaredStreams = int(config.StreamCount)
 				// ADR-0006: rejoin is an entry — re-arm conformance. The fresh
 				// anchor + relay pongs re-measure δ; a mid-blip rejoin finds δ≈0
 				// and no-ops, a genuinely diverged grid snaps back onto the room.
@@ -1310,6 +1320,23 @@ func sessionLoop(
 			}
 			emitter.Emit("peers:network", PeersNetwork{Peers: networkInfos, Health: health})
 			mesh.SendMetricsReport(dcOpen, true, perPeer, localDropCount.Load(), boundaryDriftUs)
+
+			// Keep the relay's rate limit honest about how many streams we're
+			// actually sending (computed from ground truth, so engine-side
+			// restore auto-enables are covered too).
+			captureEnabled := 0
+			for _, cc := range audioEngine.CaptureChannels() {
+				if cc.Enabled {
+					captureEnabled++
+				}
+			}
+			sendStreams := activeSendStreamCount(captureEnabled,
+				testToneStream != nil, wavSenderStream != nil, metronomeSendCancelFn != nil)
+			if sendStreams != lastDeclaredStreams {
+				logInfo("[signaling] send streams changed %d -> %d, declaring to relay (update_streams)", lastDeclaredStreams, sendStreams)
+				mesh.SendUpdateStreams(uint16(sendStreams))
+				lastDeclaredStreams = sendStreams
+			}
 		}
 	}
 
@@ -1331,6 +1358,25 @@ func connectMesh(ctx context.Context, config SessionConfig, peerID string) (*Pee
 	}
 	mesh := NewPeerMesh(peerID, client, channels, config.StreamCount, peerNames)
 	return mesh, channels.SyncCh, channels.AudioCh, nil
+}
+
+// activeSendStreamCount computes how many concurrent WAIF audio streams this
+// peer is (or will be) sending to the relay: enabled Link Audio capture
+// channels plus any in-app senders (test tone, WAV, metronome broadcast).
+// The relay scales its per-peer binary rate limit by the declared count, so
+// it must stay honest or the relay drops frames (and eventually disconnects
+// us). Minimum 1 — an idle peer still occupies one room slot.
+func activeSendStreamCount(captureEnabled int, testTone, wavSender, metronome bool) int {
+	n := captureEnabled
+	for _, on := range []bool{testTone, wavSender, metronome} {
+		if on {
+			n++
+		}
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n
 }
 
 func min64(a, b uint64) uint64 {

--- a/wail-app/session.go
+++ b/wail-app/session.go
@@ -253,7 +253,12 @@ func sessionLoop(
 	// all session long (capture toggles, restore-set auto-enable, in-app
 	// senders). The status tick pushes an update_streams whenever the live
 	// count drifts from what we last declared. Initialized to the join value.
+	// If the relay rejects a declaration (room_full), streamUpdateRejected
+	// arms a retry after streamUpdateRetryBackoff — otherwise a rejection
+	// would leave the bucket undersized until the next drift.
 	lastDeclaredStreams := int(config.StreamCount)
+	streamUpdateRejected := false
+	streamUpdateRetryAt := time.Time{}
 
 	// Test tone state
 	var testToneBoundaryCh chan IntervalBoundaryInfo
@@ -638,6 +643,13 @@ func sessionLoop(
 
 			case "PeerListReceived":
 				peers.SeedLastSeen()
+
+			case "UpdateStreamsError":
+				// The relay kept the OLD count; arm a retry so a freed slot heals
+				// the undersized rate-limit bucket without waiting for drift.
+				streamUpdateRejected = true
+				streamUpdateRetryAt = time.Now().Add(streamUpdateRetryBackoff)
+				logWarn("[signaling] relay rejected stream update (%s, %d slots available) — retrying in %s", ev.Code, ev.SlotsAvailable, streamUpdateRetryBackoff)
 				logInfo("Joined room with %d peer(s)", ev.PeerCount)
 				if ev.PeerCount == 0 {
 					// Founding an empty room: assert tempo + interval config so the
@@ -1332,10 +1344,11 @@ func sessionLoop(
 			}
 			sendStreams := activeSendStreamCount(captureEnabled,
 				testToneStream != nil, wavSenderStream != nil, metronomeSendCancelFn != nil)
-			if sendStreams != lastDeclaredStreams {
-				logInfo("[signaling] send streams changed %d -> %d, declaring to relay (update_streams)", lastDeclaredStreams, sendStreams)
+			if shouldDeclareStreams(sendStreams, lastDeclaredStreams, streamUpdateRejected, streamUpdateRetryAt, time.Now()) {
+				logInfo("[signaling] declaring %d send streams to relay (update_streams, was %d)", sendStreams, lastDeclaredStreams)
 				mesh.SendUpdateStreams(uint16(sendStreams))
 				lastDeclaredStreams = sendStreams
+				streamUpdateRejected = false
 			}
 		}
 	}
@@ -1358,6 +1371,22 @@ func connectMesh(ctx context.Context, config SessionConfig, peerID string) (*Pee
 	}
 	mesh := NewPeerMesh(peerID, client, channels, config.StreamCount, peerNames)
 	return mesh, channels.SyncCh, channels.AudioCh, nil
+}
+
+// streamUpdateRetryBackoff is how long the session waits before re-declaring
+// its stream count after the relay rejects an update (room_full) — long
+// enough not to spam a full room, short enough to heal when slots free up.
+const streamUpdateRetryBackoff = 30 * time.Second
+
+// shouldDeclareStreams reports whether an update_streams declaration is due
+// this tick: the desired count drifted from the last declaration (always
+// immediate), or the relay rejected the previous declaration and the retry
+// backoff has elapsed.
+func shouldDeclareStreams(desired, lastDeclared int, rejected bool, retryAt, now time.Time) bool {
+	if desired != lastDeclared {
+		return true
+	}
+	return rejected && !now.Before(retryAt)
 }
 
 // activeSendStreamCount computes how many concurrent WAIF audio streams this

--- a/wail-app/session_test.go
+++ b/wail-app/session_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+// The relay scales its per-peer binary rate limit by the declared stream
+// count, so the count the app declares must track the number of streams it
+// can actually send on: enabled Link Audio capture channels plus any in-app
+// senders (test tone, WAV, metronome broadcast).
+func TestActiveSendStreamCount(t *testing.T) {
+	cases := []struct {
+		name                           string
+		captureEnabled                 int
+		testTone, wavSender, metronome bool
+		want                           int
+	}{
+		{"idle peer still declares 1", 0, false, false, false, 1},
+		{"one capture channel", 1, false, false, false, 1},
+		{"three capture channels", 3, false, false, false, 3},
+		{"capture plus metronome", 2, false, false, true, 3},
+		{"all in-app senders", 0, true, true, true, 3},
+		{"everything at once", 2, true, true, true, 5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := activeSendStreamCount(tc.captureEnabled, tc.testTone, tc.wavSender, tc.metronome)
+			if got != tc.want {
+				t.Fatalf("activeSendStreamCount(%d, %v, %v, %v) = %d, want %d",
+					tc.captureEnabled, tc.testTone, tc.wavSender, tc.metronome, got, tc.want)
+			}
+		})
+	}
+}

--- a/wail-app/session_test.go
+++ b/wail-app/session_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 // The relay scales its per-peer binary rate limit by the declared stream
 // count, so the count the app declares must track the number of streams it
@@ -26,6 +29,38 @@ func TestActiveSendStreamCount(t *testing.T) {
 			if got != tc.want {
 				t.Fatalf("activeSendStreamCount(%d, %v, %v, %v) = %d, want %d",
 					tc.captureEnabled, tc.testTone, tc.wavSender, tc.metronome, got, tc.want)
+			}
+		})
+	}
+}
+
+// A rejected update_streams declaration must not be a dead end: the session
+// re-declares once the retry backoff elapses, and any drift in the desired
+// count always declares immediately.
+func TestShouldDeclareStreams(t *testing.T) {
+	now := time.Now()
+	past := now.Add(-time.Second)
+	future := now.Add(30 * time.Second)
+	cases := []struct {
+		name                  string
+		desired, lastDeclared int
+		rejected              bool
+		retryAt               time.Time
+		want                  bool
+	}{
+		{"declared matches, no rejection", 3, 3, false, time.Time{}, false},
+		{"drift declares immediately", 4, 3, false, time.Time{}, true},
+		{"shrink declares immediately", 2, 3, false, time.Time{}, true},
+		{"rejected but backoff pending", 3, 3, true, future, false},
+		{"rejected and backoff elapsed", 3, 3, true, past, true},
+		{"drift wins over pending backoff", 4, 3, true, future, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldDeclareStreams(tc.desired, tc.lastDeclared, tc.rejected, tc.retryAt, now)
+			if got != tc.want {
+				t.Fatalf("shouldDeclareStreams(%d, %d, %v, retryAt, now) = %v, want %v",
+					tc.desired, tc.lastDeclared, tc.rejected, got, tc.want)
 			}
 		})
 	}

--- a/wail-app/signaling.go
+++ b/wail-app/signaling.go
@@ -278,6 +278,10 @@ func ConnectSignaling(
 					slots = *msg.SlotsAvailable
 				}
 				log.Printf("[signaling] WARN: relay rejected stream update (%s, %d slots available) — extra streams may be rate-limited", msg.Code, slots)
+				select {
+				case incomingCh <- SignalMessage{Type: "UpdateStreamsError", Code: msg.Code, SlotsAvailable: slots}:
+				default:
+				}
 			case "log":
 				incomingCh <- SignalMessage{
 					Type:        "LogBroadcast",
@@ -490,6 +494,8 @@ func (m *PeerMesh) handleSignalMessage(msg SignalMessage) *MeshEvent {
 			Level: msg.Level, Target: msg.Target,
 			Message: msg.Message, TimestampUs: msg.TimestampUs,
 		}
+	case "UpdateStreamsError":
+		return &MeshEvent{Type: "UpdateStreamsError", Code: msg.Code, SlotsAvailable: msg.SlotsAvailable}
 	}
 	return nil
 }

--- a/wail-app/signaling.go
+++ b/wail-app/signaling.go
@@ -268,6 +268,16 @@ func ConnectSignaling(
 			case "evicted":
 				log.Printf("[signaling] Evicted by server")
 				return
+			case "update_streams_ok":
+				if msg.StreamCount != nil {
+					log.Printf("[signaling] relay acked stream_count=%d", *msg.StreamCount)
+				}
+			case "update_streams_error":
+				slots := uint64(0)
+				if msg.SlotsAvailable != nil {
+					slots = *msg.SlotsAvailable
+				}
+				log.Printf("[signaling] WARN: relay rejected stream update (%s, %d slots available) — extra streams may be rate-limited", msg.Code, slots)
 			case "log":
 				incomingCh <- SignalMessage{
 					Type:        "LogBroadcast",
@@ -339,6 +349,11 @@ func ConnectSignaling(
 					raw = map[string]any{
 						"type":    "set_loopback",
 						"enabled": msg.Enabled,
+					}
+				case "UpdateStreams":
+					raw = map[string]any{
+						"type":         "update_streams",
+						"stream_count": msg.StreamCount,
 					}
 				default:
 					continue
@@ -532,6 +547,13 @@ func (m *PeerMesh) SendLog(level, target, message string, timestampUs uint64) {
 // back to us — the server-echo loopback debug monitor.
 func (m *PeerMesh) SendLoopback(enabled bool) {
 	m.signaling.SendControl(SignalMessage{Type: "Loopback", Enabled: enabled})
+}
+
+// SendUpdateStreams redeclares our send-stream count so the relay rescales
+// the per-peer binary rate limit (streams can open/close mid-session, but
+// the relay sizes the limit at join).
+func (m *PeerMesh) SendUpdateStreams(n uint16) {
+	m.signaling.SendControl(SignalMessage{Type: "UpdateStreams", StreamCount: n})
 }
 
 // SendMetricsReport sends a metrics report to the signaling server.


### PR DESCRIPTION
## Problem

Seen in production relay logs: a peer went from rate-limit violation #5 to #50 in under a second and was disconnected for "sustained rate limit abuse".

Root cause: the relay sizes each peer's binary token bucket **once at join** from the declared `stream_count` (100 tokens/sec per stream), but streams open and close all session long — capture-channel toggles, restore-set auto-enable on later channel discovery, and the in-app test tone / WAV / metronome senders each add a ~50 fps stream. A peer that joined with `stream_count: 1` and later enabled extra streams permanently exceeded its bucket: every excess frame was dropped (~20ms of audio each, ~1s lost here) and the cumulative violation counter marched to 50 → kick. The auto-reconnect made it look self-healing while the cycle repeated.

## Fix

**Relay** — new `update_streams` message redeclares the count mid-session:
- re-checks room capacity (rejects with `update_streams_error` / `room_full`, same semantics as join; shrinking always fits)
- rescales the binary token bucket **in place** via `tokenBucket.rescale`, preserving the current token level so updates can't mint free capacity
- updates the `peers`-table slot accounting used by the capacity check
- resets the violation counter on a successful change — violations accumulated while honestly under-declared were the undersized bucket's fault, not abuse

**App** — the 2s status tick recomputes the live send-stream count **from ground truth** (enabled capture channels via `audioEngine.CaptureChannels()` + active test tone / WAV / metronome senders) and pushes `update_streams` when it drifts from the last declaration. Polling ground truth covers engine-side auto-enables that never pass through a session command. Join/rejoin declarations are unchanged; after a reconnect the next tick re-syncs. Acks/rejections are logged.

**Retry on rejection** (second commit, from code review): an `update_streams_error` is forwarded to the session as an `UpdateStreamsError` event and arms a 30s retry backoff, so a freed room slot heals the undersized bucket instead of dead-ending until the next drift. Drift always declares immediately.

Backward compatible both ways: old relay + new app = `update_streams` falls through the relay switch silently (pre-fix behavior); new relay + old app just never receives updates. **The production fix requires deploying the relay.**

## Testing

- 8 new relay/app tests: `tokenBucket.rescale` token preservation/clamping, hub-level update / room-full rejection / clamp to `maxStreamsPerPeer` / unchanged-ack, websocket end-to-end, `activeSendStreamCount`, `shouldDeclareStreams` retry/backoff matrix
- `go test ./...` ✅ · `go test -tags linkstub ./...` ✅ · `signaling-server go test ./...` ✅ · `scripts/tier2-e2e.sh` **PASS** ✅
- `docs/architecture.md` updated (message table + design decision #7, including its previously-stale rate numbers)

## Review

Two-axis subagent code review (standards + spec) run on the branch: no hard standards violations, all spec lines implemented; the one cross-axis finding (rejected declarations never retried) was fixed in the second commit. Remaining judgement-call notes: count-clamp/capacity-query duplication with `join` (tolerable), violations reset rather than decayed on accepted update (bounded by the text rate limit).
