### PR TITLE
feat: add -debug to join the debug room with diagnostics armed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,8 @@ WAIL is a single-language project: two Go modules, `wail-app/` (the desktop app)
 ```
 wail-app/                Go/Wails desktop app: session orchestration, Ableton Link
 │                        + Link Audio, Opus codec, relay client, GUI. Needs cgo.
-├── main.go               Entry point, Wails window setup, CLI flags (headless, --wav)
+├── main.go               Entry point, Wails window setup, CLI flags (headless, --wav,
+│                         --debug: join the debug room with all diagnostics armed)
 ├── app.go                Frontend-callable methods (JoinRoom, Disconnect, SetTestTone, …)
 ├── session.go            Session state machine (goroutine-based select loop)
 ├── signaling.go          WebSocket signaling/relay client + PeerMesh

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -89,6 +89,10 @@ For measuring a peer's rhythmic phase offset against the room grid (the
   `wail-app -debug`. This is the one to hand a tester: it needs no room name
   and no settings change, and every debug session then carries the same
   diagnostics, so captures are comparable across machines.
+  - `-debug` **implies developer mode** for that run, so the Debug tab (stream
+    offsets, cushion) is there without talking anyone through a checkbox. The
+    saved preference is left alone — relaunching without the flag restores it —
+    and unticking Developer mode in settings still wins for the session.
   - Add `-room NAME` for a private debug room instead of the shared one
     (`wail-app -debug -room debug-geren`) when you don't want testers landing
     on top of each other's audio.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -80,11 +80,27 @@ sed -i 's/\binterface\b/iface/g' vendor/link/include/ableton/link_audio/Channels
 For measuring a peer's rhythmic phase offset against the room grid (the
 "GerenM felt 90ms off" class of problem):
 
-- **GUI**: press **Debug Room** on the join screen. It joins the shared
-  `wail-debug` room and arms all diagnostics: the WAIL Metronome broadcast
-  (a grid-rendered reference click), server-echo loopback, and peer log
-  sharing (the room collates everyone's logs into each client).
-- **Headless**: `-metronome-broadcast` (plus `-loopback` for self-echo).
+- **GUI**: turn on **Developer mode** in settings, then press **Debug Room**
+  on the join screen. It joins the shared `wail-debug` room and arms all
+  diagnostics: the WAIL Metronome broadcast (a grid-rendered reference click),
+  server-echo loopback, and peer log sharing (the room collates everyone's
+  logs into each client).
+- **`-debug`**: the same arming from the command line, GUI or headless —
+  `wail-app -debug`. This is the one to hand a tester: it needs no room name
+  and no settings change, and every debug session then carries the same
+  diagnostics, so captures are comparable across machines.
+  - Add `-room NAME` for a private debug room instead of the shared one
+    (`wail-app -debug -room debug-geren`) when you don't want testers landing
+    on top of each other's audio.
+  - Collect with `wail-logstore -room wail-debug` (see **Log store** below)
+    while the tester is connected.
+- **Individually**: `-metronome-broadcast`, `-loopback` if you want one
+  diagnostic rather than the set.
+
+> `-debug` and the Debug Room button share the room's log stream, which
+> carries Link Audio channel names — i.e. the tester's DAW track names — to
+> everyone in the room. Both paths say so in the log when they arm. Worth
+> mentioning to testers before pointing them at the shared room.
 - **In-app readout (DAW-less)**: the Debug tab's *Stream offsets* section
   shows each remote stream's measured phase offset vs the room grid in ms
   (`internal/offset`, computed from labeled WAIF frames — exact, no envelope

--- a/wail-app/app.go
+++ b/wail-app/app.go
@@ -366,28 +366,44 @@ func (a *App) SetTelemetry(enabled bool) error {
 	return nil
 }
 
-// DebugRoom joins the shared "wail-debug" room with all diagnostics armed:
-// the WAIL Metronome broadcast (a grid-rendered reference click every peer
-// can measure against), server-echo loopback, and peer log sharing (the room
-// collates everyone's logs). Built for offset/latency hunts: have the other
-// peer press it too, then compare their content against their own metronome
-// (linkaudio-probe -offset-ref).
+// DebugRoomName is the room the debug entry points join by default. One known
+// room means a collector (wail-logstore -room) watches a single place instead
+// of chasing per-session names; pass -room alongside -debug for an isolated one.
+const DebugRoomName = "wail-debug"
+
+// DebugRoom joins the shared debug room with all diagnostics armed. Built for
+// offset/latency hunts: have the other peer join it too, then compare their
+// content against their own metronome (linkaudio-probe -offset-ref).
 func (a *App) DebugRoom(displayName string, linkAudioName *string) (*JoinResult, error) {
-	res, err := a.JoinRoom("wail-debug", nil, displayName, nil, nil, nil, nil, nil, nil, nil, nil, linkAudioName)
+	res, err := a.JoinRoom(DebugRoomName, nil, displayName, nil, nil, nil, nil, nil, nil, nil, nil, linkAudioName)
 	if err != nil {
 		return nil, err
 	}
+	a.ArmDebugDiagnostics()
+	return res, nil
+}
+
+// ArmDebugDiagnostics turns on what a debug session is expected to carry: the
+// WAIL Metronome broadcast (a grid-rendered reference click every peer can
+// measure against), server-echo loopback, and peer log sharing. Shared by the
+// GUI button and -debug so a tester's capture is comparable however they
+// started it. Failures are logged rather than fatal — a session missing one
+// diagnostic is still worth more than no session.
+func (a *App) ArmDebugDiagnostics() {
 	if err := a.SetMetronomeBroadcast(true); err != nil {
-		log.Printf("[app] debug room: metronome broadcast failed: %v", err)
+		log.Printf("[app] debug: metronome broadcast failed: %v", err)
 	}
 	if err := a.SetLoopback(true); err != nil {
-		log.Printf("[app] debug room: loopback failed: %v", err)
+		log.Printf("[app] debug: loopback failed: %v", err)
 	}
 	if err := a.SetLogSharing(true); err != nil {
-		log.Printf("[app] debug room: log sharing failed: %v", err)
+		log.Printf("[app] debug: log sharing failed: %v", err)
 	}
-	log.Printf("[app] debug room joined: metronome broadcast + loopback + log sharing armed")
-	return res, nil
+	// Stated plainly because this ships the machine's log lines — which carry
+	// Link Audio channel names, i.e. the user's DAW track names — to everyone
+	// in the room. A tester should be able to see that they opted into it.
+	log.Printf("[app] debug diagnostics armed: metronome broadcast + loopback + log sharing " +
+		"(this machine's logs, including Link Audio channel names, are shared with the room)")
 }
 
 // logSource returns the session's log entry source when the writer exists

--- a/wail-app/app.go
+++ b/wail-app/app.go
@@ -38,6 +38,10 @@ type App struct {
 	// rememberEnabled mirrors the frontend "Remember settings" checkbox (pushed
 	// via SetRememberEnabled); it gates persisting captureEnabled to disk.
 	rememberEnabled bool
+	// debugMode records that the app was launched with -debug. The frontend
+	// reads it to imply developer mode: someone handed a debug build should get
+	// the Debug tab without being talked through a setting first.
+	debugMode bool
 	// captureEnabled is the remembered set of enabled capture channels, keyed
 	// by (peer, channel) name; restored into each session's audio engine.
 	captureEnabled []CaptureChannelKey
@@ -381,6 +385,22 @@ func (a *App) DebugRoom(displayName string, linkAudioName *string) (*JoinResult,
 	}
 	a.ArmDebugDiagnostics()
 	return res, nil
+}
+
+// SetDebugMode records the -debug launch flag (main, before the UI starts).
+func (a *App) SetDebugMode(on bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.debugMode = on
+}
+
+// IsDebugMode reports whether the app was launched with -debug. The frontend
+// treats it as developer mode: the flag is the whole opt-in, so making a tester
+// also find a checkbox is a step that only loses us diagnostics.
+func (a *App) IsDebugMode() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.debugMode
 }
 
 // ArmDebugDiagnostics turns on what a debug session is expected to carry: the

--- a/wail-app/audio_engine.go
+++ b/wail-app/audio_engine.go
@@ -1,6 +1,20 @@
 package main
 
-import "time"
+import (
+	"strings"
+	"time"
+)
+
+// loopbackIdentitySuffix marks the server-echo monitor stream: our own frames
+// round-tripped through the relay and republished under a distinct identity.
+// It is not a room peer, so diagnostics phrased about "a peer" have to say
+// something else about it.
+const loopbackIdentitySuffix = ":loopback"
+
+// isLoopbackIdentity reports whether an emit identity is our own server echo.
+func isLoopbackIdentity(identity string) bool {
+	return strings.HasSuffix(identity, loopbackIdentitySuffix)
+}
 
 // AudioEngine is WAIL's Link Audio audio path (ADR-0001/0002): capture subscribes
 // to local Link Audio channels and ships them as WAIF over the relay; playback

--- a/wail-app/audio_engine_real.go
+++ b/wail-app/audio_engine_real.go
@@ -1045,8 +1045,16 @@ func (e *linkAudioEngine) HandleRemoteAudio(fromIdentity, displayName, streamNam
 			if n < 0 {
 				dir, n = "early", -n
 			}
-			log.Printf("[audio] warn: %s stream %d labels intervals off by %+d — their audio plays %d interval(s) %s",
-				fromIdentity, f.StreamID, verdict, n, dir)
+			if isLoopbackIdentity(fromIdentity) {
+				// Self-echo: "the peer" is this machine, so there is nobody to
+				// chase — it is our own capture labels against our own room
+				// clock, which is a labeler fault, not a remote one.
+				log.Printf("[audio] warn: server-echo loopback stream %d labels intervals off by %+d — our own capture labels disagree with our room clock by %d interval(s)",
+					f.StreamID, verdict, n)
+			} else {
+				log.Printf("[audio] warn: %s stream %d labels intervals off by %+d — their audio plays %d interval(s) %s",
+					fromIdentity, f.StreamID, verdict, n, dir)
+			}
 		}
 	}
 

--- a/wail-app/frontend/index.html
+++ b/wail-app/frontend/index.html
@@ -88,6 +88,7 @@
         </details>
 
         <button type="submit" id="join-btn">Join Room</button>
+        <button type="button" id="debug-room-btn" style="display:none" title="Join the shared wail-debug room with the metronome broadcast, server-echo loopback and peer log sharing armed. Your logs — including Link Audio channel names — are shared with everyone in that room.">Debug Room</button>
       </form>
 
       <div id="join-error" class="error" style="display:none"></div>

--- a/wail-app/frontend/main.js
+++ b/wail-app/frontend/main.js
@@ -10,6 +10,7 @@ const sessionScreen = document.getElementById('session-screen');
 const joinForm = document.getElementById('join-form');
 const joinBtn = document.getElementById('join-btn');
 const joinError = document.getElementById('join-error');
+const debugRoomBtn = document.getElementById('debug-room-btn');
 const disconnectBtn = document.getElementById('disconnect-btn');
 const sessionError = document.getElementById('session-error');
 const sessionBpmInput = document.getElementById('session-bpm');
@@ -649,6 +650,7 @@ sessionTabDebugBtn.addEventListener('click', () => switchSessionTab(sessionTabDe
 // Debug tab is active falls back to the Session tab.
 function applyDeveloperMode(on) {
   sessionTabDebugBtn.style.display = on ? '' : 'none';
+  debugRoomBtn.style.display = on ? '' : 'none';
   if (!on && sessionTabDebugBtn.classList.contains('active')) {
     switchSessionTab(sessionTabSessionBtn);
   }
@@ -753,6 +755,26 @@ joinForm.addEventListener('submit', async (e) => {
     showError(joinError, err);
     joinBtn.disabled = false;
     joinBtn.textContent = 'Join Room';
+  }
+});
+
+// --- Debug room (developer mode only; same arming as the -debug flag) ---
+debugRoomBtn.addEventListener('click', async () => {
+  joinError.style.display = 'none';
+  debugRoomBtn.disabled = true;
+  debugRoomBtn.textContent = 'Connecting...';
+  try {
+    const result = await invoke('debug_room', {
+      displayName: getDisplayName(),
+      linkAudioName: getLinkAudioName(),
+    });
+    showSession(result.room);
+    setupListeners();
+  } catch (err) {
+    showError(joinError, err);
+  } finally {
+    debugRoomBtn.disabled = false;
+    debugRoomBtn.textContent = 'Debug Room';
   }
 });
 

--- a/wail-app/frontend/main.js
+++ b/wail-app/frontend/main.js
@@ -299,6 +299,12 @@ const REMEMBER_KEY = 'wail-remember';
 const DEVELOPER_KEY = 'wail-developer-mode';
 function getDeveloperMode() { return localStorage.getItem(DEVELOPER_KEY) === '1'; }
 function saveDeveloperMode(on) { localStorage.setItem(DEVELOPER_KEY, on ? '1' : '0'); }
+// Set when the app was launched with -debug, which implies developer mode for
+// the session without touching the saved preference. Everything that reads
+// "is developer mode on" has to go through developerModeActive(), or opening
+// Settings would show the stored value and quietly switch the Debug tab off.
+let debugFlagImpliesDeveloper = false;
+function developerModeActive() { return debugFlagImpliesDeveloper || getDeveloperMode(); }
 
 function getDisplayName() {
   return localStorage.getItem(DISPLAY_NAME_KEY) || '';
@@ -576,7 +582,7 @@ function openSettings() {
   settingsLinkAudioNameInput.value = getLinkAudioName();
   settingsTelemetryCheckbox.checked = getTelemetryEnabled();
   settingsRememberCheckbox.checked = getRememberEnabled();
-  settingsDeveloperCheckbox.checked = getDeveloperMode();
+  settingsDeveloperCheckbox.checked = developerModeActive();
   settingsPanel.style.display = 'flex';
 }
 
@@ -609,8 +615,11 @@ settingsForm.addEventListener('submit', (e) => {
   const rememberEnabled = settingsRememberCheckbox.checked;
   saveRememberEnabled(rememberEnabled);
   invoke('set_remember_enabled', { enabled: rememberEnabled }).catch(() => {});
-  // Developer mode: persist + show/hide the Debug tab immediately.
+  // Developer mode: persist + show/hide the Debug tab immediately. Unchecking
+  // it also drops what -debug implied — an explicit choice outranks the flag,
+  // and otherwise reopening Settings would tick the box straight back on.
   const developerEnabled = settingsDeveloperCheckbox.checked;
+  debugFlagImpliesDeveloper = debugFlagImpliesDeveloper && developerEnabled;
   saveDeveloperMode(developerEnabled);
   applyDeveloperMode(developerEnabled);
   if (rememberEnabled) {
@@ -655,7 +664,19 @@ function applyDeveloperMode(on) {
     switchSessionTab(sessionTabSessionBtn);
   }
 }
-applyDeveloperMode(getDeveloperMode());
+applyDeveloperMode(developerModeActive());
+
+// Launching with -debug implies developer mode: the flag is the whole opt-in,
+// so making a tester also hunt for a checkbox only costs us diagnostics. The
+// saved preference is deliberately not written — this holds for the session,
+// and relaunching without the flag goes back to whatever they had.
+invoke('is_debug_mode')
+  .then((on) => {
+    if (!on) return;
+    debugFlagImpliesDeveloper = true;
+    applyDeveloperMode(true);
+  })
+  .catch(() => {}); // binding absent: fall back to the saved preference
 
 function resetStatsWindow() {
   statusSnapshots = [];

--- a/wail-app/frontend/wails-adapter.js
+++ b/wail-app/frontend/wails-adapter.js
@@ -49,6 +49,7 @@
         'set_metronome_broadcast': 'main.App.SetMetronomeBroadcast',
         'set_cushion_ms': 'main.App.SetCushionMs',
         'set_grid_align': 'main.App.SetGridAlign',
+        'debug_room': 'main.App.DebugRoom',
         'rename_stream': 'main.App.RenameStream',
         'get_app_version': 'main.App.GetAppVersion',
     };
@@ -75,6 +76,7 @@
         'set_metronome_broadcast': ['enabled'],
         'set_cushion_ms': ['ms'],
         'set_grid_align': ['enabled'],
+        'debug_room': ['displayName', 'linkAudioName'],
     };
 
     async function invoke(command, args) {

--- a/wail-app/frontend/wails-adapter.js
+++ b/wail-app/frontend/wails-adapter.js
@@ -50,6 +50,7 @@
         'set_cushion_ms': 'main.App.SetCushionMs',
         'set_grid_align': 'main.App.SetGridAlign',
         'debug_room': 'main.App.DebugRoom',
+        'is_debug_mode': 'main.App.IsDebugMode',
         'rename_stream': 'main.App.RenameStream',
         'get_app_version': 'main.App.GetAppVersion',
     };

--- a/wail-app/internal/emit/labeloffset.go
+++ b/wail-app/internal/emit/labeloffset.go
@@ -17,6 +17,13 @@ const (
 	// labelOffsetMinFrames is the minimum frames in an interval before a
 	// verdict is finalized (an interval at any normal tempo has hundreds).
 	labelOffsetMinFrames = 10
+	// labelOffsetPersistIntervals is how many consecutive finalized intervals a
+	// NONZERO delta must hold before it is reported. One odd interval is what a
+	// join transition looks like while the labeler settles, and reporting it
+	// claims a peer plays intervals late when nothing is wrong — indistinguishable
+	// from the real fault it exists to catch. A genuine offset is stuck, so it
+	// survives the wait and is reported one interval later.
+	labelOffsetPersistIntervals = 2
 )
 
 // LabelOffsetTracker accumulates per-interval label deltas for one remote
@@ -28,6 +35,11 @@ type LabelOffsetTracker struct {
 	total    uint64
 	verdict  int64
 	valid    bool
+	// pending is the modal delta awaiting confirmation and pendingCount how
+	// many consecutive finalized intervals have agreed on it — the hold-down
+	// that keeps a join transition from reading as a mislabeled peer.
+	pending      int64
+	pendingCount int
 }
 
 // Add records one frame's label against the current local room index. When the
@@ -43,9 +55,21 @@ func (t *LabelOffsetTracker) Add(roomIdx, frameIdx int64) (int64, bool) {
 	if !t.started || t.countIdx != roomIdx {
 		if t.started && t.total >= labelOffsetMinFrames {
 			v := t.modalDelta()
-			if !t.valid || v != t.verdict {
-				t.verdict, t.valid = v, true
-				changed = true
+			if v == t.pending {
+				t.pendingCount++
+			} else {
+				t.pending, t.pendingCount = v, 1
+			}
+			// Healthy (0) publishes at once — recovery is always safe to report,
+			// and holding it down would leave a stale fault on the books. A
+			// nonzero delta waits for confirmation. Intervals too sparse to
+			// finalize neither confirm nor break a run: they carry no evidence
+			// either way.
+			if v == 0 || t.pendingCount >= labelOffsetPersistIntervals {
+				if !t.valid || v != t.verdict {
+					t.verdict, t.valid = v, true
+					changed = true
+				}
 			}
 		}
 		t.counts = [2*labelOffsetRange + 1]uint64{}

--- a/wail-app/internal/emit/labeloffset_test.go
+++ b/wail-app/internal/emit/labeloffset_test.go
@@ -21,11 +21,15 @@ func TestLabelOffsetHealthyStream(t *testing.T) {
 
 func TestLabelOffsetLaggingPeer(t *testing.T) {
 	var tr LabelOffsetTracker
-	// Every frame labeled one behind the local room index.
+	// Every frame labeled one behind the local room index, held across two
+	// intervals — one alone is a blip (see the hold-down).
 	for i := 0; i < 50; i++ {
 		tr.Add(20, 19)
 	}
-	v, changed := tr.Add(21, 20)
+	for i := 0; i < 50; i++ {
+		tr.Add(21, 20)
+	}
+	v, changed := tr.Add(22, 21)
 	if !changed || v != -1 {
 		t.Fatalf("lagging peer verdict = (%d, %v), want (-1, true)", v, changed)
 	}
@@ -36,14 +40,19 @@ func TestLabelOffsetVerdictChangeReportedOnce(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		tr.Add(30, 29)
 	}
-	tr.Add(31, 30) // finalize: -1
-	// Next interval also lags: no new verdict to report.
 	for i := 0; i < 50; i++ {
-		if _, changed := tr.Add(31, 30); changed {
+		tr.Add(31, 30)
+	}
+	if _, changed := tr.Add(32, 31); !changed { // confirmed across two intervals: -1
+		t.Fatal("a persistent -1 was never reported")
+	}
+	// Still lagging: no new verdict to report, however long it goes on.
+	for i := 0; i < 50; i++ {
+		if _, changed := tr.Add(32, 31); changed {
 			t.Fatal("verdict re-reported without change")
 		}
 	}
-	if _, changed := tr.Add(32, 31); changed {
+	if _, changed := tr.Add(33, 32); changed {
 		t.Fatal("same verdict (-1) must not re-report")
 	}
 }
@@ -53,13 +62,64 @@ func TestLabelOffsetRecovery(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		tr.Add(40, 39)
 	}
-	tr.Add(41, 40) // finalize: -1
-	// Peer realigns (entry snap): healthy interval.
 	for i := 0; i < 50; i++ {
-		tr.Add(41, 41)
+		tr.Add(41, 40)
 	}
-	if v, changed := tr.Add(42, 42); !changed || v != 0 {
+	if v, changed := tr.Add(42, 41); !changed || v != -1 {
+		t.Fatalf("setup: want a reported -1 to recover from, got (%d, %v)", v, changed)
+	}
+	// Peer realigns (entry snap): healthy interval. Recovery is not held down —
+	// leaving a stale fault on the books is worse than reporting one early.
+	for i := 0; i < 50; i++ {
+		tr.Add(42, 42)
+	}
+	if v, changed := tr.Add(43, 43); !changed || v != 0 {
 		t.Fatalf("recovery verdict = (%d, %v), want (0, true)", v, changed)
+	}
+}
+
+// The join transition produces exactly this: one interval where the stream's
+// labels and our room index disagree while the labeler is still settling.
+// Reporting it claims a peer is playing intervals late when nothing is wrong,
+// and the operator has no way to tell that from the real thing.
+func TestLabelOffsetIgnoresASingleIntervalBlip(t *testing.T) {
+	var tr LabelOffsetTracker
+	for i := 0; i < 50; i++ {
+		tr.Add(70, 71) // one odd interval: labels read +1
+	}
+	if v, changed := tr.Add(71, 71); changed && v != 0 {
+		t.Fatalf("a one-interval blip reported %+d — join settling reads as a mislabeled peer", v)
+	}
+	// ...and the stream is healthy from here on, so nothing nonzero ever lands.
+	for i := 0; i < 50; i++ {
+		if v, changed := tr.Add(71, 71); changed && v != 0 {
+			t.Fatalf("blip reported late as %+d", v)
+		}
+	}
+	if v, changed := tr.Add(72, 72); changed && v != 0 {
+		t.Fatalf("blip reported at the next roll as %+d", v)
+	}
+	if v, ok := tr.Verdict(); !ok || v != 0 {
+		t.Fatalf("Verdict = (%d, %v), want (0, true)", v, ok)
+	}
+}
+
+// The flip side: a genuinely mislabeled peer must still be reported, one
+// interval later than before. Anything that suppresses the blip has to leave
+// this working, or the tracker stops earning its keep.
+func TestLabelOffsetReportsAPersistentOffset(t *testing.T) {
+	var tr LabelOffsetTracker
+	for i := 0; i < 50; i++ {
+		tr.Add(80, 82)
+	}
+	if _, changed := tr.Add(81, 83); changed {
+		t.Fatal("reported on the first interval — that is the blip case")
+	}
+	for i := 0; i < 50; i++ {
+		tr.Add(81, 83)
+	}
+	if v, changed := tr.Add(82, 84); !changed || v != 2 {
+		t.Fatalf("persistent offset = (%d, %v), want (2, true)", v, changed)
 	}
 }
 
@@ -79,7 +139,10 @@ func TestLabelOffsetClampsExtremeDeltas(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		tr.Add(60, 100) // +40: clamped to +4
 	}
-	if v, changed := tr.Add(61, 61); !changed || v != labelOffsetRange {
+	for i := 0; i < 20; i++ {
+		tr.Add(61, 101)
+	}
+	if v, changed := tr.Add(62, 62); !changed || v != labelOffsetRange {
 		t.Fatalf("clamped verdict = (%d, %v), want (%d, true)", v, changed, labelOffsetRange)
 	}
 }

--- a/wail-app/main.go
+++ b/wail-app/main.go
@@ -33,7 +33,14 @@ func main() {
 	loopback := flag.Bool("loopback", false, "Ask the relay to echo our own audio back; republished as a \"(loopback)\" Link Audio channel (headless mode)")
 	metronomeBroadcast := flag.Bool("metronome-broadcast", false, "Broadcast the WAIL Metronome click to the room as an audio stream (headless mode; debug reference)")
 	instance := flag.Int("instance", 0, "Instance number (separate data dir / identity)")
+	debugMode := flag.Bool("debug", false, "Join the shared \""+DebugRoomName+"\" room with all diagnostics armed (metronome broadcast, server-echo loopback, peer log sharing). Add -room to use a private debug room instead. Note: this shares this machine's logs, including Link Audio channel names, with everyone in the room")
 	flag.Parse()
+
+	// -debug picks the room so a tester needs one flag, not two; an explicit
+	// -room still wins, which is how you get an isolated debug session.
+	if *debugMode && *room == "" {
+		*room = DebugRoomName
+	}
 
 	// Initialize Honeybadger error reporting
 	InitHoneybadger()
@@ -70,7 +77,7 @@ func main() {
 	log.Printf("App initialized — identity: %s", appBackend.identity)
 
 	if *headless {
-		runHeadless(appBackend, *room, *password, *bpmFlag, *name, *wavFile, *testTone, *loopback, *metronomeBroadcast)
+		runHeadless(appBackend, *room, *password, *bpmFlag, *name, *wavFile, *testTone, *loopback, *metronomeBroadcast, *debugMode)
 		return
 	}
 
@@ -126,6 +133,9 @@ func main() {
 				return
 			}
 			log.Printf("Joined room %q as peer %s", result.Room, result.PeerID)
+			if *debugMode {
+				appBackend.ArmDebugDiagnostics()
+			}
 		}()
 	}
 
@@ -136,9 +146,9 @@ func main() {
 	}
 }
 
-func runHeadless(app *App, room, password string, bpm float64, name, wavFile string, testTone, loopback, metronomeBroadcast bool) {
+func runHeadless(app *App, room, password string, bpm float64, name, wavFile string, testTone, loopback, metronomeBroadcast, debugMode bool) {
 	if room == "" {
-		log.Fatal("-room is required in headless mode")
+		log.Fatal("-room is required in headless mode (or pass -debug to use the shared debug room)")
 	}
 
 	app.SetEmitter(&NoopEmitter{})
@@ -160,6 +170,11 @@ func runHeadless(app *App, room, password string, bpm float64, name, wavFile str
 		log.Fatalf("Failed to join room: %v", err)
 	}
 	log.Printf("Joined room %q as peer %s", result.Room, result.PeerID)
+
+	// Before the individual flags below, which are then just no-op re-sets.
+	if debugMode {
+		app.ArmDebugDiagnostics()
+	}
 
 	if wavFile != "" {
 		streamIdx := uint16(0)

--- a/wail-app/main.go
+++ b/wail-app/main.go
@@ -50,6 +50,7 @@ func main() {
 	log.Println("WAIL - WebSocket Audio Interchange for Link (Go/Wails)")
 
 	appBackend := NewApp(*instance)
+	appBackend.SetDebugMode(*debugMode)
 
 	// Set up rotating file logger + WebSocket log broadcaster
 	logDir := filepath.Join(appBackend.dataDir, "logs")

--- a/wail-app/session.go
+++ b/wail-app/session.go
@@ -529,12 +529,12 @@ func sessionLoop(
 					// Undo any earlier drop: nothing else ever will, since the echo
 					// identity never sends StreamNames, and a drop left in force
 					// retires the monitor channels the next time frames pause.
-					audioEngine.ClearPeerIntent(identity + ":loopback")
+					audioEngine.ClearPeerIntent(identity + loopbackIdentitySuffix)
 				} else {
 					// The echo stops, so no StreamNames or PeerLeft will ever reach
 					// these — retire them explicitly or the monitor channels stay
 					// published for the rest of the session.
-					audioEngine.DropPeer(identity + ":loopback")
+					audioEngine.DropPeer(identity + loopbackIdentitySuffix)
 				}
 				logInfo("[loopback] server echo enabled=%v", cmd.Enabled)
 			case "SetMetronome":
@@ -919,7 +919,7 @@ func sessionLoop(
 				audioBytesRecv += uint64(len(data))
 				intervalFramesRecv++
 				intervalBytesRecv += uint64(len(data))
-				audioEngine.HandleRemoteAudio(identity+":loopback", displayName+" (loopback)", loopStreamName, data)
+				audioEngine.HandleRemoteAudio(identity+loopbackIdentitySuffix, displayName+" (loopback)", loopStreamName, data)
 				continue
 			}
 


### PR DESCRIPTION
Restores the debug-room entry point, so getting diagnostics out of a tester is one flag and nothing else — and fixes a false-positive warning that the first debug session immediately exposed.

Three commits, deliberately separate. The middle one is a `fix:` that stands on its own: it affects real peers, not just debug sessions.

## What it does

`wail-app -debug` — GUI or headless — joins the shared `wail-debug` room and arms the metronome broadcast, server-echo loopback, and peer log sharing. An explicit `-room` still wins, so `-debug -room debug-geren` gives an isolated session when you don't want testers landing on top of each other's audio.

`-debug` also **implies developer mode** in the GUI, so the Debug tab (stream offsets, cushion) is present without talking anyone through a checkbox. Arming the diagnostics but hiding the readout was the worst of both. The saved preference is deliberately not written — relaunch without the flag and you get whatever you had — and unticking Developer mode still wins for the session, since an explicit choice should outrank an implied one.

So the tester instruction is now exactly: **run it with `-debug`.**

## The button was already gone

`App.DebugRoom` was still in `app.go` doing exactly the right thing — and **had no caller**. The frontend button had been dropped, so the method was orphaned; `SetLogSharing(true)` inside it was a no-op too, since log sharing is armed unconditionally at startup now.

So this rewires the button rather than writing anything new, and points both it and the flag at one shared `ArmDebugDiagnostics()`. That matters more than it looks: if the button and the flag arm different things, captures from different testers aren't comparable.

## The label-offset false positive (`ee2a3ec`)

The first debug session logged `loopback stream 65281 labels intervals off by +1 — their audio plays 1 interval(s) late`. My first read was "loopback should be exempt from this check". Measuring said otherwise: run across ~8 intervals and the warning **never fires**, so the `+1` was a join-transition transient, not a loopback condition. Exempting loopback would have hidden it in one place and left it firing for real peers.

The real defect is in `LabelOffsetTracker`: it finalized a verdict from a **single** interval. The one odd interval a join transition produces while the labeler settles got reported as "their audio plays N intervals late" — indistinguishable in the log from the genuine fault the check exists to catch. And that check earns its place: the relay's own logs show peers landing **−567** and **+8091** intervals out.

A nonzero delta now has to hold for two consecutive finalized intervals. A real offset is stuck, so it survives the wait and is reported one interval later. Recovery to zero still publishes immediately — leaving a stale fault on the books is worse than reporting one early. Intervals too sparse to finalize neither confirm nor break a run, since they carry no evidence either way.

Loopback still gets its own wording rather than an exemption — a self-echo disagreement is our own labeler against our own room clock, which is worth seeing, it just isn't a peer to chase. The `":loopback"` suffix that was scattered as a literal across three call sites is now one constant.

## Privacy

Debug sessions share the room's log stream, which carries Link Audio channel names — the tester's **DAW track names** — with everyone in the room. Both entry points say so in the log when they arm, and DEVELOPMENT.md calls it out as something to mention before pointing testers at the shared room. Flagging it because "encourage testers to run this" is the point of the change, and the shared room makes it everyone's track names, not just ours.

Issue #506 proposes a bounded counters-only beacon as the better long-term answer — collectable days later from Fly with no live collector, and no track names.

## Collecting

Pairs with `wail-logstore -room wail-debug` (#501) while a tester is connected. Peer logs can't be backfilled, so the collector has to be running at the time — which is the main argument for #506.

## Testing

- Full `wail-app` suite green in **both** build modes; `gofmt`, `go vet` clean; `node --check` on both touched JS files
- `./scripts/tier2-e2e.sh`: **PASS** — 0 loss, 4/4 placement (re-run against each commit)
- Both new tracker tests fail red against the old code with the exact field symptom (`a one-interval blip reported +1`) and pass after. Three existing tests encoded the old first-interval contract and were updated to the new one, each still checking its original property
- Smoke-tested against the live relay on a private room, before and after the fix:

```
[app] debug diagnostics armed: metronome broadcast + loopback + log sharing
      (this machine's logs, including Link Audio channel names, are shared with the room)
[session] [metronome] broadcast to room started
[session] [loopback] server echo enabled=true
[audio] publishing Link Audio channel "WAIL · fixtest (loopback) · Metronome"
```

…and the spurious `labels intervals off` line is gone from the join.

## One thing worth a second pair of eyes

`openSettings()` read the *stored* developer-mode value directly, so under `-debug` it would have shown the box unticked and switched the Debug tab off on save. Everything that asks "is developer mode on" now goes through `developerModeActive()`. Worth checking I haven't missed a caller.

<sub>Co-authored by a very tired language model.</sub>