### PR TITLE
feat: ship a macOS .dmg installer (WAIL.app with bundled libopus)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,14 @@ jobs:
         run: go build ./... && go test ./...
         working-directory: signaling-server
 
+      - name: Smoke-test macOS packaging
+        # Exercises scripts/package-macos.sh end to end (bundle, dylib
+        # bundling, ad-hoc sign, dmg) so a broken script fails on the PR
+        # instead of on release day.
+        run: |
+          scripts/package-macos.sh --version 0.0.0-ci --plugins build/plugins --out /tmp/wail-pkg
+          test -f /tmp/wail-pkg/wail-macos-arm64-0.0.0-ci.dmg
+
   build-windows:
     # Pinned to windows-2022 to match the release workflow's toolchain (older
     # MinGW GCC + CMake). windows-latest rolled over to the 2025/2026 image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,13 +345,63 @@ jobs:
           name: wail-release-linux
           path: dist/
 
+  build-macos:
+    # macOS (Apple Silicon): WAIL.app + .dmg. libopus is bundled into
+    # Contents/Frameworks by scripts/package-macos.sh, so the .app runs on
+    # machines without Homebrew. Ad-hoc signed — first launch is right-click
+    # → Open (no Developer ID notarization yet). Intel Macs stay on the
+    # Homebrew source tarball.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+          submodules: recursive
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: wail-app/go.mod
+          # Both Go modules live in subdirs, so point the built-in cache at every
+          # go.sum — otherwise setup-go looks only at the repo root and warns.
+          cache-dependency-path: "**/go.sum"
+
+      - name: Install opus
+        run: brew install opus
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "value=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build CLAP plugins
+        run: |
+          cmake -S plugins -B build/plugins -DCMAKE_BUILD_TYPE=Release
+          cmake --build build/plugins
+
+      - name: Package WAIL.app + .dmg
+        run: |
+          scripts/package-macos.sh \
+            --version "${{ steps.version.outputs.value }}" \
+            --plugins build/plugins \
+            --out dist
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wail-release-macos
+          path: dist/
+
   create-release:
-    needs: [build-windows, build-linux, build-homebrew-tarball]
+    needs: [build-windows, build-linux, build-macos, build-homebrew-tarball]
     # A failed platform build must not sink the whole release: run whenever at
     # least one artifact source succeeded and upload what exists (e.g. a
     # mac-only release is the Homebrew source tarball when Windows/Linux fail).
     # The run still reports failure overall, so a missing platform is visible.
-    if: always() && (needs.build-windows.result == 'success' || needs.build-linux.result == 'success' || needs.build-homebrew-tarball.result == 'success')
+    if: always() && (needs.build-windows.result == 'success' || needs.build-linux.result == 'success' || needs.build-macos.result == 'success' || needs.build-homebrew-tarball.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -395,6 +445,10 @@ jobs:
           else
             echo "::warning::no Linux artifact — releasing without it"
           fi
+          # macOS: the dmg is final as built by scripts/package-macos.sh.
+          if [ ! -d wail-release-macos ]; then
+            echo "::warning::no macOS artifact — releasing without it"
+          fi
 
       - name: Find individual installers
         id: files
@@ -402,6 +456,7 @@ jobs:
           echo "src_tarball=$(ls wail-homebrew-src/wail-*-src.tar.gz 2>/dev/null | head -1 || true)" >> "$GITHUB_OUTPUT"
           echo "windows_zip=$(ls wail-windows-x64-*.zip 2>/dev/null | head -1 || true)" >> "$GITHUB_OUTPUT"
           echo "linux_tarball=$(ls wail-linux-x64-*.tar.gz 2>/dev/null | head -1 || true)" >> "$GITHUB_OUTPUT"
+          echo "macos_dmg=$(ls wail-release-macos/wail-macos-arm64-*.dmg 2>/dev/null | head -1 || true)" >> "$GITHUB_OUTPUT"
 
       - uses: softprops/action-gh-release@v3
         with:
@@ -413,6 +468,7 @@ jobs:
             ${{ steps.files.outputs.src_tarball }}
             ${{ steps.files.outputs.windows_zip }}
             ${{ steps.files.outputs.linux_tarball }}
+            ${{ steps.files.outputs.macos_dmg }}
 
       # Update the Homebrew tap formula with the new version and SHA256.
       # Requires a HOMEBREW_TAP_TOKEN secret with push access to MostDistant/homebrew-wail.

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ wail-app/wail-app
 .envrc
 debug-runs/
 /.pi-subagents/
+/dist/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ There are two channels (see `docs/adr/0008-beta-channel.md`): **main is the beta
 
 1. **Push to `main`** → `auto-release.yml` runs `knope prepare-release`, which consumes conventional commits (and `.changeset/` files if present as a fallback), bumps versions, updates `CHANGELOG.md`, and opens/updates a standing PR from the `release` branch → `main`. Its body lists the betas soaked this cycle. This PR is the promotion button; merging it ships stable.
 2. **Merge the release PR** → `release-on-merge.yml` runs `knope release` (creates GitHub release + git tag), dispatches artifact builds, and **resets `beta` to main** so the next cycle starts clean.
-3. **`release.yml`** builds platform artifacts (Windows/Linux app binaries + zip/tar archives, plus the Homebrew source tarball that serves as the macOS channel) and uploads them to the GitHub release. A failed platform build does not block the release: `create-release` packages and uploads whatever artifacts exist (the run still reports failure so a missing platform is visible).
+3. **`release.yml`** builds platform artifacts (Windows/Linux app binaries + zip/tar archives, a macOS Apple-Silicon `WAIL.app` + `.dmg` via `scripts/package-macos.sh` — libopus bundled, ad-hoc signed — plus the Homebrew source tarball that remains the macOS source/Intel channel) and uploads them to the GitHub release. A failed platform build does not block the release: `create-release` packages and uploads whatever artifacts exist (the run still reports failure so a missing platform is visible).
 
 **Beta** (every releasable merge, automatic):
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -296,6 +296,11 @@ brew unlink wail-beta && brew link --overwrite wail   # back to stable, instantl
 `brew upgrade wail-beta` rebuilds the newest beta from source. Both kegs stay on
 disk, so falling back to stable mid-session is a `link`, not a reinstall.
 
+Beta prereleases also ship the same `wail-macos-arm64-<version>.dmg` as stable
+(Apple Silicon, ad-hoc signed — right-click → Open on first launch). Dragging
+the beta WAIL.app into Applications replaces any stable .app install; keep it
+somewhere else (e.g. `~/Applications`) to run both.
+
 ### Windows
 
 Download the `wail-windows-x64-<version>.zip` asset from the beta's prerelease on

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ WAIL is an Ableton **Link Audio** peer — it captures and plays audio directly 
 
 Download the latest release from the [Releases page](https://github.com/MostDistant/WAIL/releases).
 
-**macOS (Homebrew, from source)** — Build and install directly from source:
+**macOS (download, Apple Silicon)** — Download `wail-macos-arm64-<version>.dmg` from the Releases page, open it, and drag **WAIL.app** into Applications. The app is not notarized, so on first launch right-click the app and choose **Open** (Gatekeeper), then confirm — after that it launches normally. The CLAP plugins auto-install on first launch into `~/.clap`.
+
+**macOS (Homebrew, from source)** — Build and install directly from source (also the path for Intel Macs):
 
 ```sh
 brew tap MostDistant/wail
@@ -33,7 +35,7 @@ For DAWs that don't support Ableton Link Audio, load the **WAIL Send** and **WAI
 
 Two requirements: your DAW must load **CLAP** plugins (Bitwig, REAPER, Studio One, Qtractor; not Logic or Pro Tools), and the project must run at **48 kHz** — Link Audio is 48 kHz only, so at any other rate Send publishes nothing and Recv outputs silence.
 
-On the Windows and Linux release builds the plugins auto-install on first launch into your per-user CLAP folder (`%LOCALAPPDATA%\Programs\Common\CLAP` / `~/.clap`); if that's blocked, copy the `.clap` bundles from the release's `lib/` folder there yourself and rescan. On Homebrew, run `wail-install-plugins`.
+On the Windows, macOS (dmg), and Linux release builds the plugins auto-install on first launch into your per-user CLAP folder (`%LOCALAPPDATA%\Programs\Common\CLAP` / `~/.clap`); if that's blocked, copy the `.clap` bundles from the release's `lib/` folder there yourself and rescan. On Homebrew, run `wail-install-plugins`.
 
 ## Getting Started
 

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# package-macos.sh — build WAIL.app and a distributable .dmg for macOS.
+#
+# The app binary is self-contained except for libopus (cgo, dynamically
+# linked from Homebrew), so the bundle carries its own copy in
+# Contents/Frameworks and the binary's reference is rewritten to
+# @executable_path. The bundle is ad-hoc signed: first launch shows
+# Gatekeeper's "developer cannot be verified" — right-click → Open once.
+# (Developer ID signing + notarization is a separate, later step.)
+#
+# Usage:
+#   scripts/package-macos.sh --version X.Y.Z [--binary PATH] [--plugins DIR] [--out DIR]
+#
+#   --version   Version string baked into the binary and Info.plist (required).
+#   --binary    Prebuilt wail binary (default: build wail-app from source).
+#   --plugins   Directory containing wail-send.clap and wail-recv.clap; staged
+#               into Contents/lib where the app's first-launch installer finds
+#               them (FindPluginDir → {exe}/../lib). Warns loudly if omitted.
+#   --out       Output directory for the .dmg (default: dist/macos).
+set -euo pipefail
+
+VERSION=""
+BINARY=""
+PLUGINS_DIR=""
+OUT_DIR="dist/macos"
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--version) VERSION="$2"; shift 2 ;;
+		--binary)  BINARY="$2"; shift 2 ;;
+		--plugins) PLUGINS_DIR="$2"; shift 2 ;;
+		--out)     OUT_DIR="$2"; shift 2 ;;
+		*) echo "unknown argument: $1" >&2; exit 2 ;;
+	esac
+done
+
+if [ -z "$VERSION" ]; then
+	echo "error: --version is required" >&2
+	exit 2
+fi
+if [ "$(uname -s)" != "Darwin" ]; then
+	echo "error: package-macos.sh must run on macOS" >&2
+	exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- 1. Build (or accept) the app binary -----------------------------------
+if [ -z "$BINARY" ]; then
+	echo ">> building wail-app (version $VERSION)"
+	# nolibopusfile: the opus binding's stream.go (libopusfile) is unused by
+	# WAIL — suppressing it leaves libopus as the only non-system dylib.
+	(cd "$REPO_ROOT/wail-app" && go build -tags nolibopusfile \
+		-ldflags "-X main.appVersion=${VERSION}" -o "$WORK/wail" .)
+	BINARY="$WORK/wail"
+fi
+
+# --- 2. Stage the .app bundle ----------------------------------------------
+APP="$WORK/WAIL.app"
+mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Frameworks" "$APP/Contents/Resources"
+cp "$BINARY" "$APP/Contents/MacOS/wail"
+
+cat > "$APP/Contents/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundlePackageType</key><string>APPL</string>
+	<key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+	<key>CFBundleName</key><string>WAIL</string>
+	<key>CFBundleDisplayName</key><string>WAIL</string>
+	<key>CFBundleIdentifier</key><string>com.mostdistant.wail</string>
+	<key>CFBundleExecutable</key><string>wail</string>
+	<key>CFBundleVersion</key><string>${VERSION}</string>
+	<key>CFBundleShortVersionString</key><string>${VERSION}</string>
+	<key>CFBundleIconFile</key><string>AppIcon</string>
+	<key>LSMinimumSystemVersion</key><string>11.0</string>
+	<key>NSHighResolutionCapable</key><true/>
+</dict>
+</plist>
+EOF
+
+# Icon: the frontend logo, rendered into an .icns at the sizes the source
+# resolution honestly supports (128px source → up to 128x128).
+ICON_SRC="$REPO_ROOT/wail-app/frontend/logo.png"
+if [ -f "$ICON_SRC" ]; then
+	ICONSET="$WORK/AppIcon.iconset"
+	mkdir -p "$ICONSET"
+	for spec in "16:16" "16@2x:32" "32:32" "32@2x:64" "128:128"; do
+		name="${spec%%:*}"; px="${spec##*:}"
+		sips -z "$px" "$px" "$ICON_SRC" --out "$ICONSET/icon_${name}x${name}.png" >/dev/null
+	done
+	iconutil -c icns "$ICONSET" -o "$APP/Contents/Resources/AppIcon.icns"
+else
+	echo ">> warning: no icon source at $ICON_SRC — bundle gets the default icon"
+fi
+
+# --- 3. Bundle non-system dylibs (libopus) ---------------------------------
+# Anything linked from a package-manager prefix gets copied into
+# Contents/Frameworks and rewritten to @executable_path. Loops to catch
+# transitive deps (e.g. opusfile → ogg) if the link set ever grows.
+rewrite_refs() { # $1 = mach-o file to rewrite
+	local file="$1" dep base
+	while read -r dep; do
+		base="$(basename "$dep")"
+		install_name_tool -change "$dep" "@executable_path/../Frameworks/$base" "$file"
+	done < <(otool -L "$file" | awk '/^[[:space:]]+\/(opt\/homebrew|usr\/local)/ {print $1}')
+}
+
+for pass in 1 2 3; do
+	targets=("$APP/Contents/MacOS/wail")
+	for d in "$APP"/Contents/Frameworks/*.dylib; do
+		[ -e "$d" ] && targets+=("$d")
+	done
+	pending="$(otool -L "${targets[@]}" | awk '/^[[:space:]]+\/(opt\/homebrew|usr\/local)/ {print $1}' | sort -u)"
+	[ -z "$pending" ] && break
+	while read -r dep; do
+		[ -z "$dep" ] && continue
+		base="$(basename "$dep")"
+		if [ ! -f "$APP/Contents/Frameworks/$base" ]; then
+			echo ">> bundling $base"
+			cp "$dep" "$APP/Contents/Frameworks/$base"
+			chmod +w "$APP/Contents/Frameworks/$base"
+			install_name_tool -id "@executable_path/../Frameworks/$base" "$APP/Contents/Frameworks/$base"
+		fi
+	done <<< "$pending"
+done
+rewrite_refs "$APP/Contents/MacOS/wail"
+for dylib in "$APP"/Contents/Frameworks/*.dylib; do
+	[ -e "$dylib" ] || continue
+	rewrite_refs "$dylib"
+done
+
+if otool -L "$APP/Contents/MacOS/wail" | grep -qE '/(opt/homebrew|usr/local)/'; then
+	echo "error: binary still references package-manager dylibs:" >&2
+	otool -L "$APP/Contents/MacOS/wail" | grep -E '/(opt/homebrew|usr/local)/' >&2
+	exit 1
+fi
+
+# --- 4. Stage the CLAP plugins ---------------------------------------------
+if [ -n "$PLUGINS_DIR" ]; then
+	mkdir -p "$APP/Contents/lib"
+	for b in wail-send wail-recv; do
+		if [ ! -e "$PLUGINS_DIR/$b.clap" ]; then
+			echo "error: missing plugin bundle $PLUGINS_DIR/$b.clap" >&2
+			exit 1
+		fi
+		cp -R "$PLUGINS_DIR/$b.clap" "$APP/Contents/lib/"
+	done
+else
+	echo ">> WARNING: no --plugins dir — the .app will not carry the CLAP plugins" >&2
+fi
+
+# --- 5. Ad-hoc sign ---------------------------------------------------------
+# arm64 requires a signature; install_name_tool invalidated the linker's.
+# Sign inside-out: dylibs, plugin bundles, then the app itself.
+find "$APP/Contents/Frameworks" -name '*.dylib' -exec codesign --force --sign - {} \;
+if [ -d "$APP/Contents/lib" ]; then
+	find "$APP/Contents/lib" -name '*.clap' -exec codesign --force --sign - {} \;
+fi
+codesign --force --sign - "$APP"
+codesign --verify --deep --strict "$APP"
+
+# --- 6. Build the .dmg ------------------------------------------------------
+mkdir -p "$OUT_DIR"
+DMG_STAGE="$WORK/dmg"
+mkdir -p "$DMG_STAGE"
+cp -R "$APP" "$DMG_STAGE/"
+ln -s /Applications "$DMG_STAGE/Applications"
+DMG="$OUT_DIR/wail-macos-arm64-${VERSION}.dmg"
+hdiutil create -volname "WAIL" -srcfolder "$DMG_STAGE" -ov -format UDZO "$DMG" >/dev/null
+
+echo ">> built $DMG"
+echo ">> note: unsigned build — first launch needs right-click → Open (Gatekeeper)"


### PR DESCRIPTION
## What

Adds a real macOS download: **`wail-macos-arm64-<version>.dmg`** containing `WAIL.app`, built by a new `scripts/package-macos.sh` and a `build-macos` job in `release.yml`. Until now the only Mac install path was Homebrew building from source — which exists partly because the app links libopus dynamically from the Homebrew prefix.

## How

`scripts/package-macos.sh --version X.Y.Z --plugins DIR --out DIR`:

1. Builds the app with `-tags nolibopusfile` (so libopus is the *only* non-system dylib)
2. Stages a standard `WAIL.app` — Info.plist, icon rendered from the frontend logo, and the CLAP plugins at `Contents/lib` (where the app's first-launch installer looks, via `{exe}/../lib`)
3. Copies any package-manager dylibs into `Contents/Frameworks` and rewrites references to `@executable_path` — hand-rolled `install_name_tool`, no dylibbundler dependency; a post-check **fails the build** if any Homebrew reference survives
4. Ad-hoc signs inside-out (dylibs → .clap bundles → app) and verifies with `codesign --verify --deep --strict`
5. Wraps it in a UDZO dmg with an Applications symlink

**Verified locally**: mounted dmg, `codesign --verify` clean, and the bundled binary launches with the Homebrew opus prefix temporarily hidden (proving it loads libopus from inside the .app).

## Deliberate trades

- **Apple Silicon only** — Intel Macs stay on the Homebrew source tarball (noted in README).
- **Unsigned / not notarized** — first launch is right-click → Open, same trade as the unsigned Windows build. Notarization (Developer ID + `notarytool`) can be layered on later without changing anything else.

## CI

- `release.yml`: new `build-macos` job (macos-latest → plugins → package script → artifact), wired into `create-release`'s needs/condition/files like the other platforms — a failed mac build doesn't sink the release.
- `build.yml`: the existing `build-macos` job now smoke-tests the packaging script end-to-end on PRs, so a broken script fails before release day.

## Testing

- Script verified locally (bundle + dmg + signature + no-Homebrew launch), with and without plugins
- `go test ./...` ✅ · `go test -tags linkstub ./...` ✅ · relay tests ✅ · `scripts/tier2-e2e.sh` **PASS** ✅
- Docs synced: README (install section), DEVELOPMENT.md (beta channel), CLAUDE.md (release pipeline)
