### PR TITLE
fix: declare dladdr properly, and run the build workflow on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     # head_commit exists only on push; on a pull request it is null and the
     # expression would rely on null-coercion to keep the job running. Say it
     # outright instead — the skip is about release-prep pushes to main.
-    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: prepare release')
+    if: "github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: prepare release')"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -68,7 +68,7 @@ jobs:
     # head_commit exists only on push; on a pull request it is null and the
     # expression would rely on null-coercion to keep the job running. Say it
     # outright instead — the skip is about release-prep pushes to main.
-    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: prepare release')
+    if: "github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: prepare release')"
     env:
       CCACHE_BASEDIR: ${{ github.workspace }}
       CCACHE_NOHASHDIR: "true"
@@ -184,7 +184,7 @@ jobs:
     # head_commit exists only on push; on a pull request it is null and the
     # expression would rely on null-coercion to keep the job running. Say it
     # outright instead — the skip is about release-prep pushes to main.
-    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: prepare release')
+    if: "github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: prepare release')"
     env:
       CCACHE_BASEDIR: ${{ github.workspace }}
       CCACHE_NOHASHDIR: "true"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,17 +3,28 @@ name: Build
 on:
   push:
     branches: [main, "claude/**"]
+  # Without this, nothing here ran before a merge — the Linux plugin job in
+  # particular, which is the only place a glibc-only build break can surface.
+  # One did (the dladdr fix in this PR): green on macOS, green through review,
+  # red the moment it landed on main.
+  pull_request:
   merge_group:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  # ref_name, not ref, so a push to claude/** and the pull request from that
+  # same branch land in one group and the duplicate is cancelled rather than
+  # run twice: push gives refs/heads/claude/x where the PR gives claude/x.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   build-macos:
     runs-on: macos-latest
-    if: "!startsWith(github.event.head_commit.message, 'chore: prepare release')"
+    # head_commit exists only on push; on a pull request it is null and the
+    # expression would rely on null-coercion to keep the job running. Say it
+    # outright instead — the skip is about release-prep pushes to main.
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: prepare release')
     steps:
       - uses: actions/checkout@v6
         with:
@@ -54,7 +65,10 @@ jobs:
     # MinGW GCC + CMake). windows-latest rolled over to the 2025/2026 image
     # whose newer toolchain breaks the CGo builds. See #329.
     runs-on: windows-2022
-    if: "!startsWith(github.event.head_commit.message, 'chore: prepare release')"
+    # head_commit exists only on push; on a pull request it is null and the
+    # expression would rely on null-coercion to keep the job running. Say it
+    # outright instead — the skip is about release-prep pushes to main.
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: prepare release')
     env:
       CCACHE_BASEDIR: ${{ github.workspace }}
       CCACHE_NOHASHDIR: "true"
@@ -167,7 +181,10 @@ jobs:
 
   build-linux:
     runs-on: ubuntu-22.04
-    if: "!startsWith(github.event.head_commit.message, 'chore: prepare release')"
+    # head_commit exists only on push; on a pull request it is null and the
+    # expression would rely on null-coercion to keep the job running. Say it
+    # outright instead — the skip is about release-prep pushes to main.
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: prepare release')
     env:
       CCACHE_BASEDIR: ${{ github.workspace }}
       CCACHE_NOHASHDIR: "true"

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -90,6 +90,15 @@ else()
   target_link_libraries(wail-link PUBLIC m atomic)
 endif()
 
+# dladdr (wail_link.h's build stamp) is a GNU extension: glibc only declares it
+# under _GNU_SOURCE, and it lived in libdl before glibc 2.34. PUBLIC so every
+# consumer of the header compiles with it — the macro must precede the first
+# libc header, which rules out defining it in the header itself.
+if(NOT WIN32)
+  target_compile_definitions(wail-link PUBLIC _GNU_SOURCE)
+  target_link_libraries(wail-link PUBLIC ${CMAKE_DL_LIBS})
+endif()
+
 function(add_wail_link_plugin name)
   add_library(${name} MODULE ${ARGN})
   target_include_directories(${name} PRIVATE "${CLAP_INCLUDE}" "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/plugins/wail_link.h
+++ b/plugins/wail_link.h
@@ -9,6 +9,18 @@
 // lock-free by design).
 #pragma once
 
+// glibc hides dladdr behind __USE_GNU, so <dlfcn.h> only declares it when
+// _GNU_SOURCE is defined before the first libc header — and an implicit
+// declaration is an error, not a warning, on current GCC/Clang. It cannot be
+// defined here: every consumer includes <stdio.h> and friends before this
+// header, so by now it would be too late. The build system defines it
+// (plugins/CMakeLists.txt); this only catches a build that forgets, with a
+// legible message instead of an implicit-declaration error deep in a macro.
+// macOS declares dladdr unconditionally, which is why this was invisible here.
+#if defined(__linux__) && !defined(_GNU_SOURCE)
+#error "define _GNU_SOURCE for this translation unit — dladdr needs it on glibc"
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
Two changes with one root cause: **`build.yml` never ran on pull requests**, so a platform-specific break could only surface after merge. One did.

## 1. The break — `dladdr` on Linux

#498 put `dladdr` into `wail_link.h` for the plugin build stamp. glibc only declares it when `_GNU_SOURCE` is defined **before the first libc header**, and current GCC/Clang treat an implicit declaration as an error. macOS declares it unconditionally, so this was green locally, green through review, and red the moment it reached main.

The macro cannot live in the header: `wail_recv.c` and `wail_send.c` both include `<math.h>`, `<stdio.h>` and friends *before* `wail_link.h`, so by then the libc headers are already expanded. It goes on the target — `PUBLIC`, so consumers inherit it — with `CMAKE_DL_LIBS` for glibc before 2.34 when `dladdr` lived in libdl. The header keeps a guard so any other build system that forgets gets a legible message instead of an implicit-declaration error inside a macro:

```c
#if defined(__linux__) && !defined(_GNU_SOURCE)
#error "define _GNU_SOURCE for this translation unit — dladdr needs it on glibc"
#endif
```

## 2. The reason it escaped — no PR coverage

The workflow triggered on pushes to `main` and `claude/**` only. Adding `pull_request` was two lines; two details around it were not:

**Duplicate runs.** A push to `claude/**` and the PR from that same branch would both run. The concurrency key used `github.ref`, which gives `refs/heads/claude/x` for the push and `claude/x` for the PR — different groups, so both ran to completion. Now keyed on `ref_name`, which normalises both to `claude/x` so the duplicate is cancelled. Visible in this branch's run list: `pull_request: success`, `push: cancelled`.

**The release-prep skip.** Three jobs carried `!startsWith(github.event.head_commit.message, ...)`. `head_commit` exists only on `push`; on a pull request it is null, so the guard was relying on null-coercion to keep those jobs running at all. Now tested explicitly against `github.event_name`.

## Verified

The Linux job is not reproducible on macOS and there's no local Docker, so this branch was named to match the `claude/**` trigger and let the real runner prove it.

- Push run [30691066026](https://github.com/MostDistant/WAIL/actions/runs/30691066026) — `build-linux: success`, compiling and linking `wail-recv.clap` and passing ctest
- Pull-request run — `build-linux`, `build-windows`, `build-macos` all green, which is the trigger working
- macOS plugin build and the full Go suite clean locally

One self-inflicted detour worth recording: the first version of the workflow edit left the `if:` expressions unquoted, and YAML treats `!` as a tag indicator wherever it follows whitespace — so `!=` and `!startsWith` broke the parse and the workflow produced a run with zero jobs and no logs. The originals were quoted for exactly that reason. Fixed, and validated with a parser rather than by eye.

Claude Code: present but not responsible
