### PR TITLE
fix: stage the beta formula so its first publish reaches the Homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -449,5 +449,9 @@ jobs:
           cd tap
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          git commit -am "Update ${NAME} to v${VERSION}"
+          # Stage the formula explicitly: on a beta's first publish wail-beta.rb
+          # is a NEW file, and `git commit -a` only stages tracked files (works
+          # for both the new beta formula and an updated wail.rb).
+          git add "Formula/${FORMULA}"
+          git commit -m "Update ${NAME} to v${VERSION}"
           git push


### PR DESCRIPTION
## What

One-line fix to the Homebrew-tap step in `release.yml`, surfaced by the **first live beta** (`v4.2.0-beta.0`) cut when #509 merged.

## The bug

Everything in the beta pipeline worked — `beta.yml` cut `v4.2.0-beta.0`, the GitHub release published with `prerelease: true` (v4.1.0 stayed `latest`), and all three platform assets uploaded — **except** the tap update:

```
Untracked files: Formula/wail-beta.rb
nothing added to commit but untracked files present
##[error]Process completed with exit code 1
```

The step used `git commit -am`, which stages only **tracked** files. On a beta's first publish, `wail-beta.rb` is a brand-new file, so it was never committed. The stable path never hit this because `wail.rb` already exists (tracked → `-a` stages it). And because the step is `continue-on-error`, the job stayed green while silently dropping the formula — so `brew install MostDistant/wail/wail-beta` would 404 until fixed.

## The fix

Stage the formula path explicitly before committing (`git add "Formula/${FORMULA}"`), which works for both the new beta formula and an updated `wail.rb`.

## After merge

This is a `fix:`, so merging cuts `v4.2.0-beta.1`, whose tap step will correctly create `wail-beta.rb` — i.e. the fix validates itself on the next beta. `actionlint`/`shellcheck` clean.

---
Claude Code was involved and is sorry.