### PR TITLE
fix: the remaining review findings from #498 and #499

### DIFF
--- a/plugins/wail_link.h
+++ b/plugins/wail_link.h
@@ -89,6 +89,10 @@ static inline void lb_module_stamp(char *stamp, unsigned long stampCap, char *pa
    time_t   mt = st.st_mtime;
    struct tm tmv;
 #ifdef _WIN32
+   // MSVCRT's localtime_s(struct tm*, const time_t*) — what MinGW-w64 gives
+   // by default. Deliberately NOT C11 Annex K's localtime_s, whose arguments
+   // are the other way round and which appears if __STDC_WANT_LIB_EXT1__ is
+   // ever defined. Same name, reversed signature: worth stating.
    if (localtime_s(&tmv, &mt) != 0) return;
 #else
    if (!localtime_r(&mt, &tmv)) return;

--- a/plugins/wail_recv.c
+++ b/plugins/wail_recv.c
@@ -53,6 +53,9 @@
 // prefix would subscribe raw LAN channels that merely start with "WAIL" — a
 // WAIL Send track named "WAIL Bass" would come back as a receive port.
 #define LBR_ROOM_PREFIX "WAIL · "
+// Length of the literal above, compile-time — the filter runs it per channel
+// per poll in three places.
+#define LBR_ROOM_PREFIX_LEN (sizeof(LBR_ROOM_PREFIX) - 1)
 #define LBR_GONE_POLLS 6 // ~3s of discovery misses → slot freed
 
 typedef struct {
@@ -316,7 +319,7 @@ static void set_port_name(lbr_recv *self, int slot, const char *name) {
 
 // display_name strips the room-published dot-prefix for the port label.
 static const char *display_name(const char *chan, char *buf, size_t cap) {
-   size_t p = strlen(LBR_ROOM_PREFIX);
+   size_t p = LBR_ROOM_PREFIX_LEN;
    if (strncmp(chan, LBR_ROOM_PREFIX, p) == 0) {
       snprintf(buf, cap, "%s", chan + p);
       return buf;
@@ -354,7 +357,7 @@ static void log_snapshot(lbr_recv *self, const lb_channel_info *chans, size_t nc
       // on the LAN — another app's tracks being renamed or armed — would
       // otherwise churn the signature and dump the table for something we
       // never act on.
-      if (strncmp(chans[c].name, LBR_ROOM_PREFIX, strlen(LBR_ROOM_PREFIX)) != 0) continue;
+      if (strncmp(chans[c].name, LBR_ROOM_PREFIX, LBR_ROOM_PREFIX_LEN) != 0) continue;
       sig += lbr_entry_hash(chans[c].id_u64, chans[c].name);
    }
    for (int i = 0; i < LBR_SLOTS; i++)
@@ -365,7 +368,7 @@ static void log_snapshot(lbr_recv *self, const lb_channel_info *chans, size_t nc
    self->snapshot_sig = sig;
 
    for (size_t c = 0; c < nch; c++) {
-      if (strncmp(chans[c].name, LBR_ROOM_PREFIX, strlen(LBR_ROOM_PREFIX)) != 0) continue;
+      if (strncmp(chans[c].name, LBR_ROOM_PREFIX, LBR_ROOM_PREFIX_LEN) != 0) continue;
       lbr_log(self, "  chan id=%016llx name=\"%s\"", (unsigned long long)chans[c].id_u64,
               chans[c].name);
    }
@@ -419,7 +422,7 @@ static void *mgr_main(void *arg) {
 
       // Assign new room-published channels.
       for (size_t c = 0; c < nch; c++) {
-         if (strncmp(chans[c].name, LBR_ROOM_PREFIX, strlen(LBR_ROOM_PREFIX)) != 0) continue;
+         if (strncmp(chans[c].name, LBR_ROOM_PREFIX, LBR_ROOM_PREFIX_LEN) != 0) continue;
 
          // Already ours? Match on channel id first, so an in-place rename
          // relabels the port this channel already holds instead of taking a

--- a/plugins/wail_send.c
+++ b/plugins/wail_send.c
@@ -171,6 +171,16 @@ static bool CLAP_ABI lbs_activate(const clap_plugin_t *plugin, double sr, uint32
 }
 static void CLAP_ABI lbs_deactivate(const clap_plugin_t *plugin) {
    lb_send *self = plugin->plugin_data;
+   // Flush a first-commit result the main thread never got to write.
+   // request_callback is optional in CLAP, so a host that omits it would
+   // otherwise drop this line entirely — including its WITHHELD case, which
+   // is the one worth having. Recv has no equivalent problem: its manager
+   // thread always runs. Safe here because process() has stopped by now.
+   if (atomic_load_explicit(&self->commit_pending, memory_order_acquire)) {
+      atomic_store_explicit(&self->commit_pending, false, memory_order_relaxed);
+      lbs_log(self, "first commit: %s (frames=%u)",
+              self->commit_ok ? "ok" : "WITHHELD (no source subscribed?)", self->commit_frames);
+   }
    if (self->sink) {
       lb_sink_destroy(self->sink);
       self->sink = NULL;

--- a/signaling-server/logmirror_test.go
+++ b/signaling-server/logmirror_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Every field on this path is unauthenticated client input, and it is written
+// into the operator's log. The newline case is the one that matters: it lets a
+// client forge whole log lines and assert anything about any room.
+func TestSanitizeForLog(t *testing.T) {
+	long := strings.Repeat("a", maxServerLoggedMessage+50)
+
+	cases := []struct {
+		name, in string
+		check    func(*testing.T, string)
+	}{
+		{"newline cannot forge a line", "grid jumped\nroom evil peer x error [align] owned", func(t *testing.T, got string) {
+			if strings.Contains(got, "\n") {
+				t.Fatalf("newline survived: %q", got)
+			}
+		}},
+		{"carriage return and tab go too", "a\rb\tc", func(t *testing.T, got string) {
+			if strings.ContainsAny(got, "\r\t") {
+				t.Fatalf("control char survived: %q", got)
+			}
+		}},
+		{"other control chars go", "a\x00b\x1bc", func(t *testing.T, got string) {
+			for _, r := range got {
+				if r < 0x20 {
+					t.Fatalf("control char survived: %q", got)
+				}
+			}
+		}},
+		{"over-length is truncated", long, func(t *testing.T, got string) {
+			if len(got) > maxServerLoggedMessage+len("…(truncated)") {
+				t.Fatalf("not truncated: %d bytes", len(got))
+			}
+			if !strings.HasSuffix(got, "(truncated)") {
+				t.Fatalf("truncation not marked: %q", got)
+			}
+		}},
+		// One ASCII byte then two-byte runes, so the byte cap lands INSIDE a
+		// rune. Without the odd prefix the cut is rune-aligned by luck and the
+		// case proves nothing — verified by mutation.
+		{"truncation keeps valid utf-8", "a" + strings.Repeat("é", maxServerLoggedMessage), func(t *testing.T, got string) {
+			// NOT ValidString: range-over-string yields U+FFFD for a broken
+			// rune and WriteRune re-encodes it, so the output is always valid
+			// UTF-8 and that assertion can never fail. The observable symptom
+			// is the replacement character itself.
+			if strings.ContainsRune(got, '\uFFFD') {
+				t.Fatal("truncation cut a multi-byte rune (U+FFFD in output)")
+			}
+		}},
+		{"ordinary text is untouched", "grid jumped +5.22 beats — cause: Link session merge", func(t *testing.T, got string) {
+			if got != "grid jumped +5.22 beats — cause: Link session merge" {
+				t.Fatalf("mangled: %q", got)
+			}
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) { c.check(t, sanitizeForLog(c.in)) })
+	}
+}
+
+// The gate exists to stay narrow as the code around it moves: peers already
+// echo each other's logs, so mirroring anything broader multiplies a room's
+// chatter into the operator's log.
+func TestShouldMirrorToServerLog(t *testing.T) {
+	cases := []struct {
+		level, target string
+		want          bool
+	}{
+		{"warn", "align", true},
+		{"error", "align", true},
+		{"info", "align", false},
+		{"debug", "align", false},
+		{"warn", "", false},
+		{"warn", "session", false},
+		{"error", "audio", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		if got := shouldMirrorToServerLog(c.level, c.target); got != c.want {
+			t.Errorf("shouldMirrorToServerLog(%q, %q) = %v, want %v", c.level, c.target, got, c.want)
+		}
+	}
+}

--- a/signaling-server/main.go
+++ b/signaling-server/main.go
@@ -19,6 +19,7 @@ import (
 	"sync/atomic"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/gorilla/websocket"
 	"golang.org/x/crypto/bcrypt"
@@ -771,18 +772,35 @@ const serverLoggedTarget = "align"
 // websocket read limit, and this text reaches the operator's log pipeline.
 const maxServerLoggedMessage = 512
 
+// shouldMirrorToServerLog reports whether a client log line is mirrored into
+// the relay's own log. Deliberately narrow, and a named predicate so it stays
+// that way: every field below is unauthenticated client input, and peers
+// already echo each other's logs, so widening this multiplies a room's chatter
+// into the operator's log.
+func shouldMirrorToServerLog(level, target string) bool {
+	return target == serverLoggedTarget && (level == "warn" || level == "error")
+}
+
 // sanitizeForLog makes an unauthenticated client string safe to write into the
-// relay's log: control characters (newlines above all — they let a client forge
-// whole log lines and assert anything about any room) become spaces, and the
-// result is truncated.
+// relay's log. Every control character becomes a space — the newline above all,
+// since it lets a client forge whole log lines and assert anything about any
+// room — and the result is truncated on a rune boundary.
 func sanitizeForLog(s string) string {
 	if len(s) > maxServerLoggedMessage {
-		s = s[:maxServerLoggedMessage] + "…(truncated)"
+		// Back up to a rune start: slicing bytes can cut a multi-byte rune in
+		// half and emit a replacement character.
+		cut := maxServerLoggedMessage
+		for cut > 0 && !utf8.RuneStart(s[cut]) {
+			cut--
+		}
+		s = s[:cut] + "…(truncated)"
 	}
 	var b strings.Builder
 	b.Grow(len(s))
 	for _, r := range s {
-		if r == '\n' || r == '\r' || r == '\t' || unicode.IsControl(r) {
+		// IsControl already covers \n, \r, \t and everything else below 0x20;
+		// listing them separately as well was dead.
+		if unicode.IsControl(r) {
 			b.WriteByte(' ')
 			continue
 		}
@@ -807,9 +825,11 @@ func (h *hub) broadcastLog(room, peerID string, c *conn, msg clientMsg) {
 	// stream. Peers already echo each other's logs, so mirroring everything
 	// would multiply a room's chatter into the operator's log — and every
 	// field here is unauthenticated client input.
-	if msg.Target == serverLoggedTarget && (msg.Level == "warn" || msg.Level == "error") {
-		log.Printf("room %s peer %s %s [%s] %s", room, peerID, msg.Level, msg.Target,
-			sanitizeForLog(msg.Message))
+	if shouldMirrorToServerLog(msg.Level, msg.Target) {
+		// room and peerID are client-supplied too — join() takes both verbatim —
+		// so sanitizing only the message left half the line forgeable.
+		log.Printf("room %s peer %s %s [%s] %s", sanitizeForLog(room), sanitizeForLog(peerID),
+			msg.Level, msg.Target, sanitizeForLog(msg.Message))
 	}
 	raw, err := json.Marshal(map[string]any{
 		"type": "log", "from": peerID, "level": msg.Level,

--- a/wail-app/audio_engine_real.go
+++ b/wail-app/audio_engine_real.go
@@ -521,8 +521,13 @@ func (e *linkAudioEngine) RoomIndex(localIndex int64) (int64, bool) {
 func (e *linkAudioEngine) OnGridSnap(deltaUs int64) {
 	// Recorded before the early return: a backward snap moves the grid too,
 	// so it must still be attributable when the detector sees it.
-	e.lastSnapAtNs.Store(time.Now().UnixNano())
+	//
+	// Magnitude first, timestamp second — the timestamp publishes the pair.
+	// Storing the other way round let a reader land between the two and match
+	// a fresh timestamp against the PREVIOUS snap's magnitude; they disagree,
+	// the snap reads as an external jump, and that costs an audible re-entry.
 	e.lastSnapDeltaUs.Store(deltaUs)
+	e.lastSnapAtNs.Store(time.Now().UnixNano())
 	if deltaUs <= 0 {
 		return // backward jump: the playhead pauses; nothing to skip
 	}
@@ -1260,9 +1265,7 @@ func (e *linkAudioEngine) sweepRetiredLocked(now time.Time, roomLabel int64) {
 			// discards it. Count it so the log can say so — silently dropping
 			// a decoded backlog is exactly the kind of thing that should not
 			// have to be inferred later.
-			if max, ok := st.reasm.MaxIndex(); ok {
-				backlog = int(max-min) + 1
-			}
+			backlog = st.reasm.Count()
 		}
 		e.retireStreamLocked(key, st, backlog)
 	}
@@ -1388,6 +1391,8 @@ func (e *linkAudioEngine) classifyGridJump(beats, roomBPM, sessionBPM float64, p
 // it so nothing ever re-aligns. The record is consumed, so one snap can explain
 // at most one jump.
 func (e *linkAudioEngine) matchesOwnSnap(ms float64, now time.Time) bool {
+	// Timestamp first, magnitude second — the mirror of OnGridSnap's store
+	// order, so seeing a fresh timestamp guarantees its magnitude is visible.
 	at := e.lastSnapAtNs.Load()
 	if at == 0 || now.Sub(time.Unix(0, at)) >= gridSnapAttributionWindow {
 		return false
@@ -1517,27 +1522,35 @@ func (e *linkAudioEngine) emitLoop() {
 			if beatBPM <= 0 {
 				beatBPM = tempo
 			}
-			if d := localBeat - lastBeat; haveLastBeat && isGridJump(d, elapsed, beatBPM) {
-				{
-					jump := e.classifyGridJump(d, beatBPM, sessionBPM, peers, ev, bpi, time.Now())
-					log.Printf("[audio] WARN: local Link beat jumped %+.2f beats (%+.0f ms, expected %+.2f from elapsed time) — cause: %s; %s",
-						jump.Beats, jump.Ms, elapsed*beatBPM/60.0, jump.Cause, jump.Detail)
-					// Our own snap moves the grid on purpose. Re-entering
-					// conformance over it would re-measure a grid we just
-					// aligned, and reporting it as a jump would send everyone
-					// hunting a merge that never happened.
-					e.noteGridJump(jump)
-				}
+			// Whether a PREVIOUS tick exists to compare against. Read before
+			// the assignment below sets it, or every guard downstream is
+			// trivially true.
+			hadPrevTick := haveLastBeat
+			if d := localBeat - lastBeat; hadPrevTick && isGridJump(d, elapsed, beatBPM) {
+				jump := e.classifyGridJump(d, beatBPM, sessionBPM, peers, ev, bpi, time.Now())
+				log.Printf("[audio] WARN: local Link beat jumped %+.2f beats (%+.0f ms, expected %+.2f from elapsed time) — cause: %s; %s",
+					jump.Beats, jump.Ms, elapsed*beatBPM/60.0, jump.Cause, jump.Detail)
+				// Our own snap moves the grid on purpose. Re-entering
+				// conformance over it would re-measure a grid we just
+				// aligned, and reporting it as a jump would send everyone
+				// hunting a merge that never happened.
+				e.noteGridJump(jump)
 			}
 			lastBeat, lastBeatAt, haveLastBeat = localBeat, float64(clockMicros)/1e6, true
 			// Remember *when* the evidence last moved, not just the previous
 			// tick's values: peer discovery and the timeline merge it causes
 			// are tens of milliseconds apart, so comparing across one tick
 			// reports the merge it exists to name as "unattributed".
-			if haveLastBeat && peers != lastPeers {
+			//
+			// Skipped on the bootstrap tick: lastPeers and lastSessionBPM are
+			// still zero there, so both would "change" and seed evidence of a
+			// 0→N merge and a 0→120 BPM move. A genuine jump in the next few
+			// seconds would then be blamed on that fiction — and startup is
+			// when a real merge is most likely.
+			if hadPrevTick && peers != lastPeers {
 				ev.peersChangedAt, ev.peersFrom = time.Now(), lastPeers
 			}
-			if haveLastBeat && math.Abs(sessionBPM-lastSessionBPM) > 0.01 {
+			if hadPrevTick && math.Abs(sessionBPM-lastSessionBPM) > 0.01 {
 				ev.tempoChangedAt, ev.tempoFrom = time.Now(), lastSessionBPM
 			}
 			lastPeers, lastSessionBPM = peers, sessionBPM

--- a/wail-app/internal/align/steerer.go
+++ b/wail-app/internal/align/steerer.go
@@ -31,8 +31,12 @@ const (
 	// hand, remote change, or entry adoption) so WAIL never fights a hand
 	// on the tempo knob. Deliberately longer than the 150ms echo guard.
 	tempoGate = 3 * time.Second
-	// tempoThreshold mirrors the Link poller's tempoChangeThreshold (0.01
-	// BPM): below it two tempos are "the same" for adoption decisions.
+	// tempoThreshold is the equality epsilon for adoption decisions: below it
+	// two tempos are "the same". It matches the detector's tempoSteadyBand
+	// (link_types.go), which asks a different question — has a reading stopped
+	// moving — and is deliberately NOT the detector's reporting bar, which is
+	// far coarser. It used to be described as mirroring a single shared
+	// constant; that constant was split, and the mirroring stopped being true.
 	tempoThreshold = 0.01
 	// slewPersistenceTicks is how many consecutive ticks δ must hold outside
 	// the deadband in the same direction before the slew acts. Real grid
@@ -262,7 +266,7 @@ func (s *Steerer) Tick(bpi float64, now time.Time) {
 		// — publishing that at tick rate would trade a stale number for a
 		// meaningless one. The bucket still moves if things get materially
 		// worse, and the recovery paths bound how long this can last.
-		s.emitBucket(delta)
+		s.emitBucket(delta, now)
 		s.noteGateShut(now, roomBPM, st.BPM)
 		return
 	}
@@ -488,7 +492,6 @@ func (s *Steerer) measureDelta(bpi float64) (int64, bool) {
 	return s.aligner.Delta(s.link.TimeAtBeat(boundaryBeat))
 }
 
-// emitState reports the bucketed alignment state on change only.
 // sameRateBand is how far the session tempo may sit from the slew's baseline
 // before δ stops meaning anything. Proportional, not the flat adoption
 // threshold it used to share: the gate exists to avoid fighting a real tempo
@@ -608,9 +611,13 @@ func (s *Steerer) emitState(deltaUs int64, now time.Time) {
 
 // emitBucket reports a state change only, ignoring δ movement — for ticks
 // where the measurement itself is not trustworthy enough to publish.
-func (s *Steerer) emitBucket(deltaUs int64) {
+func (s *Steerer) emitBucket(deltaUs int64, now time.Time) {
 	if state := stateName(deltaUs); state != s.lastState {
-		s.publish(state, deltaUs, time.Time{})
+		// now, not the zero time: publishing with a zero stamp left lastEmitAt
+		// zero, and the next emitState then saw IsZero() and skipped the
+		// same-bucket rate limit entirely — a gated stretch quietly re-armed
+		// the limiter it was supposed to be bounded by.
+		s.publish(state, deltaUs, now)
 	}
 }
 

--- a/wail-app/internal/emit/reassembler.go
+++ b/wail-app/internal/emit/reassembler.go
@@ -216,6 +216,12 @@ func (r *Reassembler) MinIndex() (min int64, ok bool) {
 	return min, ok
 }
 
+// Count returns how many intervals are currently buffered. Distinct from the
+// index span MaxIndex−MinIndex: the buffer is a map, and the sender this is
+// reported for — one whose labels run far from ours — is exactly what makes it
+// sparse, so a span would claim 96 for two held intervals.
+func (r *Reassembler) Count() int { return len(r.partials) }
+
 // Drop discards any partial for interval `index` and every earlier interval
 // (they can never be played once we've moved past them).
 func (r *Reassembler) Drop(upToInclusive int64) {


### PR DESCRIPTION
The mechanical half of the review — ten findings, no design changes. The tempo-threshold work those reviews also raised is deliberately not here: it's blocked on a simulation harness, per the design session.

`dladdr` and the missing PR CI coverage already went out in #505.

### Defects

**Torn read in snap attribution** (`audio_engine_real.go`) — the timestamp was stored before the magnitude, so a reader landing between the two paired a fresh timestamp with the previous snap's delta. Magnitudes then disagree, our own deliberate snap reads as an external jump, and that costs an audible re-entry. Magnitude stores first and the timestamp publishes the pair; the load order was already the correct mirror, so it's annotated rather than changed.

**Retirement log counted an index span** — the reassembler is a map, and the sender this line describes (one whose labels run far from ours) is exactly what makes it sparse, so two intervals held at 5 and 100 reported as 96. Adds `Reassembler.Count`.

**Two dead guards, and fabricated bootstrap evidence** — both `haveLastBeat &&` conditions sat one line below `haveLastBeat = true`. On the first tick `lastPeers`/`lastSessionBPM` are still zero, so both fired and seeded evidence of a `0→N` peer merge and a `0→120 BPM` move; a genuine jump in the next three seconds would have been attributed to that fiction. At startup — which is when a real merge is most likely.

**`emitBucket` disarmed its own rate limiter** — publishing with the zero time left `lastEmitAt` zero, so the next `emitState` saw `IsZero()` and skipped the same-bucket limit entirely.

**Send's first-commit diagnostic could never print** — moving it off the audio thread in #498 made it depend on `request_callback`, which CLAP does not require a host to implement. A host omitting it never drains the flag, losing the line including its `WITHHELD (no source subscribed?)` case, which is the one worth having. Also drained in `deactivate`.

**Relay log injection was half-closed** — `sanitizeForLog` scrubbed the message, but `room` and `peerID` were interpolated raw on the same line and `join()` takes both verbatim from the client. Both now go through it. Sanitising at the log site rather than validating at join, deliberately: validation is better defence in depth but would reject room names already in the SQLite store.

**Two sanitiser bugs** — the explicit `\n`/`\r`/`\t` checks were dead (`unicode.IsControl` covers everything below 0x20), and truncation sliced bytes so it could cut a multi-byte rune and emit a replacement character.

### Tidying

Stray nested block from an edit; the repeated `strlen(LBR_ROOM_PREFIX)` replaced with a compile-time length; a note on which `localtime_s` the Windows branch means (MSVCRT's, not C11 Annex K's reversed signature of the same name); two comments describing constants that no longer exist.

### Tests

Security-motivated code that shipped with none now has a table over `sanitizeForLog` and one pinning the mirror gate.

The truncation case took three attempts to write honestly, which is worth recording: a `strings.Repeat("é", 512)` input is rune-aligned at the 512-byte cap and proves nothing, and asserting `utf8.ValidString` can *never* fail because range-over-string yields U+FFFD and `WriteRune` re-encodes it. It now uses an odd-length prefix so the cut straddles a rune, and asserts on the replacement character. Mutation-checked: removing the rune back-up fails it.

### Verification

Full `wail-app` suite both build modes, `signaling-server` suite, vet, gofmt, plugin build clean.

Co-authored by a very tired language model
